### PR TITLE
[meta] Set ddraw's version in resource to match DirectX 7.1

### DIFF
--- a/src/ddraw/version.rc
+++ b/src/ddraw/version.rc
@@ -2,8 +2,8 @@
 
 // DLL version information.
 VS_VERSION_INFO    VERSIONINFO
-FILEVERSION        10,0,17763,1
-PRODUCTVERSION     10,0,17763,1
+FILEVERSION        4,07,00,700
+PRODUCTVERSION     4,07,00,700
 FILEFLAGSMASK      VS_FFI_FILEFLAGSMASK
 FILEFLAGS          0
 FILEOS VOS_NT_WINDOWS32
@@ -16,12 +16,12 @@ BEGIN
     BEGIN
       VALUE "CompanyName",      "DXVK"
       VALUE "FileDescription",  "Direct3D 7 Runtime"
-      VALUE "FileVersion",      "10.0.17763.1 (WinBuild.160101.0800)"
+      VALUE "FileVersion",      "4.07.00.0700"
       VALUE "InternalName",     "DDRAW.dll"
       VALUE "LegalCopyright",   "zlib/libpng license"
       VALUE "OriginalFilename", "ddraw.dll"
       VALUE "ProductName",      "DXVK"
-      VALUE "ProductVersion",   "10.0.17763.1"
+      VALUE "ProductVersion",   "4.07.00.0700"
     END
   END
   BLOCK "VarFileInfo"


### PR DESCRIPTION
Fixes 3DMark 99 Max, which checks for "DirectX 6.1 or later" by looking up product version in ddraw's resource.

<img width="1920" height="1440" alt="Screenshot_20251229_031641" src="https://github.com/user-attachments/assets/07777add-b980-4c75-8b9b-0de7bfa3f34c" />
<img width="1920" height="1440" alt="Screenshot_20251229_031503" src="https://github.com/user-attachments/assets/ed262e38-0048-4148-b615-460fd8573531" />
<img width="1114" height="659" alt="Screenshot_20251229_032352" src="https://github.com/user-attachments/assets/6c3a0d82-fd70-4101-b4cc-d3a631a7cf21" />
