### PR TITLE
[d3d7] Workaround missing mipmaps in DSN The Fallen.

### DIFF
--- a/src/util/config/config.cpp
+++ b/src/util/config/config.cpp
@@ -1549,6 +1549,11 @@ namespace dxvk {
       { "d3d7.forceProxiedPresent",         "True" },
       { "d3d7.forceSWVPDevice",             "True" },
     }} },
+    /* Star Trek: Deep Space Nine - The Fallen    *
+     * Fixes missing mip map uploads              */
+    { R"(\\DS9\.exe$)", {{
+      { "d3d7.autoGenMipMaps",              "True" },
+    }} },
 
   };
 


### PR DESCRIPTION
This fixes a mipmap bug in Star Trek: Deep Space Nine - The Fallen

Before:
![20251217_18h00m45s_grim](https://github.com/user-attachments/assets/7d153def-24f5-4585-8e03-7a12ac00923b)

After:
![20251217_17h59m41s_grim](https://github.com/user-attachments/assets/97c262cf-43de-42da-9a55-1d515cf25b81)
