### PR TITLE
[d3d6/5/3] Implement legacy viewport projection and clipping

### DIFF
--- a/src/ddraw/d3d3/d3d3_device.cpp
+++ b/src/ddraw/d3d3/d3d3_device.cpp
@@ -1092,17 +1092,23 @@ namespace dxvk {
     }
 
     if (!vertices.empty() && m_d3d9 != nullptr) {
+      HandlePreDrawLegacyProjection();
+
       m_d3d9->SetFVF(D3DFVF_TLVERTEX);
       HRESULT hr = m_d3d9->DrawPrimitiveUP(
            d3d9::D3DPT_TRIANGLELIST,
            GetPrimitiveCount(D3DPT_TRIANGLELIST, vertices.size()),
            vertices.data(),
            GetFVFSize(D3DFVF_TLVERTEX));
+
+      HandlePostDrawLegacyProjection();
+
       if (SUCCEEDED(hr)) {
         Logger::debug(str::format("D3D3Device::Execute: D3DOP_TRIANGLE drawn vertices: ", vertices.size()));
       } else {
         Logger::err(str::format("D3D3Device::Execute: D3DOP_TRIANGLE failed to draw vertices: ", vertices.size()));
       }
+
       vertices.clear();
     }
   }
@@ -1121,17 +1127,23 @@ namespace dxvk {
     }
 
     if (!vertices.empty() && m_d3d9 != nullptr) {
+      HandlePreDrawLegacyProjection();
+
       m_d3d9->SetFVF(D3DFVF_TLVERTEX);
       HRESULT hr = m_d3d9->DrawPrimitiveUP(
            d3d9::D3DPT_LINELIST,
            GetPrimitiveCount(D3DPT_LINELIST, vertices.size()),
            vertices.data(),
            GetFVFSize(D3DFVF_TLVERTEX));
+
+      HandlePostDrawLegacyProjection();
+
       if (SUCCEEDED(hr)) {
         Logger::debug(str::format("D3D3Device::Execute: D3DOP_LINE drawn vertices: ", vertices.size()));
       } else {
         Logger::err(str::format("D3D3Device::Execute: D3DOP_LINE failed to draw vertices: ", vertices.size()));
       }
+
       vertices.clear();
     }
   }
@@ -1151,12 +1163,17 @@ namespace dxvk {
     }
 
     if (!vertices.empty() && m_d3d9 != nullptr) {
+      HandlePreDrawLegacyProjection();
+
       m_d3d9->SetFVF(D3DFVF_TLVERTEX);
       HRESULT hr = m_d3d9->DrawPrimitiveUP(
            d3d9::D3DPT_POINTLIST,
            GetPrimitiveCount(D3DPT_POINTLIST, vertices.size()),
            vertices.data(),
            GetFVFSize(D3DFVF_TLVERTEX));
+
+      HandlePostDrawLegacyProjection();
+
       if (SUCCEEDED(hr)) {
         Logger::debug(str::format("D3D3Device::Execute: D3DOP_POINT drawn vertices: ", vertices.size()));
       } else {
@@ -1181,17 +1198,23 @@ namespace dxvk {
     }
 
     if (!vertices.empty() && m_d3d9 != nullptr) {
+      HandlePreDrawLegacyProjection();
+
       m_d3d9->SetFVF(D3DFVF_TLVERTEX);
       HRESULT hr = m_d3d9->DrawPrimitiveUP(
            d3d9::D3DPT_LINESTRIP,
            GetPrimitiveCount(D3DPT_LINESTRIP, vertices.size()),
            vertices.data(),
            GetFVFSize(D3DFVF_TLVERTEX));
+
+      HandlePostDrawLegacyProjection();
+
       if (SUCCEEDED(hr)) {
         Logger::debug(str::format("D3D3Device::Execute: D3DOP_SPAN drawn vertices: ", vertices.size()));
       } else {
         Logger::err(str::format("D3D3Device::Execute: D3DOP_SPAN failed to draw vertices: ", vertices.size()));
       }
+
       vertices.clear();
     }
   }

--- a/src/ddraw/d3d3/d3d3_device.h
+++ b/src/ddraw/d3d3/d3d3_device.h
@@ -133,6 +133,25 @@ namespace dxvk {
 
     inline void TextureLoadInternal(D3DTEXTURELOAD* textureLoad, DWORD count);
 
+    inline void HandlePreDrawLegacyProjection() {
+      if (likely(m_currentViewport != nullptr)) {
+        m_legacyProjection = m_currentViewport->GetCommonViewport()->GetLegacyProjectionMatrix(0);
+
+        if (m_legacyProjection != nullptr) {
+          //Logger::debug("D3D3Device: Applying legacy projection");
+          m_d3d9->GetTransform(d3d9::D3DTS_PROJECTION, &m_projectionMatrix);
+          m_d3d9->MultiplyTransform(d3d9::D3DTS_PROJECTION, m_legacyProjection);
+        }
+      }
+    }
+
+    inline void HandlePostDrawLegacyProjection() {
+      if (m_legacyProjection != nullptr) {
+        //Logger::debug("D3D3Device: Reverting legacy projection");
+        m_d3d9->SetTransform(d3d9::D3DTS_PROJECTION, &m_projectionMatrix);
+      }
+    }
+
     bool                           m_inScene     = false;
 
     static uint32_t                s_deviceCount;
@@ -159,7 +178,10 @@ namespace dxvk {
     std::vector<Com<D3D3Viewport>> m_viewports;
 
     // Value of D3DRENDERSTATE_TEXTUREMAPBLEND
-    DWORD                          m_textureMapBlend = D3DTBLEND_MODULATE;
+    DWORD                          m_textureMapBlend  = D3DTBLEND_MODULATE;
+
+    D3DMATRIX                      m_projectionMatrix = {};
+    const D3DMATRIX*               m_legacyProjection = nullptr;
 
     D3DMATRIXHANDLE                m_matrixHandle = 0;
     std::unordered_map<D3DMATRIXHANDLE, D3DMATRIX> m_matrices;

--- a/src/ddraw/d3d3/d3d3_viewport.cpp
+++ b/src/ddraw/d3d3/d3d3_viewport.cpp
@@ -133,13 +133,12 @@ namespace dxvk {
     data->dwHeight = viewport9->Height;
     data->dvMinZ   = viewport9->MinZ;
     data->dvMaxZ   = viewport9->MaxZ;
-    // Docs state: "Values of the D3DVALUE type describing the maximum and minimum
-    // nonhomogeneous coordinates of x, y, and z. Again, the relevant coordinates
-    // are the nonhomogeneous coordinates that result from the perspective division."
+
     data->dvMaxX   = 1.0f;
     data->dvMaxY   = 1.0f;
-    data->dvScaleX = 1.0f;
-    data->dvScaleY = 1.0f;
+    D3DVECTOR* legacyScale = m_commonViewport->GetLegacyScale();
+    data->dvScaleX = legacyScale->x * (float)data->dwWidth / 2.0f;
+    data->dvScaleY = legacyScale->y * (float)data->dwHeight / 2.0f;
 
     return D3D_OK;
   }
@@ -160,7 +159,8 @@ namespace dxvk {
     if (unlikely(m_device == nullptr))
       return D3DERR_VIEWPORTHASNODEVICE;
 
-    // TODO: Check viewport dimensions against the currently set RT
+    // TODO: Check viewport dimensions against the currently set RT,
+    // and perform some sanity checks (positive, non-zero dimensions)
 
     d3d9::D3DVIEWPORT9* viewport9 = m_commonViewport->GetD3D9Viewport();
 
@@ -172,6 +172,15 @@ namespace dxvk {
     viewport9->Height = data->dwHeight;
     viewport9->MinZ   = 0.0f;
     viewport9->MaxZ   = 1.0f;
+
+    D3DVECTOR* legacyScale = m_commonViewport->GetLegacyScale();
+    legacyScale->x = 2.0f * data->dvScaleX / (float)data->dwWidth;
+    legacyScale->y = 2.0f * data->dvScaleY / (float)data->dwHeight;
+    legacyScale->z = 1.0f;
+    D3DVECTOR* legacyClip = m_commonViewport->GetLegacyClip();
+    legacyClip->x = 0.0f;
+    legacyClip->y = 0.0f;
+    legacyClip->z = 0.0f;
 
     m_commonViewport->MarkViewportAsSet();
 

--- a/src/ddraw/d3d5/d3d5_device.cpp
+++ b/src/ddraw/d3d5/d3d5_device.cpp
@@ -1272,6 +1272,7 @@ namespace dxvk {
     DWORD vertex_type5 = ConvertVertexType(vertex_type);
 
     HandlePreDrawFlags(flags, vertex_type5);
+    HandlePreDrawLegacyProjection(flags);
 
     m_d3d9->SetFVF(vertex_type5);
     HRESULT hr = m_d3d9->DrawPrimitiveUP(
@@ -1280,6 +1281,7 @@ namespace dxvk {
                      vertices,
                      GetFVFSize(vertex_type5));
 
+    HandlePostDrawLegacyProjection();
     HandlePostDrawFlags(flags, vertex_type5);
 
     if (unlikely(FAILED(hr))) {
@@ -1311,6 +1313,7 @@ namespace dxvk {
     DWORD fvf5 = ConvertVertexType(fvf);
 
     HandlePreDrawFlags(flags, fvf5);
+    HandlePreDrawLegacyProjection(flags);
 
     m_d3d9->SetFVF(fvf5);
     HRESULT hr = m_d3d9->DrawIndexedPrimitiveUP(
@@ -1323,6 +1326,7 @@ namespace dxvk {
                       vertices,
                       GetFVFSize(fvf5));
 
+    HandlePostDrawLegacyProjection();
     HandlePostDrawFlags(flags, fvf5);
 
     if (unlikely(FAILED(hr))) {

--- a/src/ddraw/d3d5/d3d5_device.h
+++ b/src/ddraw/d3d5/d3d5_device.h
@@ -177,14 +177,33 @@ namespace dxvk {
       }
     }
 
-    bool                           m_inScene      = false;
+    inline void HandlePreDrawLegacyProjection(DWORD drawFlags) {
+      if (likely(m_currentViewport != nullptr)) {
+        m_legacyProjection = m_currentViewport->GetCommonViewport()->GetLegacyProjectionMatrix(drawFlags);
+
+        if (m_legacyProjection != nullptr) {
+          //Logger::debug("D3D5Device: Applying legacy projection");
+          m_d3d9->GetTransform(d3d9::D3DTS_PROJECTION, &m_projectionMatrix);
+          m_d3d9->MultiplyTransform(d3d9::D3DTS_PROJECTION, m_legacyProjection);
+        }
+      }
+    }
+
+    inline void HandlePostDrawLegacyProjection() {
+      if (m_legacyProjection != nullptr) {
+        //Logger::debug("D3D5Device: Reverting legacy projection");
+        m_d3d9->SetTransform(d3d9::D3DTS_PROJECTION, &m_projectionMatrix);
+      }
+    }
+
+    bool                           m_inScene     = false;
 
     static uint32_t                s_deviceCount;
-    uint32_t                       m_deviceCount  = 0;
+    uint32_t                       m_deviceCount = 0;
 
-    DWORD                          m_lighting     = FALSE;
+    DWORD                          m_lighting    = FALSE;
 
-    DDrawCommonInterface*          m_commonIntf   = nullptr;
+    DDrawCommonInterface*          m_commonIntf  = nullptr;
 
     Com<DxvkD3D8Bridge>            m_bridge;
 
@@ -212,13 +231,16 @@ namespace dxvk {
     std::vector<D3DTLVERTEX>       m_tlvertexStream;
 
     // Value of D3DRENDERSTATE_COLORKEYENABLE
-    DWORD           m_colorKeyEnabled = 0;
+    DWORD            m_colorKeyEnabled  = 0;
     // Value of D3DRENDERSTATE_ANTIALIAS
-    DWORD           m_antialias       = D3DANTIALIAS_NONE;
+    DWORD            m_antialias        = D3DANTIALIAS_NONE;
     // Value of D3DRENDERSTATE_LINEPATTERN
-    D3DLINEPATTERN  m_linePattern     = {};
+    D3DLINEPATTERN   m_linePattern      = {};
     // Value of D3DRENDERSTATE_TEXTUREMAPBLEND
-    DWORD           m_textureMapBlend = D3DTBLEND_MODULATE;
+    DWORD            m_textureMapBlend  = D3DTBLEND_MODULATE;
+
+    D3DMATRIX        m_projectionMatrix = {};
+    const D3DMATRIX* m_legacyProjection = nullptr;
 
   };
 

--- a/src/ddraw/d3d5/d3d5_viewport.cpp
+++ b/src/ddraw/d3d5/d3d5_viewport.cpp
@@ -134,13 +134,12 @@ namespace dxvk {
     data->dwHeight = viewport9->Height;
     data->dvMinZ   = viewport9->MinZ;
     data->dvMaxZ   = viewport9->MaxZ;
-    // Docs state: "Values of the D3DVALUE type describing the maximum and minimum
-    // nonhomogeneous coordinates of x, y, and z. Again, the relevant coordinates
-    // are the nonhomogeneous coordinates that result from the perspective division."
+
     data->dvMaxX   = 1.0f;
     data->dvMaxY   = 1.0f;
-    data->dvScaleX = 1.0f;
-    data->dvScaleY = 1.0f;
+    D3DVECTOR* legacyScale = m_commonViewport->GetLegacyScale();
+    data->dvScaleX = legacyScale->x * (float)data->dwWidth / 2.0f;
+    data->dvScaleY = legacyScale->y * (float)data->dwHeight / 2.0f;
 
     return D3D_OK;
   }
@@ -161,7 +160,8 @@ namespace dxvk {
     if (unlikely(m_device == nullptr))
       return D3DERR_VIEWPORTHASNODEVICE;
 
-    // TODO: Check viewport dimensions against the currently set RT
+    // TODO: Check viewport dimensions against the currently set RT,
+    // and perform some sanity checks (positive, non-zero dimensions)
 
     d3d9::D3DVIEWPORT9* viewport9 = m_commonViewport->GetD3D9Viewport();
 
@@ -173,6 +173,15 @@ namespace dxvk {
     viewport9->Height = data->dwHeight;
     viewport9->MinZ   = 0.0f;
     viewport9->MaxZ   = 1.0f;
+
+    D3DVECTOR* legacyScale = m_commonViewport->GetLegacyScale();
+    legacyScale->x = 2.0f * data->dvScaleX / (float)data->dwWidth;
+    legacyScale->y = 2.0f * data->dvScaleY / (float)data->dwHeight;
+    legacyScale->z = 1.0f;
+    D3DVECTOR* legacyClip = m_commonViewport->GetLegacyClip();
+    legacyClip->x = 0.0f;
+    legacyClip->y = 0.0f;
+    legacyClip->z = 0.0f;
 
     m_commonViewport->MarkViewportAsSet();
 
@@ -364,15 +373,13 @@ namespace dxvk {
     data->dwHeight     = viewport9->Height;
     data->dvMinZ       = viewport9->MinZ;
     data->dvMaxZ       = viewport9->MaxZ;
-    // Docs state: "In most cases, dvClipX is set to -1.0 and dvClipY is set
-    // to the inverse of the viewport's aspect ratio on the target surface,
-    // which can be calculated by dividing the dwHeight member by dwWidth.
-    // Similarly, the dvClipWidth member is typically 2.0 and dvClipHeight is
-    // set to twice the aspect ratio set in dwClipY."
-    data->dvClipX      = -1.0f;
-    data->dvClipY      =  static_cast<float>(viewport9->Height) / static_cast<float>(viewport9->Width);
-    data->dvClipWidth  =  2.0f;
-    data->dvClipHeight =  2.0f * data->dvClipY;
+
+    D3DVECTOR* legacyScale = m_commonViewport->GetLegacyScale();
+    data->dvClipWidth  = 2.0f / legacyScale->x;
+    data->dvClipHeight = 2.0f / legacyScale->y;
+    D3DVECTOR* legacyClip = m_commonViewport->GetLegacyClip();
+    data->dvClipX      = data->dvClipWidth  * (legacyClip->x + 1.0f) / -2.0f;
+    data->dvClipY      = data->dvClipHeight * (legacyClip->y - 1.0f) / -2.0f;
 
     return D3D_OK;
   }
@@ -393,7 +400,8 @@ namespace dxvk {
     if (unlikely(m_device == nullptr))
       return D3DERR_VIEWPORTHASNODEVICE;
 
-    // TODO: Check viewport dimensions against the currently set RT
+    // TODO: Check viewport dimensions against the currently set RT,
+    // and perform some sanity checks (positive, non-zero dimensions)
 
     d3d9::D3DVIEWPORT9* viewport9 = m_commonViewport->GetD3D9Viewport();
 
@@ -401,23 +409,17 @@ namespace dxvk {
     viewport9->Y      = data->dwY;
     viewport9->Width  = data->dwWidth;
     viewport9->Height = data->dwHeight;
-    // Empire of the Ants uses 1.0f and 1000000.0f, so the expectation
-    // is most likely for these values to be normalized to [0.0f, 1.0f]
-    viewport9->MinZ   = data->dvMaxZ <= 1.0f ? data->dvMinZ : data->dvMinZ / data->dvMaxZ;
-    viewport9->MaxZ   = data->dvMaxZ <= 1.0f ? data->dvMaxZ : 1.0f;
+    viewport9->MinZ   = 0.0f;
+    viewport9->MaxZ   = 1.0f;
 
-    const D3DOptions* d3dOptions = m_commonViewport->GetCommonD3DInterface()->GetOptions();
-
-    if (unlikely(d3dOptions->viewportCorrection)) {
-      // The Summoner sets both to 0.0f and expects to end up with 0.0f / 1.0f
-      if (viewport9->MinZ == 0.0f && viewport9->MaxZ == 0.0f) {
-        viewport9->MaxZ = 1.0f;
-      // Urban Chaos mixes up MinZ / MaxZ, and this somehow works on native...
-      } else if (viewport9->MinZ == 1.0f && viewport9->MaxZ == 0.0f) {
-        viewport9->MinZ = 0.0f;
-        viewport9->MaxZ = 1.0f;
-      }
-    }
+    D3DVECTOR* legacyScale = m_commonViewport->GetLegacyScale();
+    legacyScale->x = 2.0f / data->dvClipWidth;
+    legacyScale->y = 2.0f / data->dvClipHeight;
+    legacyScale->z = 1.0f / (data->dvMaxZ - data->dvMinZ);
+    D3DVECTOR* legacyClip = m_commonViewport->GetLegacyClip();
+    legacyClip->x = -2.0f * data->dvClipX / data->dvClipWidth - 1.0f;
+    legacyClip->y = -2.0f * data->dvClipY / data->dvClipHeight + 1.0f;
+    legacyClip->z = -data->dvMinZ / (data->dvMaxZ - data->dvMinZ);
 
     m_commonViewport->MarkViewportAsSet();
 

--- a/src/ddraw/d3d6/d3d6_device.cpp
+++ b/src/ddraw/d3d6/d3d6_device.cpp
@@ -1285,6 +1285,7 @@ namespace dxvk {
       return DDERR_INVALIDPARAMS;
 
     HandlePreDrawFlags(flags, vertex_type);
+    HandlePreDrawLegacyProjection(flags);
 
     m_d3d9->SetFVF(vertex_type);
     HRESULT hr = m_d3d9->DrawPrimitiveUP(
@@ -1293,6 +1294,7 @@ namespace dxvk {
                      vertices,
                      GetFVFSize(vertex_type));
 
+    HandlePostDrawLegacyProjection();
     HandlePostDrawFlags(flags, vertex_type);
 
     if (unlikely(FAILED(hr))) {
@@ -1322,6 +1324,7 @@ namespace dxvk {
       Logger::warn("D3D6Device::DrawIndexedPrimitive: D3DPT_POINTLIST primitive type");
 
     HandlePreDrawFlags(flags, fvf);
+    HandlePreDrawLegacyProjection(flags);
 
     m_d3d9->SetFVF(fvf);
     HRESULT hr = m_d3d9->DrawIndexedPrimitiveUP(
@@ -1334,6 +1337,7 @@ namespace dxvk {
                       vertices,
                       GetFVFSize(fvf));
 
+    HandlePostDrawLegacyProjection();
     HandlePostDrawFlags(flags, fvf);
 
     if (unlikely(FAILED(hr))) {
@@ -1402,6 +1406,7 @@ namespace dxvk {
     PackedVertexBuffer pvb = TransformStridedtoUP(fvf, strided_data, vertex_count);
 
     HandlePreDrawFlags(flags, fvf);
+    HandlePreDrawLegacyProjection(flags);
 
     m_d3d9->SetFVF(fvf);
     HRESULT hr = m_d3d9->DrawPrimitiveUP(
@@ -1410,6 +1415,7 @@ namespace dxvk {
                      pvb.vertexData.data(),
                      pvb.stride);
 
+    HandlePostDrawLegacyProjection();
     HandlePostDrawFlags(flags, fvf);
 
     if (unlikely(FAILED(hr))) {
@@ -1439,6 +1445,7 @@ namespace dxvk {
     PackedVertexBuffer pvb = TransformStridedtoUP(fvf, strided_data, vertex_count);
 
     HandlePreDrawFlags(flags, fvf);
+    HandlePreDrawLegacyProjection(flags);
 
     m_d3d9->SetFVF(fvf);
     HRESULT hr = m_d3d9->DrawIndexedPrimitiveUP(
@@ -1451,6 +1458,7 @@ namespace dxvk {
                       pvb.vertexData.data(),
                       pvb.stride);
 
+    HandlePostDrawLegacyProjection();
     HandlePostDrawFlags(flags, fvf);
 
     if (unlikely(FAILED(hr))) {
@@ -1484,6 +1492,7 @@ namespace dxvk {
     }
 
     HandlePreDrawFlags(flags, vb6->GetFVF());
+    HandlePreDrawLegacyProjection(flags);
 
     m_d3d9->SetFVF(vb6->GetFVF());
     m_d3d9->SetStreamSource(0, vb6->GetD3D9(), 0, vb6->GetStride());
@@ -1492,6 +1501,7 @@ namespace dxvk {
                            start_vertex,
                            GetPrimitiveCount(primitive_type, vertex_count));
 
+    HandlePostDrawLegacyProjection();
     HandlePostDrawFlags(flags, vb6->GetFVF());
 
     if (unlikely(FAILED(hr))) {
@@ -1543,6 +1553,7 @@ namespace dxvk {
     }
 
     HandlePreDrawFlags(flags, vb6->GetFVF());
+    HandlePreDrawLegacyProjection(flags);
 
     d3d9::IDirect3DIndexBuffer9* ib9 = m_ib9[ibIndex].ptr();
 
@@ -1559,6 +1570,7 @@ namespace dxvk {
                     0,
                     GetPrimitiveCount(primitive_type, index_count));
 
+    HandlePostDrawLegacyProjection();
     HandlePostDrawFlags(flags, vb6->GetFVF());
 
     if(unlikely(FAILED(hr))) {

--- a/src/ddraw/d3d6/d3d6_device.h
+++ b/src/ddraw/d3d6/d3d6_device.h
@@ -207,6 +207,25 @@ namespace dxvk {
       }
     }
 
+    inline void HandlePreDrawLegacyProjection(DWORD drawFlags) {
+      if (likely(m_currentViewport != nullptr)) {
+        m_legacyProjection = m_currentViewport->GetCommonViewport()->GetLegacyProjectionMatrix(drawFlags);
+
+        if (m_legacyProjection != nullptr) {
+          //Logger::debug("D3D6Device: Applying legacy projection");
+          m_d3d9->GetTransform(d3d9::D3DTS_PROJECTION, &m_projectionMatrix);
+          m_d3d9->MultiplyTransform(d3d9::D3DTS_PROJECTION, m_legacyProjection);
+        }
+      }
+    }
+
+    inline void HandlePostDrawLegacyProjection() {
+      if (m_legacyProjection != nullptr) {
+        //Logger::debug("D3D6Device: Reverting legacy projection");
+        m_d3d9->SetTransform(d3d9::D3DTS_PROJECTION, &m_projectionMatrix);
+      }
+    }
+
     bool                           m_inScene     = false;
     bool                           m_alphaOpSet  = false;
 
@@ -243,15 +262,18 @@ namespace dxvk {
     std::array<Com<D3D6Texture, false>, ddrawCaps::TextureStageCount> m_textures;
 
     // Value of D3DRENDERSTATE_COLORKEYENABLE
-    DWORD           m_colorKeyEnabled = 0;
+    DWORD            m_colorKeyEnabled  = 0;
     // Value of D3DRENDERSTATE_ANTIALIAS
-    DWORD           m_antialias       = D3DANTIALIAS_NONE;
+    DWORD            m_antialias        = D3DANTIALIAS_NONE;
     // Value of D3DRENDERSTATE_LINEPATTERN
-    D3DLINEPATTERN  m_linePattern     = {};
+    D3DLINEPATTERN   m_linePattern      = {};
     // Value of D3DRENDERSTATE_ZVISIBLE (although the RS is not supported, its value is stored)
-    DWORD           m_zVisible        = 0;
+    DWORD            m_zVisible         = 0;
     // Value of D3DRENDERSTATE_TEXTUREMAPBLEND
-    DWORD           m_textureMapBlend = D3DTBLEND_MODULATE;
+    DWORD            m_textureMapBlend  = D3DTBLEND_MODULATE;
+
+    D3DMATRIX        m_projectionMatrix = {};
+    const D3DMATRIX* m_legacyProjection = nullptr;
 
     // Common index buffers used for indexed draws, split up into five sizes:
     // XS, S, M, L and XL, corresponding to 0.5 kb, 2 kb, 8 kb, 32 kb and 128 kb

--- a/src/ddraw/d3d6/d3d6_viewport.cpp
+++ b/src/ddraw/d3d6/d3d6_viewport.cpp
@@ -134,13 +134,12 @@ namespace dxvk {
     data->dwHeight = viewport9->Height;
     data->dvMinZ   = viewport9->MinZ;
     data->dvMaxZ   = viewport9->MaxZ;
-    // Docs state: "Values of the D3DVALUE type describing the maximum and minimum
-    // nonhomogeneous coordinates of x, y, and z. Again, the relevant coordinates
-    // are the nonhomogeneous coordinates that result from the perspective division."
+
     data->dvMaxX   = 1.0f;
     data->dvMaxY   = 1.0f;
-    data->dvScaleX = 1.0f;
-    data->dvScaleY = 1.0f;
+    D3DVECTOR* legacyScale = m_commonViewport->GetLegacyScale();
+    data->dvScaleX = legacyScale->x * (float)data->dwWidth / 2.0f;
+    data->dvScaleY = legacyScale->y * (float)data->dwHeight / 2.0f;
 
     return D3D_OK;
   }
@@ -161,7 +160,8 @@ namespace dxvk {
     if (unlikely(m_device == nullptr))
       return D3DERR_VIEWPORTHASNODEVICE;
 
-    // TODO: Check viewport dimensions against the currently set RT
+    // TODO: Check viewport dimensions against the currently set RT,
+    // and perform some sanity checks (positive, non-zero dimensions)
 
     d3d9::D3DVIEWPORT9* viewport9 = m_commonViewport->GetD3D9Viewport();
 
@@ -173,6 +173,15 @@ namespace dxvk {
     viewport9->Height = data->dwHeight;
     viewport9->MinZ   = 0.0f;
     viewport9->MaxZ   = 1.0f;
+
+    D3DVECTOR* legacyScale = m_commonViewport->GetLegacyScale();
+    legacyScale->x = 2.0f * data->dvScaleX / (float)data->dwWidth;
+    legacyScale->y = 2.0f * data->dvScaleY / (float)data->dwHeight;
+    legacyScale->z = 1.0f;
+    D3DVECTOR* legacyClip = m_commonViewport->GetLegacyClip();
+    legacyClip->x = 0.0f;
+    legacyClip->y = 0.0f;
+    legacyClip->z = 0.0f;
 
     m_commonViewport->MarkViewportAsSet();
 
@@ -364,15 +373,13 @@ namespace dxvk {
     data->dwHeight     = viewport9->Height;
     data->dvMinZ       = viewport9->MinZ;
     data->dvMaxZ       = viewport9->MaxZ;
-    // Docs state: "In most cases, dvClipX is set to -1.0 and dvClipY is set
-    // to the inverse of the viewport's aspect ratio on the target surface,
-    // which can be calculated by dividing the dwHeight member by dwWidth.
-    // Similarly, the dvClipWidth member is typically 2.0 and dvClipHeight is
-    // set to twice the aspect ratio set in dwClipY."
-    data->dvClipX      = -1.0f;
-    data->dvClipY      =  static_cast<float>(viewport9->Height) / static_cast<float>(viewport9->Width);
-    data->dvClipWidth  =  2.0f;
-    data->dvClipHeight =  2.0f * data->dvClipY;
+
+    D3DVECTOR* legacyScale = m_commonViewport->GetLegacyScale();
+    data->dvClipWidth  = 2.0f / legacyScale->x;
+    data->dvClipHeight = 2.0f / legacyScale->y;
+    D3DVECTOR* legacyClip = m_commonViewport->GetLegacyClip();
+    data->dvClipX      = data->dvClipWidth  * (legacyClip->x + 1.0f) / -2.0f;
+    data->dvClipY      = data->dvClipHeight * (legacyClip->y - 1.0f) / -2.0f;
 
     return D3D_OK;
   }
@@ -393,7 +400,8 @@ namespace dxvk {
     if (unlikely(m_device == nullptr))
       return D3DERR_VIEWPORTHASNODEVICE;
 
-    // TODO: Check viewport dimensions against the currently set RT
+    // TODO: Check viewport dimensions against the currently set RT,
+    // and perform some sanity checks (positive, non-zero dimensions)
 
     d3d9::D3DVIEWPORT9* viewport9 = m_commonViewport->GetD3D9Viewport();
 
@@ -401,23 +409,17 @@ namespace dxvk {
     viewport9->Y      = data->dwY;
     viewport9->Width  = data->dwWidth;
     viewport9->Height = data->dwHeight;
-    // Empire of the Ants uses 1.0f and 1000000.0f, so the expectation
-    // is most likely for these values to be normalized to [0.0f, 1.0f]
-    viewport9->MinZ   = data->dvMaxZ <= 1.0f ? data->dvMinZ : data->dvMinZ / data->dvMaxZ;
-    viewport9->MaxZ   = data->dvMaxZ <= 1.0f ? data->dvMaxZ : 1.0f;
+    viewport9->MinZ   = 0.0f;
+    viewport9->MaxZ   = 1.0f;
 
-    const D3DOptions* d3dOptions = m_commonViewport->GetCommonD3DInterface()->GetOptions();
-
-    if (unlikely(d3dOptions->viewportCorrection)) {
-      // The Summoner sets both to 0.0f and expects to end up with 0.0f / 1.0f
-      if (viewport9->MinZ == 0.0f && viewport9->MaxZ == 0.0f) {
-        viewport9->MaxZ = 1.0f;
-      // Urban Chaos mixes up MinZ / MaxZ, and this somehow works on native...
-      } else if (viewport9->MinZ == 1.0f && viewport9->MaxZ == 0.0f) {
-        viewport9->MinZ = 0.0f;
-        viewport9->MaxZ = 1.0f;
-      }
-    }
+    D3DVECTOR* legacyScale = m_commonViewport->GetLegacyScale();
+    legacyScale->x = 2.0f / data->dvClipWidth;
+    legacyScale->y = 2.0f / data->dvClipHeight;
+    legacyScale->z = 1.0f / (data->dvMaxZ - data->dvMinZ);
+    D3DVECTOR* legacyClip = m_commonViewport->GetLegacyClip();
+    legacyClip->x = -2.0f * data->dvClipX / data->dvClipWidth - 1.0f;
+    legacyClip->y = -2.0f * data->dvClipY / data->dvClipHeight + 1.0f;
+    legacyClip->z = -data->dvMinZ / (data->dvMaxZ - data->dvMinZ);
 
     m_commonViewport->MarkViewportAsSet();
 

--- a/src/ddraw/d3d7/d3d7_device.cpp
+++ b/src/ddraw/d3d7/d3d7_device.cpp
@@ -446,15 +446,18 @@ namespace dxvk {
       }
     }
 
-    d3d9::D3DVIEWPORT9* data9 = reinterpret_cast<d3d9::D3DVIEWPORT9*>(data);
-
-    const D3DOptions* d3dOptions = m_commonIntf->GetOptions();
     // (The) Summoner sets both to 0.0f and expects to get
-    // the behavioral equivalent of setting 0.0f/1.0f
-    if (unlikely(d3dOptions->viewportCorrection && data9->MinZ == 0.0f && data9->MaxZ == 0.0f))
-      data9->MaxZ = 1.0f;
+    // the behavioral equivalent of setting 0.0f/1.0f, although
+    // the actual D3D7 behavior will result in 0.0f/0.001f.
+    //
+    // It is somewhat unclear why this works properly on native,
+    // however it is possible some corrections were performed at
+    // driver level or in the runtime, but without affecting
+    // reported viewport dvMinZ/dvMaxZ values.
+    if (unlikely(data->dvMinZ == 0.0f && data->dvMaxZ == 0.0f))
+      data->dvMaxZ = 1.0f;
 
-    return m_d3d9->SetViewport(data9);
+    return m_d3d9->SetViewport(reinterpret_cast<d3d9::D3DVIEWPORT9*>(data));
   }
 
   HRESULT STDMETHODCALLTYPE D3D7Device::GetViewport(D3DVIEWPORT7 *data) {

--- a/src/ddraw/d3d_common_viewport.h
+++ b/src/ddraw/d3d_common_viewport.h
@@ -32,7 +32,9 @@ namespace dxvk {
     }
 
     void MarkViewportAsSet() {
-      m_isViewportSet = true;
+      m_isViewportSet   = true;
+      // Also dirty legacy projection on any viewport updates
+      m_dirtyProjection = true;
     }
 
     bool IsViewportSet() const {
@@ -99,17 +101,67 @@ namespace dxvk {
       return m_origin == origin;
     }
 
+    D3DVECTOR* GetLegacyScale() {
+      return &m_legacyScale;
+    }
+
+    D3DVECTOR* GetLegacyClip() {
+      return &m_legacyClip;
+    }
+
+    const D3DMATRIX* GetLegacyProjectionMatrix(DWORD drawFlags) {
+      // Fast skip if viewport values haven't been set
+      if (unlikely(!m_isViewportSet))
+        return nullptr;
+
+      const bool needsClipping = !(drawFlags & D3DDP_DONOTCLIP);
+      if (unlikely(m_needsClipping != needsClipping)) {
+        m_dirtyProjection = true;
+        m_needsClipping = needsClipping;
+      }
+
+      // Recalculate legacy projection matrix only when needed
+      if (unlikely(m_dirtyProjection)) {
+        m_legacyProjection._11 = m_legacyScale.x;
+        m_legacyProjection._22 = m_legacyScale.y;
+        m_legacyProjection._33 = m_legacyScale.z;
+        m_legacyProjection._41 = m_needsClipping ? m_legacyClip.x : 0.0f;
+        m_legacyProjection._42 = m_needsClipping ? m_legacyClip.y : 0.0f;
+        m_legacyProjection._43 = m_needsClipping ? m_legacyClip.z : 0.0f;
+        m_legacyProjection._44 = 1.0f;
+        // Determine if the projection matrix is an identity matrix
+        m_isIdentityMatrix = m_legacyProjection._11 == 1.0f &&
+                             m_legacyProjection._22 == 1.0f &&
+                             m_legacyProjection._33 == 1.0f &&
+                             m_legacyProjection._41 == 0.0f &&
+                             m_legacyProjection._42 == 0.0f &&
+                             m_legacyProjection._43 == 0.0f;
+        m_dirtyProjection = false;
+      }
+
+      return m_isIdentityMatrix ? nullptr : &m_legacyProjection;
+    }
+
   private:
 
     bool                m_isViewportSet     = false;
     bool                m_isCurrentViewport = false;
     bool                m_isMaterialSet     = false;
 
+    // Legacy projection state
+    bool                m_isIdentityMatrix  = false;
+    bool                m_needsClipping     = false;
+    bool                m_dirtyProjection   = false;
+
     D3DCommonInterface* m_commonD3DIntf     = nullptr;
 
     D3DMATERIALHANDLE   m_materialHandle    = 0;
 
     d3d9::D3DVIEWPORT9  m_viewport9 = { };
+
+    D3DVECTOR           m_legacyScale       = { };
+    D3DVECTOR           m_legacyClip        = { };
+    D3DMATRIX           m_legacyProjection  = { };
 
     // Track all possible viewport versions of the same object
     D3D6Viewport*       m_d3d6Viewport      = nullptr;

--- a/src/ddraw/ddraw_options.h
+++ b/src/ddraw/ddraw_options.h
@@ -44,9 +44,6 @@ namespace dxvk {
     /// Respect DISCARD only on DYNAMIC + WRITEONLY buffers
     bool forceLegacyDiscard;
 
-    /// Temporary workaround for bad behaving viewport MinZ/MaxZ use
-    bool viewportCorrection;
-
     /// Circumvents the texelFetch color key shader path
     bool colorKeyCompatibility;
 
@@ -101,7 +98,6 @@ namespace dxvk {
       this->mask8BitModes         = config.getOption<bool>   ("ddraw.mask8BitModes",         false);
       this->forcePOW2Textures     = config.getOption<bool>   ("ddraw.forcePOW2Textures",     false);
       this->forceLegacyDiscard    = config.getOption<bool>   ("ddraw.forceLegacyDiscard",    false);
-      this->viewportCorrection    = config.getOption<bool>   ("ddraw.viewportCorrection",    false);
       this->colorKeyCompatibility = config.getOption<bool>   ("ddraw.colorKeyCompatibility", false);
       this->forceSingleBackBuffer = config.getOption<bool>   ("ddraw.forceSingleBackBuffer", false);
       this->backBufferResize      = config.getOption<bool>   ("ddraw.backBufferResize",       true);

--- a/src/util/config/config.cpp
+++ b/src/util/config/config.cpp
@@ -1565,7 +1565,6 @@ namespace dxvk {
     { R"(\\Sum\.exe$)", {{
       { "d3d9.maxFrameRate",                 "-60" },
       { "ddraw.emulateFSAA",                "True" },
-      { "ddraw.viewportCorrection",         "True" },
     }} },
     /* Wizardry 8 - Fixes broken input handling   */
     { R"(\\Wiz8\.exe$)", {{
@@ -1740,7 +1739,6 @@ namespace dxvk {
     { R"(\\fallen\.exe$)", {{
       { "ddraw.ignoreExclusiveMode",        "True" },
       { "ddraw.forceSingleBackBuffer",      "True" },
-      { "ddraw.viewportCorrection",         "True" },
     }} },
     /* Redline - Fixes missing weapon mip maps    */
     { R"(\\Redline\.exe$)", {{


### PR DESCRIPTION
Handles viewport projection and clipping, which a few games apparently rely on. Also obsoletes the viewport MinZ/MaxZ corrections we were doing earlier, with the exception of Summoner. Rather than keeping it as a config option, I've decided to simply correct it globally, although it technically deviates from native behavior.