### PR TITLE
[meta] Replace proxied presenation with legacy presentation

### DIFF
--- a/dxvk.conf
+++ b/dxvk.conf
@@ -969,19 +969,19 @@
 
 # ddraw.backBufferResize = True
 
-# Proxied presentation using the DDraw swapchain
+# Legacy presentation for DDraw interoperability
 #
-# Some DDraw applications compose an image by blitting elements directly onto
-# the front/back buffer, once rendering is complete. These elements will not
+# Some early D3D applications compose an image by blitting elements directly onto
+# the front buffer, once rendering is complete. These elements will not
 # be accounted for properly by D7VK, so instead copy back the rendered image
-# onto its original surface (DDraw swapchain), allow the blitting to happen,
-# and then present using DDraw. This will reduce performance and is only used
-# for compatibility purposes/with misbehaving titles.
+# onto its original DDraw surface, allow the blitting to happen, and then
+# copy the image back again for presentation. This will reduce performance
+# and is only intended for compatibility purposes/use with misbehaving titles.
 #
 # Supported values:
 # - True/False
 
-# ddraw.forceProxiedPresent = False
+# ddraw.forceLegacyPresent = False
 
 # Ignore application set gamma ramps
 #

--- a/src/ddraw/d3d3/d3d3_device.cpp
+++ b/src/ddraw/d3d3/d3d3_device.cpp
@@ -395,13 +395,13 @@ namespace dxvk {
 
     RefreshLastUsedDevice();
 
-    if (unlikely(m_inScene))
+    if (unlikely(m_commonD3DDevice->IsInScene()))
       return D3DERR_SCENE_IN_SCENE;
 
     HRESULT hr = m_d3d9->BeginScene();
 
     if (likely(SUCCEEDED(hr)))
-      m_inScene = true;
+      m_commonD3DDevice->SetInScene(true);
 
     return hr;
   }
@@ -413,28 +413,28 @@ namespace dxvk {
 
     RefreshLastUsedDevice();
 
-    if (unlikely(!m_inScene))
+    if (unlikely(!m_commonD3DDevice->IsInScene()))
       return D3DERR_SCENE_NOT_IN_SCENE;
 
     HRESULT hr = m_d3d9->EndScene();
 
     if (likely(SUCCEEDED(hr))) {
-      const D3DOptions* d3dOptions = m_commonIntf->GetOptions();
+      if (unlikely(m_commonIntf->GetOptions()->forceLegacyPresent)) {
+        DDrawSurface* shadowSurf = m_rt->GetShadowSurface();
 
-      if (d3dOptions->forceProxiedPresent) {
-        // If we have drawn anything, we need to make sure we blit back
-        // the results onto the D3D3 render target before we flip it
-        if (m_commonIntf->HasDrawn())
-          BlitToDDrawSurface<IDirectDrawSurface, DDSURFACEDESC>(m_rt->GetProxied(), m_rt->GetD3D9());
+        // Some games need an explicit blit back to work properly
+        if (m_rt->IsInitialized() && m_commonIntf->HasDrawn()) {
+          IDirectDrawSurface* targetSurf = shadowSurf == nullptr ? m_rt->GetProxied() : shadowSurf->GetProxied();
+          BlitToDDrawSurface<IDirectDrawSurface, DDSURFACEDESC>(targetSurf, m_rt->GetD3D9());
+        }
 
-        m_rt->GetProxied()->Flip(static_cast<IDirectDrawSurface*>(m_commonIntf->GetFlipRTSurface()),
-                                 m_commonIntf->GetFlipRTFlags());
-
-        if (likely(d3dOptions->backBufferGuard != D3DBackBufferGuard::Strict))
+        // Allow uploads to the D3D9 back buffer once a scene completes,
+        // in order to reflect any post-rendering blits an application does
+        if (likely(m_commonIntf->GetOptions()->backBufferGuard != D3DBackBufferGuard::Strict))
           m_commonIntf->ResetDrawTracking();
       }
 
-      m_inScene = false;
+      m_commonD3DDevice->SetInScene(false);
     }
 
     return hr;
@@ -916,8 +916,7 @@ namespace dxvk {
   }
 
   void D3D3Device::InitializeDS() {
-    if (!m_rt->IsInitialized())
-      m_rt->InitializeD3D9RenderTarget();
+    m_rt->InitializeD3D9RenderTarget();
 
     m_ds = m_rt->GetAttachedDepthStencil();
 

--- a/src/ddraw/d3d3/d3d3_device.h
+++ b/src/ddraw/d3d3/d3d3_device.h
@@ -153,8 +153,6 @@ namespace dxvk {
 
     inline void TextureLoadInternal(D3DTEXTURELOAD* textureLoad, uint16_t count);
 
-    bool                           m_inScene     = false;
-
     static uint32_t                s_deviceCount;
     uint32_t                       m_deviceCount = 0;
 

--- a/src/ddraw/d3d5/d3d5_device.cpp
+++ b/src/ddraw/d3d5/d3d5_device.cpp
@@ -401,13 +401,13 @@ namespace dxvk {
 
     RefreshLastUsedDevice();
 
-    if (unlikely(m_inScene))
+    if (unlikely(m_commonD3DDevice->IsInScene()))
       return D3DERR_SCENE_IN_SCENE;
 
     HRESULT hr = m_d3d9->BeginScene();
 
     if (likely(SUCCEEDED(hr)))
-      m_inScene = true;
+      m_commonD3DDevice->SetInScene(true);
 
     return hr;
   }
@@ -419,28 +419,28 @@ namespace dxvk {
 
     RefreshLastUsedDevice();
 
-    if (unlikely(!m_inScene))
+    if (unlikely(!m_commonD3DDevice->IsInScene()))
       return D3DERR_SCENE_NOT_IN_SCENE;
 
     HRESULT hr = m_d3d9->EndScene();
 
     if (likely(SUCCEEDED(hr))) {
-      const D3DOptions* d3dOptions = m_commonIntf->GetOptions();
+      if (unlikely(m_commonIntf->GetOptions()->forceLegacyPresent)) {
+        DDrawSurface* shadowSurf = m_rt->GetShadowSurface();
 
-      if (d3dOptions->forceProxiedPresent) {
-        // If we have drawn anything, we need to make sure we blit back
-        // the results onto the D3D5 render target before we flip it
-        if (m_commonIntf->HasDrawn())
-          BlitToDDrawSurface<IDirectDrawSurface, DDSURFACEDESC>(m_rt->GetProxied(), m_rt->GetD3D9());
+        // Some games need an explicit blit back to work properly
+        if (m_rt->IsInitialized() && m_commonIntf->HasDrawn()) {
+          IDirectDrawSurface* targetSurf = shadowSurf == nullptr ? m_rt->GetProxied() : shadowSurf->GetProxied();
+          BlitToDDrawSurface<IDirectDrawSurface, DDSURFACEDESC>(targetSurf, m_rt->GetD3D9());
+        }
 
-        m_rt->GetProxied()->Flip(static_cast<IDirectDrawSurface*>(m_commonIntf->GetFlipRTSurface()),
-                                 m_commonIntf->GetFlipRTFlags());
-
-        if (likely(d3dOptions->backBufferGuard != D3DBackBufferGuard::Strict))
+        // Allow uploads to the D3D9 back buffer once a scene completes,
+        // in order to reflect any post-rendering blits an application does
+        if (likely(m_commonIntf->GetOptions()->backBufferGuard != D3DBackBufferGuard::Strict))
           m_commonIntf->ResetDrawTracking();
       }
 
-      m_inScene = false;
+      m_commonD3DDevice->SetInScene(false);
     }
 
     return hr;
@@ -524,20 +524,10 @@ namespace dxvk {
 
     DDrawSurface* rt5 = static_cast<DDrawSurface*>(surface);
 
-    const D3DOptions* d3dOptions = m_commonIntf->GetOptions();
-
-    if (unlikely(d3dOptions->forceProxiedPresent)) {
-      HRESULT hrRT = m_proxy->SetRenderTarget(rt5->GetProxied(), flags);
-      if (unlikely(FAILED(hrRT))) {
-        Logger::warn("D3D5Device::SetRenderTarget: Failed to set RT");
-        return hrRT;
-      }
-    } else {
-      // Needed to ensure proxied Z/Stencil viewport clears will work
-      HRESULT hrRT = m_proxy->SetRenderTarget(rt5->GetProxied(), flags);
-      if (unlikely(FAILED(hrRT)))
-        Logger::debug("D3D5Device::SetRenderTarget: Failed to set RT");
-    }
+    // Needed to ensure proxied Z/Stencil viewport clears will work
+    HRESULT hrRT = m_proxy->SetRenderTarget(rt5->GetShadowOrProxied(), flags);
+    if (unlikely(FAILED(hrRT)))
+      Logger::debug("D3D5Device::SetRenderTarget: Failed to set RT");
 
     HRESULT hr = rt5->GetCommonSurface()->ValidateRTUsage();
     if (unlikely(FAILED(hr)))
@@ -1458,8 +1448,7 @@ namespace dxvk {
   }
 
   void D3D5Device::InitializeDS() {
-    if (!m_rt->IsInitialized())
-      m_rt->InitializeD3D9RenderTarget();
+    m_rt->InitializeD3D9RenderTarget();
 
     m_ds = m_rt->GetAttachedDepthStencil();
 

--- a/src/ddraw/d3d5/d3d5_device.h
+++ b/src/ddraw/d3d5/d3d5_device.h
@@ -206,8 +206,6 @@ namespace dxvk {
       }
     }
 
-    bool                           m_inScene     = false;
-
     static uint32_t                s_deviceCount;
     uint32_t                       m_deviceCount = 0;
 

--- a/src/ddraw/d3d5/d3d5_interface.cpp
+++ b/src/ddraw/d3d5/d3d5_interface.cpp
@@ -448,7 +448,7 @@ namespace dxvk {
     }
 
     Com<IDirect3DDevice2> d3d5DeviceProxy;
-    HRESULT hr = m_proxy->CreateDevice(rclsidOverride, rt->GetProxied(), &d3d5DeviceProxy);
+    HRESULT hr = m_proxy->CreateDevice(rclsidOverride, rt->GetShadowOrProxied(), &d3d5DeviceProxy);
     if (unlikely(FAILED(hr))) {
       Logger::warn("D3D5Interface::CreateDevice: Failed to create the proxy device");
       return hr;
@@ -461,8 +461,7 @@ namespace dxvk {
     DWORD backBufferWidth  = desc.dwWidth;
     DWORD BackBufferHeight = desc.dwHeight;
 
-    if (likely(!d3dOptions->forceProxiedPresent &&
-                d3dOptions->backBufferResize)) {
+    if (likely(d3dOptions->backBufferResize)) {
       const bool exclusiveMode = m_commonIntf->GetCooperativeLevel() & DDSCL_EXCLUSIVE;
 
       // Ignore any mode size dimensions when in windowed present mode
@@ -519,7 +518,7 @@ namespace dxvk {
     Logger::info(str::format("D3D5Interface::CreateDevice: Back buffer size: ", desc.dwWidth, "x", desc.dwHeight));
 
     DWORD backBufferCount = 0;
-    if (likely(!d3dOptions->forceSingleBackBuffer)) {
+    if (likely(!d3dOptions->forceSingleBackBuffer && !d3dOptions->forceLegacyPresent)) {
       IDirectDrawSurface* backBuffer = rt->GetProxied();
       while (backBuffer != nullptr) {
         IDirectDrawSurface* parentSurface = backBuffer;

--- a/src/ddraw/d3d6/d3d6_device.cpp
+++ b/src/ddraw/d3d6/d3d6_device.cpp
@@ -406,13 +406,13 @@ namespace dxvk {
 
     RefreshLastUsedDevice();
 
-    if (unlikely(m_inScene))
+    if (unlikely(m_commonD3DDevice->IsInScene()))
       return D3DERR_SCENE_IN_SCENE;
 
     HRESULT hr = m_d3d9->BeginScene();
 
     if (likely(SUCCEEDED(hr)))
-      m_inScene = true;
+      m_commonD3DDevice->SetInScene(true);
 
     return hr;
   }
@@ -424,28 +424,28 @@ namespace dxvk {
 
     RefreshLastUsedDevice();
 
-    if (unlikely(!m_inScene))
+    if (unlikely(!m_commonD3DDevice->IsInScene()))
       return D3DERR_SCENE_NOT_IN_SCENE;
 
     HRESULT hr = m_d3d9->EndScene();
 
     if (likely(SUCCEEDED(hr))) {
-      const D3DOptions* d3dOptions = m_commonIntf->GetOptions();
+      if (unlikely(m_commonIntf->GetOptions()->forceLegacyPresent)) {
+        DDraw4Surface* shadowSurf = m_rt->GetShadowSurface();
 
-      if (d3dOptions->forceProxiedPresent) {
-        // If we have drawn anything, we need to make sure we blit back
-        // the results onto the D3D6 render target before we flip it
-        if (m_commonIntf->HasDrawn())
-          BlitToDDrawSurface<IDirectDrawSurface4, DDSURFACEDESC2>(m_rt->GetProxied(), m_rt->GetD3D9());
+        // Some games need an explicit blit back to work properly
+        if (m_rt->IsInitialized() && m_commonIntf->HasDrawn()) {
+          IDirectDrawSurface4* targetSurf = shadowSurf == nullptr ? m_rt->GetProxied() : shadowSurf->GetProxied();
+          BlitToDDrawSurface<IDirectDrawSurface4, DDSURFACEDESC2>(targetSurf, m_rt->GetD3D9());
+        }
 
-        m_rt->GetProxied()->Flip(static_cast<IDirectDrawSurface4*>(m_commonIntf->GetFlipRTSurface()),
-                                 m_commonIntf->GetFlipRTFlags());
-
-        if (likely(d3dOptions->backBufferGuard != D3DBackBufferGuard::Strict))
+        // Allow uploads to the D3D9 back buffer once a scene completes,
+        // in order to reflect any post-rendering blits an application does
+        if (likely(m_commonIntf->GetOptions()->backBufferGuard != D3DBackBufferGuard::Strict))
           m_commonIntf->ResetDrawTracking();
       }
 
-      m_inScene = false;
+      m_commonD3DDevice->SetInScene(false);
     }
 
     return hr;
@@ -529,20 +529,10 @@ namespace dxvk {
 
     DDraw4Surface* rt6 = static_cast<DDraw4Surface*>(surface);
 
-    const D3DOptions* d3dOptions = m_commonIntf->GetOptions();
-
-    if (unlikely(d3dOptions->forceProxiedPresent)) {
-      HRESULT hrRT = m_proxy->SetRenderTarget(rt6->GetProxied(), flags);
-      if (unlikely(FAILED(hrRT))) {
-        Logger::warn("D3D6Device::SetRenderTarget: Failed to set RT");
-        return hrRT;
-      }
-    } else {
-      // Needed to ensure proxied Z/Stencil viewport clears will work
-      HRESULT hrRT = m_proxy->SetRenderTarget(rt6->GetProxied(), flags);
-      if (unlikely(FAILED(hrRT)))
-        Logger::debug("D3D6Device::SetRenderTarget: Failed to set RT");
-    }
+    // Needed to ensure proxied Z/Stencil viewport clears will work
+    HRESULT hrRT = m_proxy->SetRenderTarget(rt6->GetShadowOrProxied(), flags);
+    if (unlikely(FAILED(hrRT)))
+      Logger::debug("D3D6Device::SetRenderTarget: Failed to set RT");
 
     HRESULT hr = rt6->GetCommonSurface()->ValidateRTUsage();
     if (unlikely(FAILED(hr)))
@@ -1835,8 +1825,7 @@ namespace dxvk {
   }
 
   void D3D6Device::InitializeDS() {
-    if (!m_rt->IsInitialized())
-      m_rt->InitializeD3D9RenderTarget();
+    m_rt->InitializeD3D9RenderTarget();
 
     m_ds = m_rt->GetAttachedDepthStencil();
 

--- a/src/ddraw/d3d6/d3d6_device.h
+++ b/src/ddraw/d3d6/d3d6_device.h
@@ -239,7 +239,6 @@ namespace dxvk {
       }
     }
 
-    bool                           m_inScene     = false;
     bool                           m_alphaOpSet  = false;
 
     static uint32_t                s_deviceCount;

--- a/src/ddraw/d3d6/d3d6_interface.cpp
+++ b/src/ddraw/d3d6/d3d6_interface.cpp
@@ -368,7 +368,7 @@ namespace dxvk {
     }
 
     Com<IDirect3DDevice3> d3d6DeviceProxy;
-    HRESULT hr = m_proxy->CreateDevice(rclsidOverride, rt4->GetProxied(), &d3d6DeviceProxy, nullptr);
+    HRESULT hr = m_proxy->CreateDevice(rclsidOverride, rt4->GetShadowOrProxied(), &d3d6DeviceProxy, nullptr);
     if (unlikely(FAILED(hr))) {
       Logger::warn("D3D6Interface::CreateDevice: Failed to create the proxy device");
       return hr;
@@ -381,8 +381,7 @@ namespace dxvk {
     DWORD backBufferWidth  = desc.dwWidth;
     DWORD BackBufferHeight = desc.dwHeight;
 
-    if (likely(!d3dOptions->forceProxiedPresent &&
-                d3dOptions->backBufferResize)) {
+    if (likely(d3dOptions->backBufferResize)) {
       const bool exclusiveMode = m_commonIntf->GetCooperativeLevel() & DDSCL_EXCLUSIVE;
 
       // Ignore any mode size dimensions when in windowed present mode
@@ -439,7 +438,7 @@ namespace dxvk {
     Logger::info(str::format("D3D6Interface::CreateDevice: Back buffer size: ", desc.dwWidth, "x", desc.dwHeight));
 
     DWORD backBufferCount = 0;
-    if (likely(!d3dOptions->forceSingleBackBuffer)) {
+    if (likely(!d3dOptions->forceSingleBackBuffer && !d3dOptions->forceLegacyPresent)) {
       IDirectDrawSurface4* backBuffer = rt4->GetProxied();
       while (backBuffer != nullptr) {
         IDirectDrawSurface4* parentSurface = backBuffer;

--- a/src/ddraw/d3d7/d3d7_device.cpp
+++ b/src/ddraw/d3d7/d3d7_device.cpp
@@ -207,13 +207,13 @@ namespace dxvk {
 
     RefreshLastUsedDevice();
 
-    if (unlikely(m_inScene))
+    if (unlikely(m_commonD3DDevice->IsInScene()))
       return D3DERR_SCENE_IN_SCENE;
 
     HRESULT hr = m_d3d9->BeginScene();
 
     if (likely(SUCCEEDED(hr)))
-      m_inScene = true;
+      m_commonD3DDevice->SetInScene(true);
 
     return hr;
   }
@@ -225,28 +225,28 @@ namespace dxvk {
 
     RefreshLastUsedDevice();
 
-    if (unlikely(!m_inScene))
+    if (unlikely(!m_commonD3DDevice->IsInScene()))
       return D3DERR_SCENE_NOT_IN_SCENE;
 
     HRESULT hr = m_d3d9->EndScene();
 
     if (likely(SUCCEEDED(hr))) {
-      const D3DOptions* d3dOptions = m_commonIntf->GetOptions();
+      if (unlikely(m_commonIntf->GetOptions()->forceLegacyPresent)) {
+        DDraw7Surface* shadowSurf = m_rt->GetShadowSurface();
 
-      if (d3dOptions->forceProxiedPresent) {
-        // If we have drawn anything, we need to make sure we blit back
-        // the results onto the D3D7 render target before we flip it
-        if (m_commonIntf->HasDrawn())
-          BlitToDDrawSurface<IDirectDrawSurface7, DDSURFACEDESC2>(m_rt->GetProxied(), m_rt->GetD3D9());
+        // Some games need an explicit blit back to work properly
+        if (m_rt->IsInitialized() && m_commonIntf->HasDrawn()) {
+          IDirectDrawSurface7* targetSurf = shadowSurf == nullptr ? m_rt->GetProxied() : shadowSurf->GetProxied();
+          BlitToDDrawSurface<IDirectDrawSurface7, DDSURFACEDESC2>(targetSurf, m_rt->GetD3D9());
+        }
 
-        m_rt->GetProxied()->Flip(static_cast<IDirectDrawSurface7*>(m_commonIntf->GetFlipRTSurface()),
-                                 m_commonIntf->GetFlipRTFlags());
-
-        if (likely(d3dOptions->backBufferGuard != D3DBackBufferGuard::Strict))
+        // Allow uploads to the D3D9 back buffer once a scene completes,
+        // in order to reflect any post-rendering blits an application does
+        if (likely(m_commonIntf->GetOptions()->backBufferGuard != D3DBackBufferGuard::Strict))
           m_commonIntf->ResetDrawTracking();
       }
 
-      m_inScene = false;
+      m_commonD3DDevice->SetInScene(false);
     }
 
     return hr;
@@ -280,20 +280,10 @@ namespace dxvk {
 
     DDraw7Surface* rt7 = static_cast<DDraw7Surface*>(surface);
 
-    const D3DOptions* d3dOptions = m_commonIntf->GetOptions();
-
-    if (unlikely(d3dOptions->forceProxiedPresent)) {
-      HRESULT hrRT = m_proxy->SetRenderTarget(rt7->GetProxied(), flags);
-      if (unlikely(FAILED(hrRT))) {
-        Logger::warn("D3D7Device::SetRenderTarget: Failed to set RT");
-        return hrRT;
-      }
-    } else {
-      // Needed to ensure proxied Z/Stencil viewport clears will work
-      HRESULT hrRT = m_proxy->SetRenderTarget(rt7->GetProxied(), flags);
-      if (unlikely(FAILED(hrRT)))
-        Logger::debug("D3D7Device::SetRenderTarget: Failed to set RT");
-    }
+    // Needed to ensure proxied Z/Stencil viewport clears will work
+    HRESULT hrRT = m_proxy->SetRenderTarget(rt7->GetShadowOrProxied(), flags);
+    if (unlikely(FAILED(hrRT)))
+      Logger::debug("D3D7Device::SetRenderTarget: Failed to set RT");
 
     HRESULT hr = rt7->GetCommonSurface()->ValidateRTUsage();
     if (unlikely(FAILED(hr)))

--- a/src/ddraw/d3d7/d3d7_device.h
+++ b/src/ddraw/d3d7/d3d7_device.h
@@ -185,8 +185,6 @@ namespace dxvk {
         m_commonIntf->SetCommonD3DDevice(m_commonD3DDevice.ptr());
     }
 
-    bool                        m_inScene     = false;
-
     static uint32_t             s_deviceCount;
     uint32_t                    m_deviceCount = 0;
 

--- a/src/ddraw/d3d7/d3d7_interface.cpp
+++ b/src/ddraw/d3d7/d3d7_interface.cpp
@@ -196,7 +196,7 @@ namespace dxvk {
     }
 
     Com<IDirect3DDevice7> d3d7DeviceProxy;
-    HRESULT hr = m_proxy->CreateDevice(rclsidOverride, rt7->GetProxied(), &d3d7DeviceProxy);
+    HRESULT hr = m_proxy->CreateDevice(rclsidOverride, rt7->GetShadowOrProxied(), &d3d7DeviceProxy);
     if (unlikely(FAILED(hr))) {
       Logger::warn("D3D7Interface::CreateDevice: Failed to create the proxy device");
       return hr;
@@ -209,8 +209,7 @@ namespace dxvk {
     DWORD backBufferWidth  = desc.dwWidth;
     DWORD BackBufferHeight = desc.dwHeight;
 
-    if (likely(!d3dOptions->forceProxiedPresent &&
-                d3dOptions->backBufferResize)) {
+    if (likely(d3dOptions->backBufferResize)) {
       const bool exclusiveMode = m_commonIntf->GetCooperativeLevel() & DDSCL_EXCLUSIVE;
 
       // Ignore any mode size dimensions when in windowed present mode
@@ -268,7 +267,7 @@ namespace dxvk {
     Logger::info(str::format("D3D7Interface::CreateDevice: Back buffer size: ", desc.dwWidth, "x", desc.dwHeight));
 
     DWORD backBufferCount = 0;
-    if (likely(!d3dOptions->forceSingleBackBuffer)) {
+    if (likely(!d3dOptions->forceSingleBackBuffer && !d3dOptions->forceLegacyPresent)) {
       IDirectDrawSurface7* backBuffer = rt7->GetProxied();
       while (backBuffer != nullptr) {
         IDirectDrawSurface7* parentSurface = backBuffer;

--- a/src/ddraw/d3d_common_device.h
+++ b/src/ddraw/d3d_common_device.h
@@ -60,6 +60,14 @@ namespace dxvk {
 
     bool IsCurrentD3D9DepthStencil(d3d9::IDirect3DSurface9* surface) const;
 
+    void SetInScene(bool inScene) {
+      m_inScene = inScene;
+    }
+
+    bool IsInScene() const {
+      return m_inScene;
+    }
+
     DDrawCommonInterface* GetCommonInterface() const {
       return m_commonIntf;
     }
@@ -113,6 +121,8 @@ namespace dxvk {
     }
 
   private:
+
+    bool                  m_inScene        = false;
 
     DDrawCommonInterface* m_commonIntf     = nullptr;
 

--- a/src/ddraw/ddraw/ddraw_interface.cpp
+++ b/src/ddraw/ddraw/ddraw_interface.cpp
@@ -294,8 +294,37 @@ namespace dxvk {
       try{
         // Surfaces created from IDirectDraw and IDirectDraw2 do not ref their parent interfaces
         Com<DDrawSurface> surface = new DDrawSurface(nullptr, std::move(ddrawSurfaceProxied), this, nullptr, false);
-        if (unlikely(lpDDSurfaceDesc->ddsCaps.dwCaps & DDSCAPS_PRIMARYSURFACE))
+
+        if (unlikely(lpDDSurfaceDesc->ddsCaps.dwCaps & DDSCAPS_PRIMARYSURFACE)) {
           m_commonIntf->SetPrimarySurface(surface->GetCommonSurface());
+
+          // Shadow surface creation for the primary surface
+          // (it needs to be based on the same incoming desc)
+          if (unlikely(!surface->GetCommonSurface()->Is8BitFormat() &&
+                        m_commonIntf->GetOptions()->forceLegacyPresent)) {
+            DDSURFACEDESC shadowDesc = *lpDDSurfaceDesc;
+            const DDSURFACEDESC* primaryDesc = surface->GetCommonSurface()->GetDesc();
+
+            shadowDesc.ddsCaps.dwCaps &= ~DDSCAPS_PRIMARYSURFACE & ~DDSCAPS_COMPLEX & ~DDSCAPS_FLIP;
+            shadowDesc.ddsCaps.dwCaps |= DDSCAPS_OFFSCREENPLAIN;
+            shadowDesc.dwFlags &= ~DDSD_BACKBUFFERCOUNT;
+            // Dimensions aren't specified in the incoming desc,
+            // but are explicitly needed for non-primary surfaces
+            shadowDesc.dwFlags |= DDSD_WIDTH | DDSD_HEIGHT;
+            shadowDesc.dwWidth  = primaryDesc->dwWidth;
+            shadowDesc.dwHeight = primaryDesc->dwHeight;
+
+            Com<IDirectDrawSurface> ddrawSurfaceShadow;
+            hr = m_proxy->CreateSurface(&shadowDesc, &ddrawSurfaceShadow, pUnkOuter);
+            if (unlikely(FAILED(hr))) {
+              Logger::warn("DDrawInterface::CreateSurface: Failed to create shadow surface");
+            } else {
+              Com<DDrawSurface> shadowSurf = new DDrawSurface(nullptr, std::move(ddrawSurfaceShadow), this, nullptr, false);
+              surface->SetShadowSurface(shadowSurf.ptr());
+            }
+          }
+        }
+
         *lplpDDSurface = surface.ref();
       } catch (const DxvkError& e) {
         Logger::err(e.message());
@@ -370,11 +399,6 @@ namespace dxvk {
   }
 
   HRESULT STDMETHODCALLTYPE DDrawInterface::FlipToGDISurface() {
-    if (unlikely(m_commonIntf->GetOptions()->forceProxiedPresent)) {
-      Logger::debug("<<< DDrawInterface::FlipToGDISurface: Proxy");
-      return m_proxy->FlipToGDISurface();
-    }
-
     Logger::debug("*** DDrawInterface::FlipToGDISurface: Ignoring");
 
     DDrawCommonSurface* ps = m_commonIntf->GetPrimarySurface();
@@ -591,8 +615,7 @@ namespace dxvk {
         Logger::warn("DDrawInterface::SetDisplayMode: Failed to update primary surface desc");
     }
 
-    if (likely(!m_commonIntf->GetOptions()->forceProxiedPresent &&
-                m_commonIntf->GetOptions()->backBufferResize)) {
+    if (likely(m_commonIntf->GetOptions()->backBufferResize)) {
       const bool exclusiveMode = m_commonIntf->GetCooperativeLevel() & DDSCL_EXCLUSIVE;
 
       // Ignore any mode size dimensions when in windowed present mode
@@ -610,11 +633,6 @@ namespace dxvk {
   }
 
   HRESULT STDMETHODCALLTYPE DDrawInterface::WaitForVerticalBlank(DWORD dwFlags, HANDLE hEvent) {
-    if (unlikely(m_commonIntf->GetOptions()->forceProxiedPresent)) {
-      Logger::debug("<<< DDrawInterface::WaitForVerticalBlank: Proxy");
-      m_proxy->WaitForVerticalBlank(dwFlags, hEvent);
-    }
-
     Logger::debug(">>> DDrawInterface::WaitForVerticalBlank");
 
     if (unlikely(dwFlags & DDWAITVB_BLOCKBEGINEVENT))

--- a/src/ddraw/ddraw/ddraw_surface.cpp
+++ b/src/ddraw/ddraw/ddraw_surface.cpp
@@ -59,7 +59,8 @@ namespace dxvk {
 
     if (m_parentSurf != nullptr && !m_commonSurf->IsFrontBuffer()
      && m_parentSurf->GetCommonSurface()->IsBackBufferOrFlippable()
-     && !m_commonIntf->GetOptions()->forceSingleBackBuffer) {
+     && !m_commonIntf->GetOptions()->forceSingleBackBuffer
+     && !m_commonIntf->GetOptions()->forceLegacyPresent) {
       const uint32_t index = m_parentSurf->GetCommonSurface()->GetBackBufferIndex();
       m_commonSurf->IncrementBackBufferIndex(index);
     }
@@ -309,18 +310,20 @@ namespace dxvk {
   HRESULT STDMETHODCALLTYPE DDrawSurface::Blt(LPRECT lpDestRect, LPDIRECTDRAWSURFACE lpDDSrcSurface, LPRECT lpSrcRect, DWORD dwFlags, LPDDBLTFX lpDDBltFx) {
     Logger::debug("<<< DDrawSurface::Blt: Proxy");
 
+    const D3DOptions* d3dOptions = m_commonIntf->GetOptions();
+
     // Write back any flippable surfaces or depth stencils from D3D9
     if (likely(lpDDSrcSurface != nullptr && m_commonIntf->IsWrappedSurface(lpDDSrcSurface))) {
       DDrawSurface* sourceSurface = static_cast<DDrawSurface*>(lpDDSrcSurface);
       if (unlikely(sourceSurface->GetCommonSurface()->IsGuardableSurface())) {
-        if (m_commonIntf->GetOptions()->backBufferWriteBack || m_commonIntf->GetOptions()->apitraceMode) {
+        if (d3dOptions->backBufferWriteBack || d3dOptions->forceLegacyPresent || d3dOptions->apitraceMode) {
           Logger::debug("DDrawSurface::Blt: Source surface is a swapchain surface");
 
           if (unlikely(m_commonIntf->GetOptions()->apitraceMode && !sourceSurface->IsInitialized()))
             sourceSurface->InitializeOrUploadD3D9();
 
           if (likely(sourceSurface->IsInitialized()))
-            BlitToDDrawSurface<IDirectDrawSurface, DDSURFACEDESC>(sourceSurface->GetProxied(), sourceSurface->GetD3D9());
+            BlitToDDrawSurface<IDirectDrawSurface, DDSURFACEDESC>(sourceSurface->GetShadowOrProxied(), sourceSurface->GetD3D9());
         } else {
           static bool s_swapchainWarningShown;
 
@@ -328,7 +331,7 @@ namespace dxvk {
             Logger::warn("DDrawSurface::Blt: Source surface is a swapchain surface");
         }
       } else if (unlikely(sourceSurface->GetCommonSurface()->IsDepthStencil())) {
-        if (m_commonIntf->GetOptions()->depthWriteBack || m_commonIntf->GetOptions()->apitraceMode) {
+        if (d3dOptions->depthWriteBack || d3dOptions->apitraceMode) {
           Logger::debug("DDrawSurface::Blt: Source surface is a depth stencil");
 
           if (likely(sourceSurface->IsInitialized()))
@@ -380,12 +383,12 @@ namespace dxvk {
       }
 
       const bool exclusiveMode = (m_commonIntf->GetCooperativeLevel() & DDSCL_EXCLUSIVE)
-                              && !m_commonIntf->GetOptions()->ignoreExclusiveMode;
+                              && !d3dOptions->ignoreExclusiveMode;
 
       // Eclusive mode back buffer guard
       if (exclusiveMode && m_commonIntf->HasDrawn() &&
           m_commonSurf->IsGuardableSurface() &&
-          m_commonIntf->GetOptions()->backBufferGuard != D3DBackBufferGuard::Disabled) {
+          d3dOptions->backBufferGuard != D3DBackBufferGuard::Disabled) {
         return DD_OK;
       // Windowed mode presentation path
       } else if (!exclusiveMode && m_commonIntf->HasDrawn() && m_commonSurf->IsPrimarySurface()) {
@@ -402,10 +405,10 @@ namespace dxvk {
         Logger::warn("DDrawSurface::Blt: Received an unwrapped source surface");
         return DDERR_UNSUPPORTED;
       }
-      hr = m_proxy->Blt(lpDestRect, lpDDSrcSurface, lpSrcRect, dwFlags, lpDDBltFx);
+      hr = GetShadowOrProxied()->Blt(lpDestRect, lpDDSrcSurface, lpSrcRect, dwFlags, lpDDBltFx);
     } else {
       DDrawSurface* ddrawSurface = static_cast<DDrawSurface*>(lpDDSrcSurface);
-      hr = m_proxy->Blt(lpDestRect, ddrawSurface->GetProxied(), lpSrcRect, dwFlags, lpDDBltFx);
+      hr = GetShadowOrProxied()->Blt(lpDestRect, ddrawSurface->GetShadowOrProxied(), lpSrcRect, dwFlags, lpDDBltFx);
     }
 
     if (likely(SUCCEEDED(hr))) {
@@ -416,6 +419,15 @@ namespace dxvk {
           Logger::warn("DDrawSurface::Blt: Failed upload to d3d9 surface");
       } else {
         m_commonSurf->DirtyMipMaps();
+      }
+
+      if (unlikely(m_shadowSurf != nullptr && m_d3d9Device != nullptr)) {
+        const bool shouldPresent = m_commonIntf->GetOptions()->legacyPresentGuard == D3DLegacyPresentGuard::Auto ?
+                                  !m_commonIntf->GetCommonD3DDevice()->IsInScene() :
+                                   m_commonIntf->GetOptions()->legacyPresentGuard == D3DLegacyPresentGuard::Strict ?
+                                   false : true;
+        if (shouldPresent)
+          m_d3d9Device->Present(NULL, NULL, NULL, NULL);
       }
     }
 
@@ -431,18 +443,20 @@ namespace dxvk {
   HRESULT STDMETHODCALLTYPE DDrawSurface::BltFast(DWORD dwX, DWORD dwY, LPDIRECTDRAWSURFACE lpDDSrcSurface, LPRECT lpSrcRect, DWORD dwTrans) {
     Logger::debug("<<< DDrawSurface::BltFast: Proxy");
 
+    const D3DOptions* d3dOptions = m_commonIntf->GetOptions();
+
     // Write back any flippable surfaces or depth stencils from D3D9
     if (likely(lpDDSrcSurface != nullptr && m_commonIntf->IsWrappedSurface(lpDDSrcSurface))) {
       DDrawSurface* sourceSurface = static_cast<DDrawSurface*>(lpDDSrcSurface);
       if (unlikely(sourceSurface->GetCommonSurface()->IsGuardableSurface())) {
-        if (m_commonIntf->GetOptions()->backBufferWriteBack || m_commonIntf->GetOptions()->apitraceMode) {
+        if (d3dOptions->backBufferWriteBack || d3dOptions->forceLegacyPresent || d3dOptions->apitraceMode) {
           Logger::debug("DDrawSurface::BltFast: Source surface is a swapchain surface");
 
           if (unlikely(m_commonIntf->GetOptions()->apitraceMode && !sourceSurface->IsInitialized()))
             sourceSurface->InitializeOrUploadD3D9();
 
           if (likely(sourceSurface->IsInitialized()))
-            BlitToDDrawSurface<IDirectDrawSurface, DDSURFACEDESC>(sourceSurface->GetProxied(), sourceSurface->GetD3D9());
+            BlitToDDrawSurface<IDirectDrawSurface, DDSURFACEDESC>(sourceSurface->GetShadowOrProxied(), sourceSurface->GetD3D9());
         } else {
           static bool s_swapchainWarningShown;
 
@@ -450,7 +464,7 @@ namespace dxvk {
             Logger::warn("DDrawSurface::BltFast: Source surface is a swapchain surface");
         }
       } else if (unlikely(sourceSurface->GetCommonSurface()->IsDepthStencil())) {
-        if (m_commonIntf->GetOptions()->depthWriteBack || m_commonIntf->GetOptions()->apitraceMode) {
+        if (d3dOptions->depthWriteBack || d3dOptions->apitraceMode) {
           Logger::debug("DDrawSurface::BltFast: Source surface is a depth stencil");
 
           if (likely(sourceSurface->IsInitialized()))
@@ -467,12 +481,12 @@ namespace dxvk {
     RefreshD3D9Device();
     if (likely(m_d3d9Device != nullptr)) {
       const bool exclusiveMode = (m_commonIntf->GetCooperativeLevel() & DDSCL_EXCLUSIVE)
-                              && !m_commonIntf->GetOptions()->ignoreExclusiveMode;
+                              && !d3dOptions->ignoreExclusiveMode;
 
       // Eclusive mode back buffer guard
       if (exclusiveMode && m_commonIntf->HasDrawn() &&
           m_commonSurf->IsGuardableSurface() &&
-          m_commonIntf->GetOptions()->backBufferGuard != D3DBackBufferGuard::Disabled) {
+          d3dOptions->backBufferGuard != D3DBackBufferGuard::Disabled) {
         return DD_OK;
       // Windowed mode presentation path
       } else if (!exclusiveMode && m_commonIntf->HasDrawn() && m_commonSurf->IsPrimarySurface()) {
@@ -489,10 +503,10 @@ namespace dxvk {
         Logger::warn("DDrawSurface::BltFast: Received an unwrapped source surface");
         return DDERR_UNSUPPORTED;
       }
-      hr = m_proxy->BltFast(dwX, dwY, lpDDSrcSurface, lpSrcRect, dwTrans);
+      hr = GetShadowOrProxied()->BltFast(dwX, dwY, lpDDSrcSurface, lpSrcRect, dwTrans);
     } else {
       DDrawSurface* ddrawSurface = static_cast<DDrawSurface*>(lpDDSrcSurface);
-      hr = m_proxy->BltFast(dwX, dwY, ddrawSurface->GetProxied(), lpSrcRect, dwTrans);
+      hr = GetShadowOrProxied()->BltFast(dwX, dwY, ddrawSurface->GetShadowOrProxied(), lpSrcRect, dwTrans);
     }
 
     if (likely(SUCCEEDED(hr))) {
@@ -503,6 +517,15 @@ namespace dxvk {
           Logger::warn("DDrawSurface::BltFast: Failed upload to d3d9 surface");
       } else {
         m_commonSurf->DirtyMipMaps();
+      }
+
+      if (unlikely(m_shadowSurf != nullptr && m_d3d9Device != nullptr)) {
+        const bool shouldPresent = m_commonIntf->GetOptions()->legacyPresentGuard == D3DLegacyPresentGuard::Auto ?
+                                  !m_commonIntf->GetCommonD3DDevice()->IsInScene() :
+                                   m_commonIntf->GetOptions()->legacyPresentGuard == D3DLegacyPresentGuard::Strict ?
+                                   false : true;
+        if (shouldPresent)
+          m_d3d9Device->Present(NULL, NULL, NULL, NULL);
       }
     }
 
@@ -641,44 +664,6 @@ namespace dxvk {
 
       m_commonIntf->ResetDrawTracking();
 
-      if (unlikely(m_commonIntf->GetOptions()->forceProxiedPresent)) {
-        D3DCommonDevice* commonDevice = m_commonIntf->GetCommonD3DDevice();
-
-        if (unlikely(!IsInitialized()))
-          InitializeD3D9(commonDevice->IsCurrentRenderTarget(this));
-
-        BlitToDDrawSurface<IDirectDrawSurface, DDSURFACEDESC>(m_proxy.ptr(), m_d3d9.ptr());
-
-        if (unlikely(!m_commonIntf->IsWrappedSurface(lpDDSurfaceTargetOverride))) {
-          if (unlikely(lpDDSurfaceTargetOverride != nullptr)) {
-            Logger::warn("DDrawSurface::Flip: Received an unwrapped surface");
-            return DDERR_UNSUPPORTED;
-          }
-
-          if (likely(commonDevice->IsCurrentRenderTarget(this)))
-            m_commonIntf->SetFlipRTSurfaceAndFlags(lpDDSurfaceTargetOverride, dwFlags);
-
-          if (unlikely(m_commonIntf->GetOptions()->forceBlitOnFlip &&
-                       rt != nullptr && m_commonSurf->IsPrimarySurface())) {
-            Logger::debug("DDrawSurface::Flip: Skipping flip");
-            return DD_OK;
-          } else {
-            return m_proxy->Flip(lpDDSurfaceTargetOverride, dwFlags);
-          }
-        } else {
-          if (likely(commonDevice->IsCurrentRenderTarget(this)))
-            m_commonIntf->SetFlipRTSurfaceAndFlags(lpDDSurfaceTargetOverride, dwFlags);
-
-          if (unlikely(m_commonIntf->GetOptions()->forceBlitOnFlip &&
-                       rt != nullptr && m_commonSurf->IsPrimarySurface())) {
-            Logger::debug("DDrawSurface::Flip: Skipping flip");
-            return DD_OK;
-          } else {
-            return m_proxy->Flip(surf->GetProxied(), dwFlags);
-          }
-        }
-      }
-
       m_d3d9Device->Present(NULL, NULL, NULL, NULL);
     // If we don't have a valid D3D5 device, this means a D3D3 application
     // is trying to flip the surface. Allow that for compatibility reasons.
@@ -688,7 +673,7 @@ namespace dxvk {
         if (unlikely(m_commonIntf->GetOptions()->forceBlitOnFlip &&
                      rt != nullptr && m_commonSurf->IsPrimarySurface())) {
           Logger::debug("DDrawSurface::Flip: Blitting instead of flipping");
-          return m_proxy->Blt(nullptr, rt->GetProxied(), nullptr, DDBLT_WAIT, nullptr);
+          return GetShadowOrProxied()->Blt(nullptr, rt->GetShadowOrProxied(), nullptr, DDBLT_WAIT, nullptr);
         } else {
           return m_proxy->Flip(lpDDSurfaceTargetOverride, dwFlags);
         }
@@ -763,11 +748,6 @@ namespace dxvk {
 
   // Blitting can be done at any time and completes within its call frame
   HRESULT STDMETHODCALLTYPE DDrawSurface::GetBltStatus(DWORD dwFlags) {
-    if (unlikely(m_commonIntf->GetOptions()->forceProxiedPresent)) {
-      Logger::debug("<<< DDrawSurface::GetBltStatus: Proxy");
-      m_proxy->GetBltStatus(dwFlags);
-    }
-
     Logger::debug(">>> DDrawSurface::GetBltStatus");
 
     if (likely(dwFlags == DDGBS_CANBLT || dwFlags == DDGBS_ISBLTDONE))
@@ -811,42 +791,36 @@ namespace dxvk {
   }
 
   HRESULT STDMETHODCALLTYPE DDrawSurface::GetDC(HDC *lphDC) {
-    if (likely(!m_commonIntf->GetOptions()->forceProxiedPresent)) {
-      if (unlikely(lphDC == nullptr))
-        return DDERR_INVALIDPARAMS;
+    if (unlikely(lphDC == nullptr))
+      return DDERR_INVALIDPARAMS;
 
-      InitReturnPtr(lphDC);
+    InitReturnPtr(lphDC);
 
-      // Foward GetDC calls if we have drawn and the surface is flippable
-      RefreshD3D9Device();
-      if (m_d3d9Device != nullptr && (m_commonIntf->HasDrawn() &&
-                                      m_commonSurf->IsGuardableSurface())) {
-        Logger::debug(">>> DDrawSurface::GetDC");
+    // Foward GetDC calls if we have drawn and the surface is flippable
+    RefreshD3D9Device();
+    if (m_d3d9Device != nullptr && (m_commonIntf->HasDrawn() &&
+                                    m_commonSurf->IsGuardableSurface())) {
+      Logger::debug(">>> DDrawSurface::GetDC");
 
-        if (unlikely(!IsInitialized())) {
-          HRESULT hrUpload = InitializeOrUploadD3D9();
-          if (unlikely(FAILED(hrUpload)))
-            Logger::warn("DDrawSurface::GetDC: Failed to initialize d3d9 surface");
-        }
-
-        HRESULT hr9 = m_d3d9->GetDC(lphDC);
-        if (unlikely(FAILED(hr9)))
-          Logger::warn("DDrawSurface::GetDC: Failed D3D9 call");
-        return hr9;
+      if (unlikely(!IsInitialized())) {
+        HRESULT hrUpload = InitializeOrUploadD3D9();
+        if (unlikely(FAILED(hrUpload)))
+          Logger::warn("DDrawSurface::GetDC: Failed to initialize d3d9 surface");
       }
+
+      HRESULT hr9 = m_d3d9->GetDC(lphDC);
+      if (unlikely(FAILED(hr9)))
+        Logger::warn("DDrawSurface::GetDC: Failed D3D9 call");
+      return hr9;
     }
 
     Logger::debug("<<< DDrawSurface::GetDC: Proxy");
-    return m_proxy->GetDC(lphDC);
+
+    return GetShadowOrProxied()->GetDC(lphDC);
   }
 
   // Flipping can be done at any time and completes within its call frame
   HRESULT STDMETHODCALLTYPE DDrawSurface::GetFlipStatus(DWORD dwFlags) {
-    if (unlikely(m_commonIntf->GetOptions()->forceProxiedPresent)) {
-      Logger::debug("<<< DDrawSurface::GetFlipStatus: Proxy");
-      m_proxy->GetFlipStatus(dwFlags);
-    }
-
     Logger::debug(">>> DDrawSurface::GetFlipStatus");
 
     if (likely(dwFlags == DDGFS_CANFLIP || dwFlags == DDGFS_ISFLIPDONE))
@@ -918,16 +892,18 @@ namespace dxvk {
   HRESULT STDMETHODCALLTYPE DDrawSurface::Lock(LPRECT lpDestRect, LPDDSURFACEDESC lpDDSurfaceDesc, DWORD dwFlags, HANDLE hEvent) {
     Logger::debug("<<< DDrawSurface::Lock: Proxy");
 
+    const D3DOptions* d3dOptions = m_commonIntf->GetOptions();
+
     // Write back any flippable surfaces or depth stencils from D3D9
     if (unlikely(m_commonSurf->IsGuardableSurface())) {
-      if (m_commonIntf->GetOptions()->backBufferWriteBack || m_commonIntf->GetOptions()->apitraceMode) {
+      if (d3dOptions->backBufferWriteBack || d3dOptions->forceLegacyPresent || d3dOptions->apitraceMode) {
         Logger::debug("DDrawSurface::Lock: Surface is a swapchain surface");
 
         if (unlikely(m_commonIntf->GetOptions()->apitraceMode && !IsInitialized()))
           InitializeOrUploadD3D9();
 
         if (likely(IsInitialized()))
-          BlitToDDrawSurface<IDirectDrawSurface, DDSURFACEDESC>(m_proxy.ptr(), m_d3d9.ptr());
+          BlitToDDrawSurface<IDirectDrawSurface, DDSURFACEDESC>(GetShadowOrProxied(), m_d3d9.ptr());
       } else {
         static bool s_swapchainWarningShown;
 
@@ -935,7 +911,7 @@ namespace dxvk {
           Logger::warn("DDrawSurface::Lock: Surface is a swapchain surface");
       }
     } else if (unlikely(m_commonSurf->IsDepthStencil())) {
-      if (m_commonIntf->GetOptions()->depthWriteBack || m_commonIntf->GetOptions()->apitraceMode) {
+      if (d3dOptions->depthWriteBack || d3dOptions->apitraceMode) {
         Logger::debug("DDrawSurface::Lock: Surface is a depth stencil");
 
         if (likely(IsInitialized()))
@@ -948,33 +924,31 @@ namespace dxvk {
       }
     }
 
-    return m_proxy->Lock(lpDestRect, lpDDSurfaceDesc, dwFlags, hEvent);
+    return GetShadowOrProxied()->Lock(lpDestRect, lpDDSurfaceDesc, dwFlags, hEvent);
   }
 
   HRESULT STDMETHODCALLTYPE DDrawSurface::ReleaseDC(HDC hDC) {
-    if (likely(!m_commonIntf->GetOptions()->forceProxiedPresent)) {
-      // Foward ReleaseDC calls if we have drawn and the surface is flippable
-      RefreshD3D9Device();
-      if (m_d3d9Device != nullptr && (m_commonIntf->HasDrawn() &&
-                                      m_commonSurf->IsGuardableSurface())) {
-        Logger::debug(">>> DDrawSurface::ReleaseDC");
+    // Foward ReleaseDC calls if we have drawn and the surface is flippable
+    RefreshD3D9Device();
+    if (m_d3d9Device != nullptr && (m_commonIntf->HasDrawn() &&
+                                    m_commonSurf->IsGuardableSurface())) {
+      Logger::debug(">>> DDrawSurface::ReleaseDC");
 
-        if (unlikely(!IsInitialized())) {
-          HRESULT hrUpload = InitializeOrUploadD3D9();
-          if (unlikely(FAILED(hrUpload)))
-            Logger::warn("DDrawSurface::ReleaseDC: Failed to initialize d3d9 surface");
-        }
-
-        HRESULT hr9 = m_d3d9->ReleaseDC(hDC);
-        if (unlikely(FAILED(hr9)))
-          Logger::warn("DDrawSurface::ReleaseDC: Failed D3D9 call");
-        return hr9;
+      if (unlikely(!IsInitialized())) {
+        HRESULT hrUpload = InitializeOrUploadD3D9();
+        if (unlikely(FAILED(hrUpload)))
+          Logger::warn("DDrawSurface::ReleaseDC: Failed to initialize d3d9 surface");
       }
+
+      HRESULT hr9 = m_d3d9->ReleaseDC(hDC);
+      if (unlikely(FAILED(hr9)))
+        Logger::warn("DDrawSurface::ReleaseDC: Failed D3D9 call");
+      return hr9;
     }
 
     Logger::debug("<<< DDrawSurface::ReleaseDC: Proxy");
 
-    HRESULT hr = m_proxy->ReleaseDC(hDC);
+    HRESULT hr = GetShadowOrProxied()->ReleaseDC(hDC);
 
     if (likely(SUCCEEDED(hr))) {
       // Textures get uploaded during SetTexture calls
@@ -1045,7 +1019,7 @@ namespace dxvk {
 
     // A nullptr lpDDPalette gets the current palette detached
     if (lpDDPalette == nullptr) {
-      HRESULT hr = m_proxy->SetPalette(lpDDPalette);
+      HRESULT hr = GetShadowOrProxied()->SetPalette(lpDDPalette);
       if (unlikely(FAILED(hr)))
         return hr;
 
@@ -1053,7 +1027,7 @@ namespace dxvk {
     } else {
       DDrawPalette* ddrawPalette = static_cast<DDrawPalette*>(lpDDPalette);
 
-      HRESULT hr = m_proxy->SetPalette(ddrawPalette->GetProxied());
+      HRESULT hr = GetShadowOrProxied()->SetPalette(ddrawPalette->GetProxied());
       if (unlikely(FAILED(hr)))
         return hr;
 
@@ -1066,7 +1040,7 @@ namespace dxvk {
   HRESULT STDMETHODCALLTYPE DDrawSurface::Unlock(LPVOID lpSurfaceData) {
     Logger::debug("<<< DDrawSurface::Unlock: Proxy");
 
-    HRESULT hr = m_proxy->Unlock(lpSurfaceData);
+    HRESULT hr = GetShadowOrProxied()->Unlock(lpSurfaceData);
 
     if (likely(SUCCEEDED(hr))) {
       // Textures and cubemaps get uploaded during SetTexture calls
@@ -1076,6 +1050,15 @@ namespace dxvk {
           Logger::warn("DDrawSurface::Unlock: Failed upload to d3d9 surface");
       } else {
         m_commonSurf->DirtyMipMaps();
+      }
+
+      if (unlikely(m_shadowSurf != nullptr && m_d3d9Device != nullptr)) {
+        const bool shouldPresent = m_commonIntf->GetOptions()->legacyPresentGuard == D3DLegacyPresentGuard::Auto ?
+                                  !m_commonIntf->GetCommonD3DDevice()->IsInScene() :
+                                   m_commonIntf->GetOptions()->legacyPresentGuard == D3DLegacyPresentGuard::Strict ?
+                                   false : true;
+        if (shouldPresent)
+          m_d3d9Device->Present(NULL, NULL, NULL, NULL);
       }
     }
 
@@ -1113,6 +1096,15 @@ namespace dxvk {
 
     DDrawSurface* ddrawSurface = static_cast<DDrawSurface*>(lpDDSReference);
     return m_proxy->UpdateOverlayZOrder(dwFlags, ddrawSurface->GetProxied());
+  }
+
+  IDirectDrawSurface* DDrawSurface::GetShadowOrProxied() {
+    RefreshD3D9Device();
+
+    if (unlikely(m_shadowSurf != nullptr && m_d3d9Device != nullptr))
+      return m_shadowSurf->GetProxied();
+
+    return m_proxy.ptr();
   }
 
   HRESULT DDrawSurface::InitializeD3D9RenderTarget() {
@@ -1485,7 +1477,7 @@ namespace dxvk {
         }
       }
 
-      BlitToD3D9Surface<IDirectDrawSurface, DDSURFACEDESC>(m_d3d9.ptr(), format, m_proxy.ptr());
+      BlitToD3D9Surface<IDirectDrawSurface, DDSURFACEDESC>(m_d3d9.ptr(), format, GetShadowOrProxied());
     }
 
     return DD_OK;
@@ -1525,15 +1517,14 @@ namespace dxvk {
     }
 
     Com<IDirect3DDevice> ppvProxyObject;
-    HRESULT hr = m_proxy->QueryInterface(rclsidOverride, reinterpret_cast<void**>(&ppvProxyObject));
+    HRESULT hr = GetShadowOrProxied()->QueryInterface(rclsidOverride, reinterpret_cast<void**>(&ppvProxyObject));
     if (unlikely(FAILED(hr)))
       return hr;
 
     DWORD backBufferWidth  = m_commonSurf->GetDesc()->dwWidth;
     DWORD BackBufferHeight = m_commonSurf->GetDesc()->dwHeight;
 
-    if (likely(!d3dOptions->forceProxiedPresent &&
-                d3dOptions->backBufferResize)) {
+    if (likely(d3dOptions->backBufferResize)) {
       const bool exclusiveMode = m_commonIntf->GetCooperativeLevel() & DDSCL_EXCLUSIVE;
 
       // Ignore any mode size dimensions when in windowed present mode

--- a/src/ddraw/ddraw/ddraw_surface.h
+++ b/src/ddraw/ddraw/ddraw_surface.h
@@ -102,6 +102,16 @@ namespace dxvk {
 
     HRESULT STDMETHODCALLTYPE UpdateOverlayZOrder(DWORD dwFlags, LPDIRECTDRAWSURFACE lpDDSReference);
 
+    IDirectDrawSurface* GetShadowOrProxied();
+
+    void SetShadowSurface(DDrawSurface* shadowSurf) {
+      m_shadowSurf = shadowSurf;
+    }
+
+    DDrawSurface* GetShadowSurface() const {
+      return m_shadowSurf.ptr();
+    }
+
     DDrawCommonSurface* GetCommonSurface() const {
       return m_commonSurf.ptr();
     }
@@ -186,21 +196,25 @@ namespace dxvk {
     static uint32_t  s_surfCount;
     uint32_t         m_surfCount       = 0;
 
-    Com<DDrawCommonSurface>             m_commonSurf;
-    DDrawCommonInterface*               m_commonIntf = nullptr;
+    Com<DDrawCommonSurface>      m_commonSurf;
+    DDrawCommonInterface*        m_commonIntf = nullptr;
 
-    DDrawSurface*                       m_parentSurf = nullptr;
+    DDrawSurface*                m_parentSurf = nullptr;
 
-    d3d9::IDirect3DDevice9*             m_d3d9Device = nullptr;
+    d3d9::IDirect3DDevice9*      m_d3d9Device = nullptr;
 
-    Com<D3D3Texture, false>             m_texture3;
-    Com<D3D5Texture, false>             m_texture5;
+    Com<D3D3Texture, false>      m_texture3;
+    Com<D3D5Texture, false>      m_texture5;
 
-    Com<d3d9::IDirect3DTexture9>        m_texture9;
+    Com<d3d9::IDirect3DTexture9> m_texture9;
+
+    // Offscreen plain surface we use to mask unwanted DDraw interactions, such
+    // as forced swapchain presents caused by blits/locks on primary surfaces
+    Com<DDrawSurface>            m_shadowSurf;
 
     // Back buffers will have depth stencil surfaces as attachments (in practice
     // I have never seen more than one depth stencil being attached at a time)
-    Com<DDrawSurface>                   m_depthStencil;
+    Com<DDrawSurface>            m_depthStencil;
 
     // These are attached surfaces, which are typically mips or other types of generated
     // surfaces, which need to exist for the entire lifecycle of their parent surface.

--- a/src/ddraw/ddraw2/ddraw2_interface.cpp
+++ b/src/ddraw/ddraw2/ddraw2_interface.cpp
@@ -289,8 +289,38 @@ namespace dxvk {
         // Surfaces created from IDirectDraw and IDirectDraw2 do not ref their parent interfaces
         Com<DDrawSurface> surface = new DDrawSurface(nullptr, std::move(ddrawSurfaceProxied),
                                                      m_commonIntf->GetDDInterface(), nullptr, false);
-        if (unlikely(lpDDSurfaceDesc->ddsCaps.dwCaps & DDSCAPS_PRIMARYSURFACE))
+
+        if (unlikely(lpDDSurfaceDesc->ddsCaps.dwCaps & DDSCAPS_PRIMARYSURFACE)) {
           m_commonIntf->SetPrimarySurface(surface->GetCommonSurface());
+
+          // Shadow surface creation for the primary surface
+          // (it needs to be based on the same incoming desc)
+          if (unlikely(!surface->GetCommonSurface()->Is8BitFormat() &&
+                        m_commonIntf->GetOptions()->forceLegacyPresent)) {
+            DDSURFACEDESC shadowDesc = *lpDDSurfaceDesc;
+            const DDSURFACEDESC* primaryDesc = surface->GetCommonSurface()->GetDesc();
+
+            shadowDesc.ddsCaps.dwCaps &= ~DDSCAPS_PRIMARYSURFACE & ~DDSCAPS_COMPLEX & ~DDSCAPS_FLIP;
+            shadowDesc.ddsCaps.dwCaps |= DDSCAPS_OFFSCREENPLAIN;
+            shadowDesc.dwFlags &= ~DDSD_BACKBUFFERCOUNT;
+            // Dimensions aren't specified in the incoming desc,
+            // but are explicitly needed for non-primary surfaces
+            shadowDesc.dwFlags |= DDSD_WIDTH | DDSD_HEIGHT;
+            shadowDesc.dwWidth  = primaryDesc->dwWidth;
+            shadowDesc.dwHeight = primaryDesc->dwHeight;
+
+            Com<IDirectDrawSurface> ddrawSurfaceShadow;
+            hr = m_proxy->CreateSurface(&shadowDesc, &ddrawSurfaceShadow, pUnkOuter);
+            if (unlikely(FAILED(hr))) {
+              Logger::warn("DDraw2Interface::CreateSurface: Failed to create shadow surface");
+            } else {
+              Com<DDrawSurface> shadowSurf = new DDrawSurface(nullptr, std::move(ddrawSurfaceShadow),
+                                                              m_commonIntf->GetDDInterface(), nullptr, false);
+              surface->SetShadowSurface(shadowSurf.ptr());
+            }
+          }
+        }
+
         *lplpDDSurface = surface.ref();
       } catch (const DxvkError& e) {
         Logger::err(e.message());
@@ -350,11 +380,6 @@ namespace dxvk {
   }
 
   HRESULT STDMETHODCALLTYPE DDraw2Interface::FlipToGDISurface() {
-    if (unlikely(m_commonIntf->GetOptions()->forceProxiedPresent)) {
-      Logger::debug("<<< DDraw2Interface::FlipToGDISurface: Proxy");
-      return m_proxy->FlipToGDISurface();
-    }
-
     Logger::debug("*** DDraw2Interface::FlipToGDISurface: Ignoring");
 
     DDrawCommonSurface* ps = m_commonIntf->GetPrimarySurface();
@@ -571,8 +596,7 @@ namespace dxvk {
         Logger::warn("DDraw2Interface::SetDisplayMode: Failed to update primary surface desc");
     }
 
-    if (likely(!m_commonIntf->GetOptions()->forceProxiedPresent &&
-                m_commonIntf->GetOptions()->backBufferResize)) {
+    if (likely(m_commonIntf->GetOptions()->backBufferResize)) {
       const bool exclusiveMode = m_commonIntf->GetCooperativeLevel() & DDSCL_EXCLUSIVE;
 
       // Ignore any mode size dimensions when in windowed present mode
@@ -590,11 +614,6 @@ namespace dxvk {
   }
 
   HRESULT STDMETHODCALLTYPE DDraw2Interface::WaitForVerticalBlank(DWORD dwFlags, HANDLE hEvent) {
-    if (unlikely(m_commonIntf->GetOptions()->forceProxiedPresent)) {
-      Logger::debug("<<< DDraw2Interface::WaitForVerticalBlank: Proxy");
-      m_proxy->WaitForVerticalBlank(dwFlags, hEvent);
-    }
-
     Logger::debug(">>> DDraw2Interface::WaitForVerticalBlank");
 
     if (unlikely(dwFlags & DDWAITVB_BLOCKBEGINEVENT))

--- a/src/ddraw/ddraw2/ddraw2_surface.cpp
+++ b/src/ddraw/ddraw2/ddraw2_surface.cpp
@@ -569,40 +569,6 @@ namespace dxvk {
 
       m_commonIntf->ResetDrawTracking();
 
-      if (unlikely(m_commonIntf->GetOptions()->forceProxiedPresent)) {
-        D3DCommonDevice* commonDevice = m_commonIntf->GetCommonD3DDevice();
-
-        if (unlikely(!IsInitialized()))
-          m_parent->InitializeD3D9(commonDevice->IsCurrentRenderTarget(m_parent));
-
-        BlitToDDrawSurface<IDirectDrawSurface2, DDSURFACEDESC>(m_proxy.ptr(), m_parent->GetD3D9());
-
-        if (likely(commonDevice->IsCurrentRenderTarget(m_parent))) {
-          if (lpDDSurfaceTargetOverride != nullptr) {
-            m_commonIntf->SetFlipRTSurfaceAndFlags(surf2->GetParent()->GetProxied(), dwFlags);
-          } else {
-            m_commonIntf->SetFlipRTSurfaceAndFlags(nullptr, dwFlags);
-          }
-        }
-        if (lpDDSurfaceTargetOverride != nullptr) {
-          if (unlikely(m_commonIntf->GetOptions()->forceBlitOnFlip &&
-                       rt != nullptr && m_commonSurf->IsPrimarySurface())) {
-            Logger::debug("DDraw2Surface::Flip: Skipping flip");
-            return DD_OK;
-          } else {
-            return m_proxy->Flip(surf2->GetProxied(), dwFlags);
-          }
-        } else {
-          if (unlikely(m_commonIntf->GetOptions()->forceBlitOnFlip &&
-                       rt != nullptr && m_commonSurf->IsPrimarySurface())) {
-            Logger::debug("DDraw2Surface::Flip: Skipping flip");
-            return DD_OK;
-          } else {
-            return m_proxy->Flip(lpDDSurfaceTargetOverride, dwFlags);
-          }
-        }
-      }
-
       m_d3d9Device->Present(NULL, NULL, NULL, NULL);
     // If we don't have a valid D3D5 device, this means a D3D3 application
     // is trying to flip the surface. Allow that for compatibility reasons.
@@ -687,11 +653,6 @@ namespace dxvk {
 
   // Blitting can be done at any time and completes within its call frame
   HRESULT STDMETHODCALLTYPE DDraw2Surface::GetBltStatus(DWORD dwFlags) {
-    if (unlikely(m_commonIntf->GetOptions()->forceProxiedPresent)) {
-      Logger::debug("<<< DDraw2Surface::GetBltStatus: Proxy");
-      m_proxy->GetBltStatus(dwFlags);
-    }
-
     Logger::debug(">>> DDraw2Surface::GetBltStatus");
 
     if (likely(dwFlags == DDGBS_CANBLT || dwFlags == DDGBS_ISBLTDONE))
@@ -735,29 +696,27 @@ namespace dxvk {
   }
 
   HRESULT STDMETHODCALLTYPE DDraw2Surface::GetDC(HDC *lphDC) {
-    if (likely(!m_commonIntf->GetOptions()->forceProxiedPresent)) {
-      if (unlikely(lphDC == nullptr))
-        return DDERR_INVALIDPARAMS;
+    if (unlikely(lphDC == nullptr))
+      return DDERR_INVALIDPARAMS;
 
-      InitReturnPtr(lphDC);
+    InitReturnPtr(lphDC);
 
-      // Foward GetDC calls if we have drawn and the surface is flippable
-      RefreshD3D9Device();
-      if (m_d3d9Device != nullptr && (m_commonIntf->HasDrawn() &&
-                                      m_commonSurf->IsGuardableSurface())) {
-        Logger::debug(">>> DDraw2Surface::GetDC");
+    // Foward GetDC calls if we have drawn and the surface is flippable
+    RefreshD3D9Device();
+    if (m_d3d9Device != nullptr && (m_commonIntf->HasDrawn() &&
+                                    m_commonSurf->IsGuardableSurface())) {
+      Logger::debug(">>> DDraw2Surface::GetDC");
 
-        if (unlikely(!IsInitialized())) {
-          HRESULT hrUpload = InitializeOrUploadD3D9();
-          if (unlikely(FAILED(hrUpload)))
-            Logger::warn("DDraw2Surface::GetDC: Failed to initialize d3d9 surface");
-        }
-
-        HRESULT hr9 = m_parent->GetD3D9()->GetDC(lphDC);
-        if (unlikely(FAILED(hr9)))
-          Logger::warn("DDraw2Surface::GetDC: Failed D3D9 call");
-        return hr9;
+      if (unlikely(!IsInitialized())) {
+        HRESULT hrUpload = InitializeOrUploadD3D9();
+        if (unlikely(FAILED(hrUpload)))
+          Logger::warn("DDraw2Surface::GetDC: Failed to initialize d3d9 surface");
       }
+
+      HRESULT hr9 = m_parent->GetD3D9()->GetDC(lphDC);
+      if (unlikely(FAILED(hr9)))
+        Logger::warn("DDraw2Surface::GetDC: Failed D3D9 call");
+      return hr9;
     }
 
     Logger::debug("<<< DDraw2Surface::GetDC: Proxy");
@@ -766,11 +725,6 @@ namespace dxvk {
 
   // Flipping can be done at any time and completes within its call frame
   HRESULT STDMETHODCALLTYPE DDraw2Surface::GetFlipStatus(DWORD dwFlags) {
-    if (unlikely(m_commonIntf->GetOptions()->forceProxiedPresent)) {
-      Logger::debug("<<< DDraw2Surface::GetFlipStatus: Proxy");
-      m_proxy->GetFlipStatus(dwFlags);
-    }
-
     Logger::debug(">>> DDraw2Surface::GetFlipStatus");
 
     if (likely(dwFlags == DDGFS_CANFLIP || dwFlags == DDGFS_ISFLIPDONE))
@@ -854,24 +808,22 @@ namespace dxvk {
   }
 
   HRESULT STDMETHODCALLTYPE DDraw2Surface::ReleaseDC(HDC hDC) {
-    if (likely(!m_commonIntf->GetOptions()->forceProxiedPresent)) {
-      // Foward ReleaseDC calls if we have drawn and the surface is flippable
-      RefreshD3D9Device();
-      if (m_d3d9Device != nullptr && (m_commonIntf->HasDrawn() &&
-                                      m_commonSurf->IsGuardableSurface())) {
-        Logger::debug(">>> DDraw2Surface::ReleaseDC");
+    // Foward ReleaseDC calls if we have drawn and the surface is flippable
+    RefreshD3D9Device();
+    if (m_d3d9Device != nullptr && (m_commonIntf->HasDrawn() &&
+                                    m_commonSurf->IsGuardableSurface())) {
+      Logger::debug(">>> DDraw2Surface::ReleaseDC");
 
-        if (unlikely(!IsInitialized())) {
-          HRESULT hrUpload = InitializeOrUploadD3D9();
-          if (unlikely(FAILED(hrUpload)))
-            Logger::warn("DDraw2Surface::ReleaseDC: Failed to initialize d3d9 surface");
-        }
-
-        HRESULT hr9 = m_parent->GetD3D9()->ReleaseDC(hDC);
-        if (unlikely(FAILED(hr9)))
-          Logger::warn("DDraw2Surface::ReleaseDC: Failed D3D9 call");
-        return hr9;
+      if (unlikely(!IsInitialized())) {
+        HRESULT hrUpload = InitializeOrUploadD3D9();
+        if (unlikely(FAILED(hrUpload)))
+          Logger::warn("DDraw2Surface::ReleaseDC: Failed to initialize d3d9 surface");
       }
+
+      HRESULT hr9 = m_parent->GetD3D9()->ReleaseDC(hDC);
+      if (unlikely(FAILED(hr9)))
+        Logger::warn("DDraw2Surface::ReleaseDC: Failed D3D9 call");
+      return hr9;
     }
 
     Logger::debug("<<< DDraw2Surface::ReleaseDC: Proxy");
@@ -1042,6 +994,15 @@ namespace dxvk {
   HRESULT STDMETHODCALLTYPE DDraw2Surface::PageUnlock(DWORD dwFlags) {
     Logger::debug("<<< DDraw2Surface::PageUnlock: Proxy");
     return m_proxy->PageUnlock(dwFlags);
+  }
+
+  IDirectDrawSurface2* DDraw2Surface::GetShadowOrProxied() {
+    RefreshD3D9Device();
+
+    if (unlikely(m_shadowSurf != nullptr && m_d3d9Device != nullptr))
+      return m_shadowSurf->GetProxied();
+
+    return m_proxy.ptr();
   }
 
   inline void DDraw2Surface::RefreshD3D9Device() {

--- a/src/ddraw/ddraw2/ddraw2_surface.h
+++ b/src/ddraw/ddraw2/ddraw2_surface.h
@@ -102,6 +102,16 @@ namespace dxvk {
 
     HRESULT STDMETHODCALLTYPE PageUnlock(DWORD dwFlags);
 
+    IDirectDrawSurface2* GetShadowOrProxied();
+
+    void SetShadowSurface(DDraw2Surface* shadowSurf) {
+      m_shadowSurf = shadowSurf;
+    }
+
+    DDraw2Surface* GetShadowSurface() const {
+      return m_shadowSurf.ptr();
+    }
+
     DDrawCommonSurface* GetCommonSurface() const {
       return m_commonSurf.ptr();
     }
@@ -168,6 +178,10 @@ namespace dxvk {
     DDraw2Surface*           m_parentSurf = nullptr;
 
     d3d9::IDirect3DDevice9*  m_d3d9Device = nullptr;
+
+    // Offscreen plain surface we use to mask unwanted DDraw interactions, such
+    // as forced swapchain presents caused by blits/locks on primary surfaces
+    Com<DDraw2Surface>       m_shadowSurf;
 
     // Back buffers will have depth stencil surfaces as attachments (in practice
     // I have never seen more than one depth stencil being attached at a time)

--- a/src/ddraw/ddraw2/ddraw3_surface.cpp
+++ b/src/ddraw/ddraw2/ddraw3_surface.cpp
@@ -586,40 +586,6 @@ namespace dxvk {
 
       m_commonIntf->ResetDrawTracking();
 
-      if (unlikely(m_commonIntf->GetOptions()->forceProxiedPresent)) {
-        D3DCommonDevice* commonDevice = m_commonIntf->GetCommonD3DDevice();
-
-        if (unlikely(!IsInitialized()))
-          m_parent->InitializeD3D9(commonDevice->IsCurrentRenderTarget(m_parent));
-
-        BlitToDDrawSurface<IDirectDrawSurface3, DDSURFACEDESC>(m_proxy.ptr(), m_parent->GetD3D9());
-
-        if (likely(commonDevice->IsCurrentRenderTarget(m_parent))) {
-          if (lpDDSurfaceTargetOverride != nullptr) {
-            m_commonIntf->SetFlipRTSurfaceAndFlags(surf3->GetParent()->GetProxied(), dwFlags);
-          } else {
-            m_commonIntf->SetFlipRTSurfaceAndFlags(nullptr, dwFlags);
-          }
-        }
-        if (lpDDSurfaceTargetOverride != nullptr) {
-          if (unlikely(m_commonIntf->GetOptions()->forceBlitOnFlip &&
-                       rt != nullptr && m_commonSurf->IsPrimarySurface())) {
-            Logger::debug("DDraw3Surface::Flip: Skipping flip");
-            return DD_OK;
-          } else {
-            return m_proxy->Flip(surf3->GetProxied(), dwFlags);
-          }
-        } else {
-          if (unlikely(m_commonIntf->GetOptions()->forceBlitOnFlip &&
-                       rt != nullptr && m_commonSurf->IsPrimarySurface())) {
-            Logger::debug("DDraw3Surface::Flip: Skipping flip");
-            return DD_OK;
-          } else {
-            return m_proxy->Flip(lpDDSurfaceTargetOverride, dwFlags);
-          }
-        }
-      }
-
       m_d3d9Device->Present(NULL, NULL, NULL, NULL);
     // If we don't have a valid D3D5 device, this means a D3D3 application
     // is trying to flip the surface. Allow that for compatibility reasons.
@@ -704,11 +670,6 @@ namespace dxvk {
 
   // Blitting can be done at any time and completes within its call frame
   HRESULT STDMETHODCALLTYPE DDraw3Surface::GetBltStatus(DWORD dwFlags) {
-    if (unlikely(m_commonIntf->GetOptions()->forceProxiedPresent)) {
-      Logger::debug("<<< DDraw3Surface::GetBltStatus: Proxy");
-      m_proxy->GetBltStatus(dwFlags);
-    }
-
     Logger::debug(">>> DDraw3Surface::GetBltStatus");
 
     if (likely(dwFlags == DDGBS_CANBLT || dwFlags == DDGBS_ISBLTDONE))
@@ -752,29 +713,27 @@ namespace dxvk {
   }
 
   HRESULT STDMETHODCALLTYPE DDraw3Surface::GetDC(HDC *lphDC) {
-    if (likely(!m_commonIntf->GetOptions()->forceProxiedPresent)) {
-      if (unlikely(lphDC == nullptr))
-        return DDERR_INVALIDPARAMS;
+    if (unlikely(lphDC == nullptr))
+      return DDERR_INVALIDPARAMS;
 
-      InitReturnPtr(lphDC);
+    InitReturnPtr(lphDC);
 
-      // Foward GetDC calls if we have drawn and the surface is flippable
-      RefreshD3D9Device();
-      if (m_d3d9Device != nullptr && (m_commonIntf->HasDrawn() &&
-                                      m_commonSurf->IsGuardableSurface())) {
-        Logger::debug(">>> DDraw3Surface::GetDC");
+    // Foward GetDC calls if we have drawn and the surface is flippable
+    RefreshD3D9Device();
+    if (m_d3d9Device != nullptr && (m_commonIntf->HasDrawn() &&
+                                    m_commonSurf->IsGuardableSurface())) {
+      Logger::debug(">>> DDraw3Surface::GetDC");
 
-        if (unlikely(!IsInitialized())) {
-          HRESULT hrUpload = InitializeOrUploadD3D9();
-          if (unlikely(FAILED(hrUpload)))
-            Logger::warn("DDraw3Surface::GetDC: Failed to initialize d3d9 surface");
-        }
-
-        HRESULT hr9 = m_parent->GetD3D9()->GetDC(lphDC);
-        if (unlikely(FAILED(hr9)))
-          Logger::warn("DDraw3Surface::GetDC: Failed D3D9 call");
-        return hr9;
+      if (unlikely(!IsInitialized())) {
+        HRESULT hrUpload = InitializeOrUploadD3D9();
+        if (unlikely(FAILED(hrUpload)))
+          Logger::warn("DDraw3Surface::GetDC: Failed to initialize d3d9 surface");
       }
+
+      HRESULT hr9 = m_parent->GetD3D9()->GetDC(lphDC);
+      if (unlikely(FAILED(hr9)))
+        Logger::warn("DDraw3Surface::GetDC: Failed D3D9 call");
+      return hr9;
     }
 
     Logger::debug("<<< DDraw3Surface::GetDC: Proxy");
@@ -783,11 +742,6 @@ namespace dxvk {
 
   // Flipping can be done at any time and completes within its call frame
   HRESULT STDMETHODCALLTYPE DDraw3Surface::GetFlipStatus(DWORD dwFlags) {
-    if (unlikely(m_commonIntf->GetOptions()->forceProxiedPresent)) {
-      Logger::debug("<<< DDraw3Surface::GetFlipStatus: Proxy");
-      m_proxy->GetFlipStatus(dwFlags);
-    }
-
     Logger::debug(">>> DDraw3Surface::GetFlipStatus");
 
     if (likely(dwFlags == DDGFS_CANFLIP || dwFlags == DDGFS_ISFLIPDONE))
@@ -871,24 +825,22 @@ namespace dxvk {
   }
 
   HRESULT STDMETHODCALLTYPE DDraw3Surface::ReleaseDC(HDC hDC) {
-    if (likely(!m_commonIntf->GetOptions()->forceProxiedPresent)) {
-      // Foward ReleaseDC calls if we have drawn and the surface is flippable
-      RefreshD3D9Device();
-      if (m_d3d9Device != nullptr && (m_commonIntf->HasDrawn() &&
-                                      m_commonSurf->IsGuardableSurface())) {
-        Logger::debug(">>> DDraw3Surface::ReleaseDC");
+    // Foward ReleaseDC calls if we have drawn and the surface is flippable
+    RefreshD3D9Device();
+    if (m_d3d9Device != nullptr && (m_commonIntf->HasDrawn() &&
+                                    m_commonSurf->IsGuardableSurface())) {
+      Logger::debug(">>> DDraw3Surface::ReleaseDC");
 
-        if (unlikely(!IsInitialized())) {
-          HRESULT hrUpload = InitializeOrUploadD3D9();
-          if (unlikely(FAILED(hrUpload)))
-            Logger::warn("DDraw3Surface::ReleaseDC: Failed to initialize d3d9 surface");
-        }
-
-        HRESULT hr9 = m_parent->GetD3D9()->ReleaseDC(hDC);
-        if (unlikely(FAILED(hr9)))
-          Logger::warn("DDraw3Surface::ReleaseDC: Failed D3D9 call");
-        return hr9;
+      if (unlikely(!IsInitialized())) {
+        HRESULT hrUpload = InitializeOrUploadD3D9();
+        if (unlikely(FAILED(hrUpload)))
+          Logger::warn("DDraw3Surface::ReleaseDC: Failed to initialize d3d9 surface");
       }
+
+      HRESULT hr9 = m_parent->GetD3D9()->ReleaseDC(hDC);
+      if (unlikely(FAILED(hr9)))
+        Logger::warn("DDraw3Surface::ReleaseDC: Failed D3D9 call");
+      return hr9;
     }
 
     Logger::debug("<<< DDraw3Surface::ReleaseDC: Proxy");
@@ -1084,6 +1036,15 @@ namespace dxvk {
     }
 
     return hr;
+  }
+
+  IDirectDrawSurface3* DDraw3Surface::GetShadowOrProxied() {
+    RefreshD3D9Device();
+
+    if (unlikely(m_shadowSurf != nullptr && m_d3d9Device != nullptr))
+      return m_shadowSurf->GetProxied();
+
+    return m_proxy.ptr();
   }
 
   inline void DDraw3Surface::RefreshD3D9Device() {

--- a/src/ddraw/ddraw2/ddraw3_surface.h
+++ b/src/ddraw/ddraw2/ddraw3_surface.h
@@ -105,6 +105,16 @@ namespace dxvk {
 
     HRESULT STDMETHODCALLTYPE SetSurfaceDesc(LPDDSURFACEDESC lpDDSD, DWORD dwFlags);
 
+    IDirectDrawSurface3* GetShadowOrProxied();
+
+    void SetShadowSurface(DDraw3Surface* shadowSurf) {
+      m_shadowSurf = shadowSurf;
+    }
+
+    DDraw3Surface* GetShadowSurface() const {
+      return m_shadowSurf.ptr();
+    }
+
     DDrawCommonSurface* GetCommonSurface() const {
       return m_commonSurf.ptr();
     }
@@ -171,6 +181,10 @@ namespace dxvk {
     DDraw3Surface*           m_parentSurf = nullptr;
 
     d3d9::IDirect3DDevice9*  m_d3d9Device = nullptr;
+
+    // Offscreen plain surface we use to mask unwanted DDraw interactions, such
+    // as forced swapchain presents caused by blits/locks on primary surfaces
+    Com<DDraw3Surface>       m_shadowSurf;
 
     // Back buffers will have depth stencil surfaces as attachments (in practice
     // I have never seen more than one depth stencil being attached at a time)

--- a/src/ddraw/ddraw4/ddraw4_interface.cpp
+++ b/src/ddraw/ddraw4/ddraw4_interface.cpp
@@ -266,9 +266,7 @@ namespace dxvk {
     // D3D9, so always strip the DDSCAPS_WRITEONLY flag on creation
     lpDDSurfaceDesc->ddsCaps.dwCaps &= ~DDSCAPS_WRITEONLY;
     // Similarly strip the DDSCAPS2_OPAQUE flag on texture creation
-    if (lpDDSurfaceDesc->ddsCaps.dwCaps & DDSCAPS_TEXTURE) {
-      lpDDSurfaceDesc->ddsCaps.dwCaps2 &= ~DDSCAPS2_OPAQUE;
-    }
+    lpDDSurfaceDesc->ddsCaps.dwCaps2 &= ~DDSCAPS2_OPAQUE;
 
     if (unlikely((lpDDSurfaceDesc->ddsCaps.dwCaps & DDSCAPS_ZBUFFER)
               && (lpDDSurfaceDesc->ddpfPixelFormat.dwZBitMask == 0xFFFFFFFF))) {
@@ -289,8 +287,37 @@ namespace dxvk {
     if (likely(SUCCEEDED(hr))) {
       try{
         Com<DDraw4Surface> surface4 = new DDraw4Surface(nullptr, std::move(ddrawSurface4Proxied), this, nullptr, true);
-        if (unlikely(lpDDSurfaceDesc->ddsCaps.dwCaps & DDSCAPS_PRIMARYSURFACE))
+
+        if (unlikely(lpDDSurfaceDesc->ddsCaps.dwCaps & DDSCAPS_PRIMARYSURFACE)) {
           m_commonIntf->SetPrimarySurface(surface4->GetCommonSurface());
+
+          // Shadow surface creation for the primary surface
+          // (it needs to be based on the same incoming desc)
+          if (unlikely(!surface4->GetCommonSurface()->Is8BitFormat() &&
+                        m_commonIntf->GetOptions()->forceLegacyPresent)) {
+            DDSURFACEDESC2 shadowDesc = *lpDDSurfaceDesc;
+            const DDSURFACEDESC2* primaryDesc = surface4->GetCommonSurface()->GetDesc2();
+
+            shadowDesc.ddsCaps.dwCaps &= ~DDSCAPS_PRIMARYSURFACE & ~DDSCAPS_COMPLEX & ~DDSCAPS_FLIP;
+            shadowDesc.ddsCaps.dwCaps |= DDSCAPS_OFFSCREENPLAIN;
+            shadowDesc.dwFlags &= ~DDSD_BACKBUFFERCOUNT;
+            // Dimensions aren't specified in the incoming desc,
+            // but are explicitly needed for non-primary surfaces
+            shadowDesc.dwFlags |= DDSD_WIDTH | DDSD_HEIGHT;
+            shadowDesc.dwWidth  = primaryDesc->dwWidth;
+            shadowDesc.dwHeight = primaryDesc->dwHeight;
+
+            Com<IDirectDrawSurface4> ddraw4SurfaceShadow;
+            hr = m_proxy->CreateSurface(&shadowDesc, &ddraw4SurfaceShadow, pUnkOuter);
+            if (unlikely(FAILED(hr))) {
+              Logger::warn("DDraw4Interface::CreateSurface: Failed to create shadow surface");
+            } else {
+              Com<DDraw4Surface> shadowSurf = new DDraw4Surface(nullptr, std::move(ddraw4SurfaceShadow), this, nullptr, false);
+              surface4->SetShadowSurface(shadowSurf.ptr());
+            }
+          }
+        }
+
         *lplpDDSurface = surface4.ref();
       } catch (const DxvkError& e) {
         Logger::err(e.message());
@@ -366,11 +393,6 @@ namespace dxvk {
   }
 
   HRESULT STDMETHODCALLTYPE DDraw4Interface::FlipToGDISurface() {
-    if (unlikely(m_commonIntf->GetOptions()->forceProxiedPresent)) {
-      Logger::debug("<<< DDraw4Interface::FlipToGDISurface: Proxy");
-      return m_proxy->FlipToGDISurface();
-    }
-
     Logger::debug("*** DDraw4Interface::FlipToGDISurface: Ignoring");
 
     DDrawCommonSurface* ps = m_commonIntf->GetPrimarySurface();
@@ -590,8 +612,7 @@ namespace dxvk {
         Logger::warn("DDraw4Interface::SetDisplayMode: Failed to update primary surface desc");
     }
 
-    if (likely(!m_commonIntf->GetOptions()->forceProxiedPresent &&
-                m_commonIntf->GetOptions()->backBufferResize)) {
+    if (likely(m_commonIntf->GetOptions()->backBufferResize)) {
       const bool exclusiveMode = m_commonIntf->GetCooperativeLevel() & DDSCL_EXCLUSIVE;
 
       // Ignore any mode size dimensions when in windowed present mode
@@ -609,11 +630,6 @@ namespace dxvk {
   }
 
   HRESULT STDMETHODCALLTYPE DDraw4Interface::WaitForVerticalBlank(DWORD dwFlags, HANDLE hEvent) {
-    if (unlikely(m_commonIntf->GetOptions()->forceProxiedPresent)) {
-      Logger::debug("<<< DDraw4Interface::WaitForVerticalBlank: Proxy");
-      m_proxy->WaitForVerticalBlank(dwFlags, hEvent);
-    }
-
     Logger::debug(">>> DDraw4Interface::WaitForVerticalBlank");
 
     if (unlikely(dwFlags & DDWAITVB_BLOCKBEGINEVENT))

--- a/src/ddraw/ddraw4/ddraw4_surface.cpp
+++ b/src/ddraw/ddraw4/ddraw4_surface.cpp
@@ -59,7 +59,8 @@ namespace dxvk {
 
     if (m_parentSurf != nullptr && !m_commonSurf->IsFrontBuffer()
      && m_parentSurf->GetCommonSurface()->IsBackBufferOrFlippable()
-     && !m_commonIntf->GetOptions()->forceSingleBackBuffer) {
+     && !m_commonIntf->GetOptions()->forceSingleBackBuffer
+     && !m_commonIntf->GetOptions()->forceLegacyPresent) {
       const uint32_t index = m_parentSurf->GetCommonSurface()->GetBackBufferIndex();
       m_commonSurf->IncrementBackBufferIndex(index);
     }
@@ -275,18 +276,20 @@ namespace dxvk {
   HRESULT STDMETHODCALLTYPE DDraw4Surface::Blt(LPRECT lpDestRect, LPDIRECTDRAWSURFACE4 lpDDSrcSurface, LPRECT lpSrcRect, DWORD dwFlags, LPDDBLTFX lpDDBltFx) {
     Logger::debug("<<< DDraw4Surface::Blt: Proxy");
 
+    const D3DOptions* d3dOptions = m_commonIntf->GetOptions();
+
     // Write back any flippable surfaces or depth stencils from D3D9
     if (likely(lpDDSrcSurface != nullptr && m_commonIntf->IsWrappedSurface(lpDDSrcSurface))) {
       DDraw4Surface* sourceSurface = static_cast<DDraw4Surface*>(lpDDSrcSurface);
       if (unlikely(sourceSurface->GetCommonSurface()->IsGuardableSurface())) {
-        if (m_commonIntf->GetOptions()->backBufferWriteBack || m_commonIntf->GetOptions()->apitraceMode) {
+        if (d3dOptions->backBufferWriteBack || d3dOptions->forceLegacyPresent || d3dOptions->apitraceMode) {
           Logger::debug("DDraw4Surface::Blt: Source surface is a swapchain surface");
 
           if (unlikely(m_commonIntf->GetOptions()->apitraceMode && !sourceSurface->IsInitialized()))
             sourceSurface->InitializeOrUploadD3D9();
 
           if (likely(sourceSurface->IsInitialized()))
-            BlitToDDrawSurface<IDirectDrawSurface4, DDSURFACEDESC2>(sourceSurface->GetProxied(), sourceSurface->GetD3D9());
+            BlitToDDrawSurface<IDirectDrawSurface4, DDSURFACEDESC2>(sourceSurface->GetShadowOrProxied(), sourceSurface->GetD3D9());
         } else {
           static bool s_swapchainWarningShown;
 
@@ -294,7 +297,7 @@ namespace dxvk {
             Logger::warn("DDraw4Surface::Blt: Source surface is a swapchain surface");
         }
       } else if (unlikely(sourceSurface->GetCommonSurface()->IsDepthStencil())) {
-        if (m_commonIntf->GetOptions()->depthWriteBack || m_commonIntf->GetOptions()->apitraceMode) {
+        if (d3dOptions->depthWriteBack || d3dOptions->apitraceMode) {
           Logger::debug("DDraw4Surface::Blt: Source surface is a depth stencil");
 
           if (likely(sourceSurface->IsInitialized()))
@@ -346,12 +349,12 @@ namespace dxvk {
       }
 
       const bool exclusiveMode = (m_commonIntf->GetCooperativeLevel() & DDSCL_EXCLUSIVE)
-                              && !m_commonIntf->GetOptions()->ignoreExclusiveMode;
+                              && !d3dOptions->ignoreExclusiveMode;
 
       // Eclusive mode back buffer guard
       if (exclusiveMode && m_commonIntf->HasDrawn() &&
           m_commonSurf->IsGuardableSurface() &&
-          m_commonIntf->GetOptions()->backBufferGuard != D3DBackBufferGuard::Disabled) {
+          d3dOptions->backBufferGuard != D3DBackBufferGuard::Disabled) {
         return DD_OK;
       // Windowed mode presentation path
       } else if (!exclusiveMode && m_commonIntf->HasDrawn() && m_commonSurf->IsPrimarySurface()) {
@@ -368,10 +371,10 @@ namespace dxvk {
         Logger::warn("DDraw4Surface::Blt: Received an unwrapped source surface");
         return DDERR_UNSUPPORTED;
       }
-      hr = m_proxy->Blt(lpDestRect, lpDDSrcSurface, lpSrcRect, dwFlags, lpDDBltFx);
+      hr = GetShadowOrProxied()->Blt(lpDestRect, lpDDSrcSurface, lpSrcRect, dwFlags, lpDDBltFx);
     } else {
       DDraw4Surface* ddraw4Surface = static_cast<DDraw4Surface*>(lpDDSrcSurface);
-      hr = m_proxy->Blt(lpDestRect, ddraw4Surface->GetProxied(), lpSrcRect, dwFlags, lpDDBltFx);
+      hr = GetShadowOrProxied()->Blt(lpDestRect, ddraw4Surface->GetShadowOrProxied(), lpSrcRect, dwFlags, lpDDBltFx);
     }
 
     if (likely(SUCCEEDED(hr))) {
@@ -382,6 +385,15 @@ namespace dxvk {
           Logger::warn("DDraw4Surface::Blt: Failed upload to d3d9 surface");
       } else {
         m_commonSurf->DirtyMipMaps();
+      }
+
+      if (unlikely(m_shadowSurf != nullptr && m_d3d9Device != nullptr)) {
+        const bool shouldPresent = m_commonIntf->GetOptions()->legacyPresentGuard == D3DLegacyPresentGuard::Auto ?
+                                  !m_commonIntf->GetCommonD3DDevice()->IsInScene() :
+                                   m_commonIntf->GetOptions()->legacyPresentGuard == D3DLegacyPresentGuard::Strict ?
+                                   false : true;
+        if (shouldPresent)
+          m_d3d9Device->Present(NULL, NULL, NULL, NULL);
       }
     }
 
@@ -397,18 +409,20 @@ namespace dxvk {
   HRESULT STDMETHODCALLTYPE DDraw4Surface::BltFast(DWORD dwX, DWORD dwY, LPDIRECTDRAWSURFACE4 lpDDSrcSurface, LPRECT lpSrcRect, DWORD dwTrans) {
     Logger::debug("<<< DDraw4Surface::BltFast: Proxy");
 
+    const D3DOptions* d3dOptions = m_commonIntf->GetOptions();
+
     // Write back any flippable surfaces or depth stencils from D3D9
     if (likely(lpDDSrcSurface != nullptr && m_commonIntf->IsWrappedSurface(lpDDSrcSurface))) {
       DDraw4Surface* sourceSurface = static_cast<DDraw4Surface*>(lpDDSrcSurface);
       if (unlikely(sourceSurface->GetCommonSurface()->IsGuardableSurface())) {
-        if (m_commonIntf->GetOptions()->backBufferWriteBack || m_commonIntf->GetOptions()->apitraceMode) {
+        if (d3dOptions->backBufferWriteBack || d3dOptions->forceLegacyPresent || d3dOptions->apitraceMode) {
           Logger::debug("DDraw4Surface::BltFast: Source surface is a swapchain surface");
 
           if (unlikely(m_commonIntf->GetOptions()->apitraceMode && !sourceSurface->IsInitialized()))
             sourceSurface->InitializeOrUploadD3D9();
 
           if (likely(sourceSurface->IsInitialized()))
-            BlitToDDrawSurface<IDirectDrawSurface4, DDSURFACEDESC2>(sourceSurface->GetProxied(), sourceSurface->GetD3D9());
+            BlitToDDrawSurface<IDirectDrawSurface4, DDSURFACEDESC2>(sourceSurface->GetShadowOrProxied(), sourceSurface->GetD3D9());
         } else {
           static bool s_swapchainWarningShown;
 
@@ -416,7 +430,7 @@ namespace dxvk {
             Logger::warn("DDraw4Surface::BltFast: Source surface is a swapchain surface");
         }
       } else if (unlikely(sourceSurface->GetCommonSurface()->IsDepthStencil())) {
-        if (m_commonIntf->GetOptions()->depthWriteBack || m_commonIntf->GetOptions()->apitraceMode) {
+        if (d3dOptions->depthWriteBack || d3dOptions->apitraceMode) {
           Logger::debug("DDraw4Surface::BltFast: Source surface is a depth stencil");
 
           if (likely(sourceSurface->IsInitialized()))
@@ -433,12 +447,12 @@ namespace dxvk {
     RefreshD3D9Device();
     if (likely(m_d3d9Device != nullptr)) {
       const bool exclusiveMode = (m_commonIntf->GetCooperativeLevel() & DDSCL_EXCLUSIVE)
-                              && !m_commonIntf->GetOptions()->ignoreExclusiveMode;
+                              && !d3dOptions->ignoreExclusiveMode;
 
       // Eclusive mode back buffer guard
       if (exclusiveMode && m_commonIntf->HasDrawn() &&
           m_commonSurf->IsGuardableSurface() &&
-          m_commonIntf->GetOptions()->backBufferGuard != D3DBackBufferGuard::Disabled) {
+          d3dOptions->backBufferGuard != D3DBackBufferGuard::Disabled) {
         return DD_OK;
       // Windowed mode presentation path
       } else if (!exclusiveMode && m_commonIntf->HasDrawn() && m_commonSurf->IsPrimarySurface()) {
@@ -455,10 +469,10 @@ namespace dxvk {
         Logger::warn("DDraw4Surface::BltFast: Received an unwrapped source surface");
         return DDERR_UNSUPPORTED;
       }
-      hr = m_proxy->BltFast(dwX, dwY, lpDDSrcSurface, lpSrcRect, dwTrans);
+      hr = GetShadowOrProxied()->BltFast(dwX, dwY, lpDDSrcSurface, lpSrcRect, dwTrans);
     } else {
       DDraw4Surface* ddraw4Surface = static_cast<DDraw4Surface*>(lpDDSrcSurface);
-      hr = m_proxy->BltFast(dwX, dwY, ddraw4Surface->GetProxied(), lpSrcRect, dwTrans);
+      hr = GetShadowOrProxied()->BltFast(dwX, dwY, ddraw4Surface->GetShadowOrProxied(), lpSrcRect, dwTrans);
     }
 
     if (likely(SUCCEEDED(hr))) {
@@ -469,6 +483,15 @@ namespace dxvk {
           Logger::warn("DDraw4Surface::BltFast: Failed upload to d3d9 surface");
       } else {
         m_commonSurf->DirtyMipMaps();
+      }
+
+      if (unlikely(m_shadowSurf != nullptr && m_d3d9Device != nullptr)) {
+        const bool shouldPresent = m_commonIntf->GetOptions()->legacyPresentGuard == D3DLegacyPresentGuard::Auto ?
+                                  !m_commonIntf->GetCommonD3DDevice()->IsInScene() :
+                                   m_commonIntf->GetOptions()->legacyPresentGuard == D3DLegacyPresentGuard::Strict ?
+                                   false : true;
+        if (shouldPresent)
+          m_d3d9Device->Present(NULL, NULL, NULL, NULL);
       }
     }
 
@@ -613,44 +636,6 @@ namespace dxvk {
     if (likely(m_d3d9Device != nullptr)) {
       m_commonIntf->ResetDrawTracking();
 
-      if (unlikely(m_commonIntf->GetOptions()->forceProxiedPresent)) {
-        D3DCommonDevice* commonDevice = m_commonIntf->GetCommonD3DDevice();
-
-        if (unlikely(!IsInitialized()))
-          InitializeD3D9(commonDevice->IsCurrentRenderTarget(this));
-
-        BlitToDDrawSurface<IDirectDrawSurface4, DDSURFACEDESC2>(m_proxy.ptr(), m_d3d9.ptr());
-
-        if (unlikely(!m_commonIntf->IsWrappedSurface(lpDDSurfaceTargetOverride))) {
-          if (unlikely(lpDDSurfaceTargetOverride != nullptr)) {
-            Logger::warn("DDraw4Surface::Flip: Received an unwrapped surface");
-            return DDERR_UNSUPPORTED;
-          }
-
-          if (likely(commonDevice->IsCurrentRenderTarget(this)))
-            m_commonIntf->SetFlipRTSurfaceAndFlags(lpDDSurfaceTargetOverride, dwFlags);
-
-          if (unlikely(m_commonIntf->GetOptions()->forceBlitOnFlip &&
-                       rt != nullptr && m_commonSurf->IsPrimarySurface())) {
-            Logger::debug("DDraw4Surface::Flip: Skipping flip");
-            return DD_OK;
-          } else {
-            return m_proxy->Flip(lpDDSurfaceTargetOverride, dwFlags);
-          }
-        } else {
-          if (likely(commonDevice->IsCurrentRenderTarget(this)))
-            m_commonIntf->SetFlipRTSurfaceAndFlags(lpDDSurfaceTargetOverride, dwFlags);
-
-          if (unlikely(m_commonIntf->GetOptions()->forceBlitOnFlip &&
-                       rt != nullptr && m_commonSurf->IsPrimarySurface())) {
-            Logger::debug("DDraw4Surface::Flip: Skipping flip");
-            return DD_OK;
-          } else {
-            return m_proxy->Flip(surf4->GetProxied(), dwFlags);
-          }
-        }
-      }
-
       // If the interface is waiting for VBlank and we get a no VSync flip, switch
       // to doing immediate presents by resetting the swapchain appropriately
       if (unlikely(m_commonIntf->GetWaitForVBlank() && (dwFlags & DDFLIP_NOVSYNC))) {
@@ -696,7 +681,7 @@ namespace dxvk {
         if (unlikely(m_commonIntf->GetOptions()->forceBlitOnFlip &&
                      rt != nullptr && m_commonSurf->IsPrimarySurface())) {
           Logger::debug("DDrawSurface::Flip: Blitting instead of flipping");
-          return m_proxy->Blt(nullptr, rt->GetProxied(), nullptr, DDBLT_WAIT, nullptr);
+          return GetShadowOrProxied()->Blt(nullptr, rt->GetShadowOrProxied(), nullptr, DDBLT_WAIT, nullptr);
         } else {
           return m_proxy->Flip(lpDDSurfaceTargetOverride, dwFlags);
         }
@@ -772,11 +757,6 @@ namespace dxvk {
 
   // Blitting can be done at any time and completes within its call frame
   HRESULT STDMETHODCALLTYPE DDraw4Surface::GetBltStatus(DWORD dwFlags) {
-    if (unlikely(m_commonIntf->GetOptions()->forceProxiedPresent)) {
-      Logger::debug("<<< DDraw4Surface::GetBltStatus: Proxy");
-      m_proxy->GetBltStatus(dwFlags);
-    }
-
     Logger::debug(">>> DDraw4Surface::GetBltStatus");
 
     if (likely(dwFlags == DDGBS_CANBLT || dwFlags == DDGBS_ISBLTDONE))
@@ -820,42 +800,36 @@ namespace dxvk {
   }
 
   HRESULT STDMETHODCALLTYPE DDraw4Surface::GetDC(HDC *lphDC) {
-    if (likely(!m_commonIntf->GetOptions()->forceProxiedPresent)) {
-      if (unlikely(lphDC == nullptr))
-        return DDERR_INVALIDPARAMS;
+    if (unlikely(lphDC == nullptr))
+      return DDERR_INVALIDPARAMS;
 
-      InitReturnPtr(lphDC);
+    InitReturnPtr(lphDC);
 
-      // Foward GetDC calls if we have drawn and the surface is flippable
-      RefreshD3D9Device();
-      if (m_d3d9Device != nullptr && (m_commonIntf->HasDrawn() &&
-                                      m_commonSurf->IsGuardableSurface())) {
-        Logger::debug(">>> DDraw4Surface::GetDC");
+    // Foward GetDC calls if we have drawn and the surface is flippable
+    RefreshD3D9Device();
+    if (m_d3d9Device != nullptr && (m_commonIntf->HasDrawn() &&
+                                    m_commonSurf->IsGuardableSurface())) {
+      Logger::debug(">>> DDraw4Surface::GetDC");
 
-        if (unlikely(!IsInitialized())) {
-          HRESULT hrUpload = InitializeOrUploadD3D9();
-          if (unlikely(FAILED(hrUpload)))
-            Logger::warn("DDraw4Surface::GetDC: Failed to initialize d3d9 surface");
-        }
-
-        HRESULT hr9 = m_d3d9->GetDC(lphDC);
-        if (unlikely(FAILED(hr9)))
-          Logger::warn("DDraw4Surface::GetDC: Failed D3D9 call");
-        return hr9;
+      if (unlikely(!IsInitialized())) {
+        HRESULT hrUpload = InitializeOrUploadD3D9();
+        if (unlikely(FAILED(hrUpload)))
+          Logger::warn("DDraw4Surface::GetDC: Failed to initialize d3d9 surface");
       }
+
+      HRESULT hr9 = m_d3d9->GetDC(lphDC);
+      if (unlikely(FAILED(hr9)))
+        Logger::warn("DDraw4Surface::GetDC: Failed D3D9 call");
+      return hr9;
     }
 
     Logger::debug("<<< DDraw4Surface::GetDC: Proxy");
-    return m_proxy->GetDC(lphDC);
+
+    return GetShadowOrProxied()->GetDC(lphDC);
   }
 
   // Flipping can be done at any time and completes within its call frame
   HRESULT STDMETHODCALLTYPE DDraw4Surface::GetFlipStatus(DWORD dwFlags) {
-    if (unlikely(m_commonIntf->GetOptions()->forceProxiedPresent)) {
-      Logger::debug("<<< DDraw4Surface::GetFlipStatus: Proxy");
-      m_proxy->GetFlipStatus(dwFlags);
-    }
-
     Logger::debug(">>> DDraw4Surface::GetFlipStatus");
 
     if (likely(dwFlags == DDGFS_CANFLIP || dwFlags == DDGFS_ISFLIPDONE))
@@ -927,16 +901,18 @@ namespace dxvk {
   HRESULT STDMETHODCALLTYPE DDraw4Surface::Lock(LPRECT lpDestRect, LPDDSURFACEDESC2 lpDDSurfaceDesc, DWORD dwFlags, HANDLE hEvent) {
     Logger::debug("<<< DDraw4Surface::Lock: Proxy");
 
+    const D3DOptions* d3dOptions = m_commonIntf->GetOptions();
+
     // Write back any flippable surfaces or depth stencils from D3D9
     if (unlikely(m_commonSurf->IsGuardableSurface())) {
-      if (m_commonIntf->GetOptions()->backBufferWriteBack || m_commonIntf->GetOptions()->apitraceMode) {
+      if (d3dOptions->backBufferWriteBack || d3dOptions->forceLegacyPresent || d3dOptions->apitraceMode) {
         Logger::debug("DDraw4Surface::Lock: Surface is a swapchain surface");
 
         if (unlikely(m_commonIntf->GetOptions()->apitraceMode && !IsInitialized()))
           InitializeOrUploadD3D9();
 
         if (likely(IsInitialized()))
-          BlitToDDrawSurface<IDirectDrawSurface4, DDSURFACEDESC2>(m_proxy.ptr(), m_d3d9.ptr());
+            BlitToDDrawSurface<IDirectDrawSurface4, DDSURFACEDESC2>(GetShadowOrProxied(), m_d3d9.ptr());
       } else {
         static bool s_swapchainWarningShown;
 
@@ -944,7 +920,7 @@ namespace dxvk {
           Logger::warn("DDraw4Surface::Lock: Surface is a swapchain surface");
       }
     } else if (unlikely(m_commonSurf->IsDepthStencil())) {
-      if (m_commonIntf->GetOptions()->depthWriteBack || m_commonIntf->GetOptions()->apitraceMode) {
+      if (d3dOptions->depthWriteBack || d3dOptions->apitraceMode) {
         Logger::debug("DDraw4Surface::Lock: Surface is a depth stencil");
 
         if (likely(IsInitialized()))
@@ -957,33 +933,31 @@ namespace dxvk {
       }
     }
 
-    return m_proxy->Lock(lpDestRect, lpDDSurfaceDesc, dwFlags, hEvent);
+    return GetShadowOrProxied()->Lock(lpDestRect, lpDDSurfaceDesc, dwFlags, hEvent);
   }
 
   HRESULT STDMETHODCALLTYPE DDraw4Surface::ReleaseDC(HDC hDC) {
-    if (likely(!m_commonIntf->GetOptions()->forceProxiedPresent)) {
-      // Foward ReleaseDC calls if we have drawn and the surface is flippable
-      RefreshD3D9Device();
-      if (m_d3d9Device != nullptr && (m_commonIntf->HasDrawn() &&
-                                      m_commonSurf->IsGuardableSurface())) {
-        Logger::debug(">>> DDraw4Surface::ReleaseDC");
+    // Foward ReleaseDC calls if we have drawn and the surface is flippable
+    RefreshD3D9Device();
+    if (m_d3d9Device != nullptr && (m_commonIntf->HasDrawn() &&
+                                    m_commonSurf->IsGuardableSurface())) {
+      Logger::debug(">>> DDraw4Surface::ReleaseDC");
 
-        if (unlikely(!IsInitialized())) {
-          HRESULT hrUpload = InitializeOrUploadD3D9();
-          if (unlikely(FAILED(hrUpload)))
-            Logger::warn("DDraw4Surface::ReleaseDC: Failed to initialize d3d9 surface");
-        }
-
-        HRESULT hr9 = m_d3d9->ReleaseDC(hDC);
-        if (unlikely(FAILED(hr9)))
-          Logger::warn("DDraw4Surface::ReleaseDC: Failed D3D9 call");
-        return hr9;
+      if (unlikely(!IsInitialized())) {
+        HRESULT hrUpload = InitializeOrUploadD3D9();
+        if (unlikely(FAILED(hrUpload)))
+          Logger::warn("DDraw4Surface::ReleaseDC: Failed to initialize d3d9 surface");
       }
+
+      HRESULT hr9 = m_d3d9->ReleaseDC(hDC);
+      if (unlikely(FAILED(hr9)))
+        Logger::warn("DDraw4Surface::ReleaseDC: Failed D3D9 call");
+      return hr9;
     }
 
     Logger::debug("<<< DDraw4Surface::ReleaseDC: Proxy");
 
-    HRESULT hr = m_proxy->ReleaseDC(hDC);
+    HRESULT hr = GetShadowOrProxied()->ReleaseDC(hDC);
 
     if (likely(SUCCEEDED(hr))) {
       // Textures and cubemaps get uploaded during SetTexture calls
@@ -1054,7 +1028,7 @@ namespace dxvk {
 
     // A nullptr lpDDPalette gets the current palette detached
     if (lpDDPalette == nullptr) {
-      HRESULT hr = m_proxy->SetPalette(lpDDPalette);
+      HRESULT hr = GetShadowOrProxied()->SetPalette(lpDDPalette);
       if (unlikely(FAILED(hr)))
         return hr;
 
@@ -1062,7 +1036,7 @@ namespace dxvk {
     } else {
       DDrawPalette* ddrawPalette = static_cast<DDrawPalette*>(lpDDPalette);
 
-      HRESULT hr = m_proxy->SetPalette(ddrawPalette->GetProxied());
+      HRESULT hr = GetShadowOrProxied()->SetPalette(ddrawPalette->GetProxied());
       if (unlikely(FAILED(hr)))
         return hr;
 
@@ -1075,7 +1049,7 @@ namespace dxvk {
   HRESULT STDMETHODCALLTYPE DDraw4Surface::Unlock(LPRECT lpSurfaceData) {
     Logger::debug("<<< DDraw4Surface::Unlock: Proxy");
 
-    HRESULT hr = m_proxy->Unlock(lpSurfaceData);
+    HRESULT hr = GetShadowOrProxied()->Unlock(lpSurfaceData);
 
     if (likely(SUCCEEDED(hr))) {
       // Textures and cubemaps get uploaded during SetTexture calls
@@ -1085,6 +1059,16 @@ namespace dxvk {
           Logger::warn("DDraw4Surface::Unlock: Failed upload to d3d9 surface");
       } else {
         m_commonSurf->DirtyMipMaps();
+      }
+
+      RefreshD3D9Device();
+      if (unlikely(m_shadowSurf != nullptr && m_d3d9Device != nullptr)) {
+        const bool shouldPresent = m_commonIntf->GetOptions()->legacyPresentGuard == D3DLegacyPresentGuard::Auto ?
+                                  !m_commonIntf->GetCommonD3DDevice()->IsInScene() :
+                                   m_commonIntf->GetOptions()->legacyPresentGuard == D3DLegacyPresentGuard::Strict ?
+                                   false : true;
+        if (shouldPresent)
+          m_d3d9Device->Present(NULL, NULL, NULL, NULL);
       }
     }
 
@@ -1207,6 +1191,15 @@ namespace dxvk {
   HRESULT STDMETHODCALLTYPE DDraw4Surface::ChangeUniquenessValue() {
     Logger::debug(">>> DDraw4Surface::ChangeUniquenessValue");
     return DD_OK;
+  }
+
+  IDirectDrawSurface4* DDraw4Surface::GetShadowOrProxied() {
+    RefreshD3D9Device();
+
+    if (unlikely(m_shadowSurf != nullptr && m_d3d9Device != nullptr))
+      return m_shadowSurf->GetProxied();
+
+    return m_proxy.ptr();
   }
 
   HRESULT DDraw4Surface::InitializeD3D9RenderTarget() {
@@ -1579,7 +1572,7 @@ namespace dxvk {
         }
       }
 
-      BlitToD3D9Surface<IDirectDrawSurface4, DDSURFACEDESC2>(m_d3d9.ptr(), format, m_proxy.ptr());
+      BlitToD3D9Surface<IDirectDrawSurface4, DDSURFACEDESC2>(m_d3d9.ptr(), format, GetShadowOrProxied());
     }
 
     return DD_OK;

--- a/src/ddraw/ddraw4/ddraw4_surface.h
+++ b/src/ddraw/ddraw4/ddraw4_surface.h
@@ -119,6 +119,16 @@ namespace dxvk {
 
     HRESULT STDMETHODCALLTYPE ChangeUniquenessValue();
 
+    IDirectDrawSurface4* GetShadowOrProxied();
+
+    void SetShadowSurface(DDraw4Surface* shadowSurf) {
+      m_shadowSurf = shadowSurf;
+    }
+
+    DDraw4Surface* GetShadowSurface() const {
+      return m_shadowSurf.ptr();
+    }
+
     DDrawCommonSurface* GetCommonSurface() const {
       return m_commonSurf.ptr();
     }
@@ -185,20 +195,24 @@ namespace dxvk {
     static uint32_t  s_surfCount;
     uint32_t         m_surfCount = 0;
 
-    Com<DDrawCommonSurface>             m_commonSurf;
-    DDrawCommonInterface*               m_commonIntf = nullptr;
+    Com<DDrawCommonSurface>      m_commonSurf;
+    DDrawCommonInterface*        m_commonIntf = nullptr;
 
-    DDraw4Surface*                      m_parentSurf = nullptr;
+    DDraw4Surface*               m_parentSurf = nullptr;
 
-    d3d9::IDirect3DDevice9*             m_d3d9Device = nullptr;
+    d3d9::IDirect3DDevice9*      m_d3d9Device = nullptr;
 
-    Com<D3D6Texture, false>             m_texture6;
+    Com<D3D6Texture, false>      m_texture6;
 
-    Com<d3d9::IDirect3DTexture9>        m_texture9;
+    Com<d3d9::IDirect3DTexture9> m_texture9;
+
+    // Offscreen plain surface we use to mask unwanted DDraw interactions, such
+    // as forced swapchain presents caused by blits/locks on primary surfaces
+    Com<DDraw4Surface>           m_shadowSurf;
 
     // Back buffers will have depth stencil surfaces as attachments (in practice
     // I have never seen more than one depth stencil being attached at a time)
-    Com<DDraw4Surface>                  m_depthStencil;
+    Com<DDraw4Surface>           m_depthStencil;
 
     // These are attached surfaces, which are typically mips or other types of generated
     // surfaces, which need to exist for the entire lifecycle of their parent surface.

--- a/src/ddraw/ddraw7/ddraw7_interface.cpp
+++ b/src/ddraw/ddraw7/ddraw7_interface.cpp
@@ -237,9 +237,7 @@ namespace dxvk {
     // D3D9, so always strip the DDSCAPS_WRITEONLY flag on creation
     lpDDSurfaceDesc->ddsCaps.dwCaps &= ~DDSCAPS_WRITEONLY;
     // Similarly strip the DDSCAPS2_OPAQUE flag on texture creation
-    if (lpDDSurfaceDesc->ddsCaps.dwCaps & DDSCAPS_TEXTURE) {
-      lpDDSurfaceDesc->ddsCaps.dwCaps2 &= ~DDSCAPS2_OPAQUE;
-    }
+    lpDDSurfaceDesc->ddsCaps.dwCaps2 &= ~DDSCAPS2_OPAQUE;
 
     if (unlikely((lpDDSurfaceDesc->ddsCaps.dwCaps & DDSCAPS_ZBUFFER)
               && (lpDDSurfaceDesc->ddpfPixelFormat.dwZBitMask == 0xFFFFFFFF))) {
@@ -260,8 +258,37 @@ namespace dxvk {
     if (likely(SUCCEEDED(hr))) {
       try{
         Com<DDraw7Surface> surface7 = new DDraw7Surface(nullptr, std::move(ddraw7SurfaceProxied), this, nullptr, true);
-        if (unlikely(lpDDSurfaceDesc->ddsCaps.dwCaps & DDSCAPS_PRIMARYSURFACE))
+
+        if (unlikely(lpDDSurfaceDesc->ddsCaps.dwCaps & DDSCAPS_PRIMARYSURFACE)) {
           m_commonIntf->SetPrimarySurface(surface7->GetCommonSurface());
+
+          // Shadow surface creation for the primary surface
+          // (it needs to be based on the same incoming desc)
+          if (unlikely(!surface7->GetCommonSurface()->Is8BitFormat() &&
+                        m_commonIntf->GetOptions()->forceLegacyPresent)) {
+            DDSURFACEDESC2 shadowDesc = *lpDDSurfaceDesc;
+            const DDSURFACEDESC2* primaryDesc = surface7->GetCommonSurface()->GetDesc2();
+
+            shadowDesc.ddsCaps.dwCaps &= ~DDSCAPS_PRIMARYSURFACE & ~DDSCAPS_COMPLEX & ~DDSCAPS_FLIP;
+            shadowDesc.ddsCaps.dwCaps |= DDSCAPS_OFFSCREENPLAIN;
+            shadowDesc.dwFlags &= ~DDSD_BACKBUFFERCOUNT;
+            // Dimensions aren't specified in the incoming desc,
+            // but are explicitly needed for non-primary surfaces
+            shadowDesc.dwFlags |= DDSD_WIDTH | DDSD_HEIGHT;
+            shadowDesc.dwWidth  = primaryDesc->dwWidth;
+            shadowDesc.dwHeight = primaryDesc->dwHeight;
+
+            Com<IDirectDrawSurface7> ddraw7SurfaceShadow;
+            hr = m_proxy->CreateSurface(&shadowDesc, &ddraw7SurfaceShadow, pUnkOuter);
+            if (unlikely(FAILED(hr))) {
+              Logger::warn("DDraw7Interface::CreateSurface: Failed to create shadow surface");
+            } else {
+              Com<DDraw7Surface> shadowSurf = new DDraw7Surface(nullptr, std::move(ddraw7SurfaceShadow), this, nullptr, false);
+              surface7->SetShadowSurface(shadowSurf.ptr());
+            }
+          }
+        }
+
         *lplpDDSurface = surface7.ref();
       } catch (const DxvkError& e) {
         Logger::err(e.message());
@@ -339,11 +366,6 @@ namespace dxvk {
   }
 
   HRESULT STDMETHODCALLTYPE DDraw7Interface::FlipToGDISurface() {
-    if (unlikely(m_commonIntf->GetOptions()->forceProxiedPresent)) {
-      Logger::debug("<<< DDraw7Interface::FlipToGDISurface: Proxy");
-      return m_proxy->FlipToGDISurface();
-    }
-
     Logger::debug("*** DDraw7Interface::FlipToGDISurface: Ignoring");
 
     DDrawCommonSurface* ps = m_commonIntf->GetPrimarySurface();
@@ -563,8 +585,7 @@ namespace dxvk {
         Logger::warn("DDraw7Interface::SetDisplayMode: Failed to update primary surface desc");
     }
 
-    if (likely(!m_commonIntf->GetOptions()->forceProxiedPresent &&
-                m_commonIntf->GetOptions()->backBufferResize)) {
+    if (likely(m_commonIntf->GetOptions()->backBufferResize)) {
       const bool exclusiveMode = m_commonIntf->GetCooperativeLevel() & DDSCL_EXCLUSIVE;
 
       // Ignore any mode size dimensions when in windowed present mode
@@ -582,11 +603,6 @@ namespace dxvk {
   }
 
   HRESULT STDMETHODCALLTYPE DDraw7Interface::WaitForVerticalBlank(DWORD dwFlags, HANDLE hEvent) {
-    if (unlikely(m_commonIntf->GetOptions()->forceProxiedPresent)) {
-      Logger::debug("<<< DDraw7Interface::WaitForVerticalBlank: Proxy");
-      m_proxy->WaitForVerticalBlank(dwFlags, hEvent);
-    }
-
     Logger::debug(">>> DDraw7Interface::WaitForVerticalBlank");
 
     if (unlikely(dwFlags & DDWAITVB_BLOCKBEGINEVENT))

--- a/src/ddraw/ddraw7/ddraw7_surface.cpp
+++ b/src/ddraw/ddraw7/ddraw7_surface.cpp
@@ -57,7 +57,8 @@ namespace dxvk {
 
     if (m_parentSurf != nullptr && !m_commonSurf->IsFrontBuffer()
      && m_parentSurf->GetCommonSurface()->IsBackBufferOrFlippable()
-     && !m_commonIntf->GetOptions()->forceSingleBackBuffer) {
+     && !m_commonIntf->GetOptions()->forceSingleBackBuffer
+     && !m_commonIntf->GetOptions()->forceLegacyPresent) {
       const uint32_t index = m_parentSurf->GetCommonSurface()->GetBackBufferIndex();
       m_commonSurf->IncrementBackBufferIndex(index);
     }
@@ -253,18 +254,20 @@ namespace dxvk {
   HRESULT STDMETHODCALLTYPE DDraw7Surface::Blt(LPRECT lpDestRect, LPDIRECTDRAWSURFACE7 lpDDSrcSurface, LPRECT lpSrcRect, DWORD dwFlags, LPDDBLTFX lpDDBltFx) {
     Logger::debug("<<< DDraw7Surface::Blt: Proxy");
 
+    const D3DOptions* d3dOptions = m_commonIntf->GetOptions();
+
     // Write back any flippable surfaces or depth stencils from D3D9
     if (likely(lpDDSrcSurface != nullptr && m_commonIntf->IsWrappedSurface(lpDDSrcSurface))) {
       DDraw7Surface* sourceSurface = static_cast<DDraw7Surface*>(lpDDSrcSurface);
       if (unlikely(sourceSurface->GetCommonSurface()->IsGuardableSurface())) {
-        if (m_commonIntf->GetOptions()->backBufferWriteBack || m_commonIntf->GetOptions()->apitraceMode) {
+        if (d3dOptions->backBufferWriteBack || d3dOptions->forceLegacyPresent || d3dOptions->apitraceMode) {
           Logger::debug("DDraw7Surface::Blt: Source surface is a swapchain surface");
 
-          if (unlikely(m_commonIntf->GetOptions()->apitraceMode && !sourceSurface->IsInitialized()))
+          if (unlikely(d3dOptions->apitraceMode && !sourceSurface->IsInitialized()))
             sourceSurface->InitializeOrUploadD3D9();
 
           if (likely(sourceSurface->IsInitialized()))
-            BlitToDDrawSurface<IDirectDrawSurface7, DDSURFACEDESC2>(sourceSurface->GetProxied(), sourceSurface->GetD3D9());
+            BlitToDDrawSurface<IDirectDrawSurface7, DDSURFACEDESC2>(sourceSurface->GetShadowOrProxied(), sourceSurface->GetD3D9());
         } else {
           static bool s_swapchainWarningShown;
 
@@ -272,7 +275,7 @@ namespace dxvk {
             Logger::warn("DDraw7Surface::Blt: Source surface is a swapchain surface");
         }
       } else if (unlikely(sourceSurface->GetCommonSurface()->IsDepthStencil())) {
-        if (m_commonIntf->GetOptions()->depthWriteBack || m_commonIntf->GetOptions()->apitraceMode) {
+        if (d3dOptions->depthWriteBack || d3dOptions->apitraceMode) {
           Logger::debug("DDraw7Surface::Blt: Source surface is a depth stencil");
 
           if (likely(sourceSurface->IsInitialized()))
@@ -324,12 +327,12 @@ namespace dxvk {
       }
 
       const bool exclusiveMode = (m_commonIntf->GetCooperativeLevel() & DDSCL_EXCLUSIVE)
-                              && !m_commonIntf->GetOptions()->ignoreExclusiveMode;
+                              && !d3dOptions->ignoreExclusiveMode;
 
       // Eclusive mode back buffer guard
       if (exclusiveMode && m_commonIntf->HasDrawn() &&
           m_commonSurf->IsGuardableSurface() &&
-          m_commonIntf->GetOptions()->backBufferGuard != D3DBackBufferGuard::Disabled) {
+          d3dOptions->backBufferGuard != D3DBackBufferGuard::Disabled) {
         return DD_OK;
       // Windowed mode presentation path
       } else if (!exclusiveMode && m_commonIntf->HasDrawn() && m_commonSurf->IsPrimarySurface()) {
@@ -346,10 +349,10 @@ namespace dxvk {
         Logger::warn("DDraw7Surface::Blt: Received an unwrapped source surface");
         return DDERR_UNSUPPORTED;
       }
-      hr = m_proxy->Blt(lpDestRect, lpDDSrcSurface, lpSrcRect, dwFlags, lpDDBltFx);
+      hr = GetShadowOrProxied()->Blt(lpDestRect, lpDDSrcSurface, lpSrcRect, dwFlags, lpDDBltFx);
     } else {
       DDraw7Surface* ddraw7Surface = static_cast<DDraw7Surface*>(lpDDSrcSurface);
-      hr = m_proxy->Blt(lpDestRect, ddraw7Surface->GetProxied(), lpSrcRect, dwFlags, lpDDBltFx);
+      hr = GetShadowOrProxied()->Blt(lpDestRect, ddraw7Surface->GetShadowOrProxied(), lpSrcRect, dwFlags, lpDDBltFx);
     }
 
     if (likely(SUCCEEDED(hr))) {
@@ -360,6 +363,15 @@ namespace dxvk {
           Logger::warn("DDraw7Surface::Blt: Failed upload to d3d9 surface");
       } else {
         m_commonSurf->DirtyMipMaps();
+      }
+
+      if (unlikely(m_shadowSurf != nullptr && m_d3d9Device != nullptr)) {
+        const bool shouldPresent = m_commonIntf->GetOptions()->legacyPresentGuard == D3DLegacyPresentGuard::Auto ?
+                                  !m_commonIntf->GetCommonD3DDevice()->IsInScene() :
+                                   m_commonIntf->GetOptions()->legacyPresentGuard == D3DLegacyPresentGuard::Strict ?
+                                   false : true;
+        if (shouldPresent)
+          m_d3d9Device->Present(NULL, NULL, NULL, NULL);
       }
     }
 
@@ -375,18 +387,20 @@ namespace dxvk {
   HRESULT STDMETHODCALLTYPE DDraw7Surface::BltFast(DWORD dwX, DWORD dwY, LPDIRECTDRAWSURFACE7 lpDDSrcSurface, LPRECT lpSrcRect, DWORD dwTrans) {
     Logger::debug("<<< DDraw7Surface::BltFast: Proxy");
 
+    const D3DOptions* d3dOptions = m_commonIntf->GetOptions();
+
     // Write back any flippable surfaces or depth stencils from D3D9
     if (likely(lpDDSrcSurface != nullptr && m_commonIntf->IsWrappedSurface(lpDDSrcSurface))) {
       DDraw7Surface* sourceSurface = static_cast<DDraw7Surface*>(lpDDSrcSurface);
       if (unlikely(sourceSurface->GetCommonSurface()->IsGuardableSurface())) {
-        if (m_commonIntf->GetOptions()->backBufferWriteBack || m_commonIntf->GetOptions()->apitraceMode) {
+        if (d3dOptions->backBufferWriteBack || d3dOptions->forceLegacyPresent || d3dOptions->apitraceMode) {
           Logger::debug("DDraw7Surface::BltFast: Source surface is a swapchain surface");
 
-          if (unlikely(m_commonIntf->GetOptions()->apitraceMode && !sourceSurface->IsInitialized()))
+          if (unlikely(d3dOptions->apitraceMode && !sourceSurface->IsInitialized()))
             sourceSurface->InitializeOrUploadD3D9();
 
           if (likely(sourceSurface->IsInitialized()))
-            BlitToDDrawSurface<IDirectDrawSurface7, DDSURFACEDESC2>(sourceSurface->GetProxied(), sourceSurface->GetD3D9());
+            BlitToDDrawSurface<IDirectDrawSurface7, DDSURFACEDESC2>(sourceSurface->GetShadowOrProxied(), sourceSurface->GetD3D9());
         } else {
           static bool s_swapchainWarningShown;
 
@@ -394,7 +408,7 @@ namespace dxvk {
             Logger::warn("DDraw7Surface::BltFast: Source surface is a swapchain surface");
         }
       } else if (unlikely(sourceSurface->GetCommonSurface()->IsDepthStencil())) {
-        if (m_commonIntf->GetOptions()->depthWriteBack || m_commonIntf->GetOptions()->apitraceMode) {
+        if (d3dOptions->depthWriteBack || d3dOptions->apitraceMode) {
           Logger::debug("DDraw7Surface::BltFast: Source surface is a depth stencil");
 
           if (likely(sourceSurface->IsInitialized()))
@@ -411,12 +425,12 @@ namespace dxvk {
     RefreshD3D9Device();
     if (likely(m_d3d9Device != nullptr)) {
       const bool exclusiveMode = (m_commonIntf->GetCooperativeLevel() & DDSCL_EXCLUSIVE)
-                              && !m_commonIntf->GetOptions()->ignoreExclusiveMode;
+                              && !d3dOptions->ignoreExclusiveMode;
 
       // Eclusive mode back buffer guard
       if (exclusiveMode && m_commonIntf->HasDrawn() &&
           m_commonSurf->IsGuardableSurface() &&
-          m_commonIntf->GetOptions()->backBufferGuard != D3DBackBufferGuard::Disabled) {
+          d3dOptions->backBufferGuard != D3DBackBufferGuard::Disabled) {
         return DD_OK;
       // Windowed mode presentation path
       } else if (!exclusiveMode && m_commonIntf->HasDrawn() && m_commonSurf->IsPrimarySurface()) {
@@ -433,10 +447,10 @@ namespace dxvk {
         Logger::warn("DDraw7Surface::BltFast: Received an unwrapped source surface");
         return DDERR_UNSUPPORTED;
       }
-      hr = m_proxy->BltFast(dwX, dwY, lpDDSrcSurface, lpSrcRect, dwTrans);
+      hr = GetShadowOrProxied()->BltFast(dwX, dwY, lpDDSrcSurface, lpSrcRect, dwTrans);
     } else {
       DDraw7Surface* ddraw7Surface = static_cast<DDraw7Surface*>(lpDDSrcSurface);
-      hr = m_proxy->BltFast(dwX, dwY, ddraw7Surface->GetProxied(), lpSrcRect, dwTrans);
+      hr = GetShadowOrProxied()->BltFast(dwX, dwY, ddraw7Surface->GetShadowOrProxied(), lpSrcRect, dwTrans);
     }
 
     if (likely(SUCCEEDED(hr))) {
@@ -447,6 +461,15 @@ namespace dxvk {
           Logger::warn("DDraw7Surface::BltFast: Failed upload to d3d9 surface");
       } else {
         m_commonSurf->DirtyMipMaps();
+      }
+
+      if (unlikely(m_shadowSurf != nullptr && m_d3d9Device != nullptr)) {
+        const bool shouldPresent = m_commonIntf->GetOptions()->legacyPresentGuard == D3DLegacyPresentGuard::Auto ?
+                                  !m_commonIntf->GetCommonD3DDevice()->IsInScene() :
+                                   m_commonIntf->GetOptions()->legacyPresentGuard == D3DLegacyPresentGuard::Strict ?
+                                   false : true;
+        if (shouldPresent)
+          m_d3d9Device->Present(NULL, NULL, NULL, NULL);
       }
     }
 
@@ -575,29 +598,6 @@ namespace dxvk {
 
       m_commonIntf->ResetDrawTracking();
 
-      if (unlikely(m_commonIntf->GetOptions()->forceProxiedPresent)) {
-        D3DCommonDevice* commonDevice = m_commonIntf->GetCommonD3DDevice();
-
-        if (unlikely(!IsInitialized()))
-          InitializeD3D9(commonDevice->IsCurrentRenderTarget(this));
-
-        BlitToDDrawSurface<IDirectDrawSurface7, DDSURFACEDESC2>(m_proxy.ptr(), m_d3d9.ptr());
-
-        if (unlikely(!m_commonIntf->IsWrappedSurface(lpDDSurfaceTargetOverride))) {
-          if (unlikely(lpDDSurfaceTargetOverride != nullptr)) {
-            Logger::warn("DDraw7Surface::Flip: Received an unwrapped surface");
-            return DDERR_UNSUPPORTED;
-          }
-          if (likely(commonDevice->IsCurrentRenderTarget(this)))
-            m_commonIntf->SetFlipRTSurfaceAndFlags(lpDDSurfaceTargetOverride, dwFlags);
-          return m_proxy->Flip(lpDDSurfaceTargetOverride, dwFlags);
-        } else {
-          if (likely(commonDevice->IsCurrentRenderTarget(this)))
-            m_commonIntf->SetFlipRTSurfaceAndFlags(lpDDSurfaceTargetOverride, dwFlags);
-          return m_proxy->Flip(surf7->GetProxied(), dwFlags);
-        }
-      }
-
       // If the interface is waiting for VBlank and we get a no VSync flip, switch
       // to doing immediate presents by resetting the swapchain appropriately
       if (unlikely(m_commonIntf->GetWaitForVBlank() && (dwFlags & DDFLIP_NOVSYNC))) {
@@ -715,11 +715,6 @@ namespace dxvk {
 
   // Blitting can be done at any time and completes within its call frame
   HRESULT STDMETHODCALLTYPE DDraw7Surface::GetBltStatus(DWORD dwFlags) {
-    if (unlikely(m_commonIntf->GetOptions()->forceProxiedPresent)) {
-      Logger::debug("<<< DDraw7Surface::GetBltStatus: Proxy");
-      m_proxy->GetBltStatus(dwFlags);
-    }
-
     Logger::debug(">>> DDraw7Surface::GetBltStatus");
 
     if (likely(dwFlags == DDGBS_CANBLT || dwFlags == DDGBS_ISBLTDONE))
@@ -763,42 +758,36 @@ namespace dxvk {
   }
 
   HRESULT STDMETHODCALLTYPE DDraw7Surface::GetDC(HDC *lphDC) {
-    if (likely(!m_commonIntf->GetOptions()->forceProxiedPresent)) {
-      if (unlikely(lphDC == nullptr))
-        return DDERR_INVALIDPARAMS;
+    if (unlikely(lphDC == nullptr))
+      return DDERR_INVALIDPARAMS;
 
-      InitReturnPtr(lphDC);
+    InitReturnPtr(lphDC);
 
-      // Foward GetDC calls if we have drawn and the surface is flippable
-      RefreshD3D9Device();
-      if (m_d3d9Device != nullptr && (m_commonIntf->HasDrawn() &&
-                                      m_commonSurf->IsGuardableSurface())) {
-        Logger::debug(">>> DDraw7Surface::GetDC");
+    // Foward GetDC calls if we have drawn and the surface is flippable
+    RefreshD3D9Device();
+    if (m_d3d9Device != nullptr && (m_commonIntf->HasDrawn() &&
+                                    m_commonSurf->IsGuardableSurface())) {
+      Logger::debug(">>> DDraw7Surface::GetDC");
 
-        if (unlikely(!IsInitialized())) {
-          HRESULT hrUpload = InitializeOrUploadD3D9();
-          if (unlikely(FAILED(hrUpload)))
-            Logger::warn("DDraw7Surface::GetDC: Failed to initialize d3d9 surface");
-        }
-
-        HRESULT hr9 = m_d3d9->GetDC(lphDC);
-        if (unlikely(FAILED(hr9)))
-          Logger::warn("DDraw7Surface::GetDC: Failed D3D9 call");
-        return hr9;
+      if (unlikely(!IsInitialized())) {
+        HRESULT hrUpload = InitializeOrUploadD3D9();
+        if (unlikely(FAILED(hrUpload)))
+          Logger::warn("DDraw7Surface::GetDC: Failed to initialize d3d9 surface");
       }
+
+      HRESULT hr9 = m_d3d9->GetDC(lphDC);
+      if (unlikely(FAILED(hr9)))
+        Logger::warn("DDraw7Surface::GetDC: Failed D3D9 call");
+      return hr9;
     }
 
     Logger::debug("<<< DDraw7Surface::GetDC: Proxy");
-    return m_proxy->GetDC(lphDC);
+
+    return GetShadowOrProxied()->GetDC(lphDC);
   }
 
   // Flipping can be done at any time and completes within its call frame
   HRESULT STDMETHODCALLTYPE DDraw7Surface::GetFlipStatus(DWORD dwFlags) {
-    if (unlikely(m_commonIntf->GetOptions()->forceProxiedPresent)) {
-      Logger::debug("<<< DDraw7Surface::GetFlipStatus: Proxy");
-      m_proxy->GetFlipStatus(dwFlags);
-    }
-
     Logger::debug(">>> DDraw7Surface::GetFlipStatus");
 
     if (likely(dwFlags == DDGFS_CANFLIP || dwFlags == DDGFS_ISFLIPDONE))
@@ -870,16 +859,18 @@ namespace dxvk {
   HRESULT STDMETHODCALLTYPE DDraw7Surface::Lock(LPRECT lpDestRect, LPDDSURFACEDESC2 lpDDSurfaceDesc, DWORD dwFlags, HANDLE hEvent) {
     Logger::debug("<<< DDraw7Surface::Lock: Proxy");
 
+    const D3DOptions* d3dOptions = m_commonIntf->GetOptions();
+
     // Write back any flippable surfaces or depth stencils from D3D9
     if (unlikely(m_commonSurf->IsGuardableSurface())) {
-      if (m_commonIntf->GetOptions()->backBufferWriteBack || m_commonIntf->GetOptions()->apitraceMode) {
+      if (d3dOptions->backBufferWriteBack || d3dOptions->forceLegacyPresent || d3dOptions->apitraceMode) {
         Logger::debug("DDraw7Surface::Lock: Surface is a swapchain surface");
 
-        if (unlikely(m_commonIntf->GetOptions()->apitraceMode && !IsInitialized()))
+        if (unlikely(d3dOptions->apitraceMode && !IsInitialized()))
           InitializeOrUploadD3D9();
 
         if (likely(IsInitialized()))
-          BlitToDDrawSurface<IDirectDrawSurface7, DDSURFACEDESC2>(m_proxy.ptr(), m_d3d9.ptr());
+          BlitToDDrawSurface<IDirectDrawSurface7, DDSURFACEDESC2>(GetShadowOrProxied(), m_d3d9.ptr());
       } else {
         static bool s_swapchainWarningShown;
 
@@ -887,7 +878,7 @@ namespace dxvk {
           Logger::warn("DDraw7Surface::Lock: Surface is a swapchain surface");
       }
     } else if (unlikely(m_commonSurf->IsDepthStencil())) {
-      if (m_commonIntf->GetOptions()->depthWriteBack || m_commonIntf->GetOptions()->apitraceMode) {
+      if (d3dOptions->depthWriteBack || d3dOptions->apitraceMode) {
         Logger::debug("DDraw7Surface::Lock: Surface is a depth stencil");
 
         if (likely(IsInitialized()))
@@ -900,33 +891,31 @@ namespace dxvk {
       }
     }
 
-    return m_proxy->Lock(lpDestRect, lpDDSurfaceDesc, dwFlags, hEvent);
+    return GetShadowOrProxied()->Lock(lpDestRect, lpDDSurfaceDesc, dwFlags, hEvent);
   }
 
   HRESULT STDMETHODCALLTYPE DDraw7Surface::ReleaseDC(HDC hDC) {
-    if (likely(!m_commonIntf->GetOptions()->forceProxiedPresent)) {
-      // Foward ReleaseDC calls if we have drawn and the surface is flippable
-      RefreshD3D9Device();
-      if (m_d3d9Device != nullptr && (m_commonIntf->HasDrawn() &&
-                                      m_commonSurf->IsGuardableSurface())) {
-        Logger::debug(">>> DDraw7Surface::ReleaseDC");
+    // Foward ReleaseDC calls if we have drawn and the surface is flippable
+    RefreshD3D9Device();
+    if (m_d3d9Device != nullptr && (m_commonIntf->HasDrawn() &&
+                                    m_commonSurf->IsGuardableSurface())) {
+      Logger::debug(">>> DDraw7Surface::ReleaseDC");
 
-        if (unlikely(!IsInitialized())) {
-          HRESULT hrUpload = InitializeOrUploadD3D9();
-          if (unlikely(FAILED(hrUpload)))
-            Logger::warn("DDraw7Surface::ReleaseDC: Failed to initialize d3d9 surface");
-        }
-
-        HRESULT hr9 = m_d3d9->ReleaseDC(hDC);
-        if (unlikely(FAILED(hr9)))
-          Logger::warn("DDraw7Surface::ReleaseDC: Failed D3D9 call");
-        return hr9;
+      if (unlikely(!IsInitialized())) {
+        HRESULT hrUpload = InitializeOrUploadD3D9();
+        if (unlikely(FAILED(hrUpload)))
+          Logger::warn("DDraw7Surface::ReleaseDC: Failed to initialize d3d9 surface");
       }
+
+      HRESULT hr9 = m_d3d9->ReleaseDC(hDC);
+      if (unlikely(FAILED(hr9)))
+        Logger::warn("DDraw7Surface::ReleaseDC: Failed D3D9 call");
+      return hr9;
     }
 
     Logger::debug("<<< DDraw7Surface::ReleaseDC: Proxy");
 
-    HRESULT hr = m_proxy->ReleaseDC(hDC);
+    HRESULT hr = GetShadowOrProxied()->ReleaseDC(hDC);
 
     if (likely(SUCCEEDED(hr))) {
       // Textures and cubemaps get uploaded during SetTexture calls
@@ -997,7 +986,7 @@ namespace dxvk {
 
     // A nullptr lpDDPalette gets the current palette detached
     if (lpDDPalette == nullptr) {
-      HRESULT hr = m_proxy->SetPalette(lpDDPalette);
+      HRESULT hr = GetShadowOrProxied()->SetPalette(lpDDPalette);
       if (unlikely(FAILED(hr)))
         return hr;
 
@@ -1005,7 +994,7 @@ namespace dxvk {
     } else {
       DDrawPalette* ddrawPalette = static_cast<DDrawPalette*>(lpDDPalette);
 
-      HRESULT hr = m_proxy->SetPalette(ddrawPalette->GetProxied());
+      HRESULT hr = GetShadowOrProxied()->SetPalette(ddrawPalette->GetProxied());
       if (unlikely(FAILED(hr)))
         return hr;
 
@@ -1018,7 +1007,7 @@ namespace dxvk {
   HRESULT STDMETHODCALLTYPE DDraw7Surface::Unlock(LPRECT lpSurfaceData) {
     Logger::debug("<<< DDraw7Surface::Unlock: Proxy");
 
-    HRESULT hr = m_proxy->Unlock(lpSurfaceData);
+    HRESULT hr = GetShadowOrProxied()->Unlock(lpSurfaceData);
 
     if (likely(SUCCEEDED(hr))) {
       // Textures and cubemaps get uploaded during SetTexture calls
@@ -1028,6 +1017,16 @@ namespace dxvk {
           Logger::warn("DDraw7Surface::Unlock: Failed upload to d3d9 surface");
       } else {
         m_commonSurf->DirtyMipMaps();
+      }
+
+      RefreshD3D9Device();
+      if (unlikely(m_shadowSurf != nullptr && m_d3d9Device != nullptr)) {
+        const bool shouldPresent = m_commonIntf->GetOptions()->legacyPresentGuard == D3DLegacyPresentGuard::Auto ?
+                                  !m_commonIntf->GetCommonD3DDevice()->IsInScene() :
+                                   m_commonIntf->GetOptions()->legacyPresentGuard == D3DLegacyPresentGuard::Strict ?
+                                   false : true;
+        if (shouldPresent)
+          m_d3d9Device->Present(NULL, NULL, NULL, NULL);
       }
     }
 
@@ -1243,6 +1242,15 @@ namespace dxvk {
     }
 
     return DD_OK;
+  }
+
+  IDirectDrawSurface7* DDraw7Surface::GetShadowOrProxied() {
+    RefreshD3D9Device();
+
+    if (unlikely(m_shadowSurf != nullptr && m_d3d9Device != nullptr))
+      return m_shadowSurf->GetProxied();
+
+    return m_proxy.ptr();
   }
 
   HRESULT DDraw7Surface::InitializeD3D9RenderTarget() {
@@ -1681,6 +1689,9 @@ namespace dxvk {
       Logger::warn("DDraw7Surface::InitializeD3D9: Skipping initialization of unknown surface");
     }
 
+    if (m_shadowSurf != nullptr)
+      m_shadowSurf->SetD3D9(m_d3d9.ptr());
+
     // Depth stencils will not need uploads post initialization
     if (likely(!m_commonSurf->IsDepthStencil()))
       UploadSurfaceData();
@@ -1748,7 +1759,7 @@ namespace dxvk {
         }
       }
 
-      BlitToD3D9Surface<IDirectDrawSurface7, DDSURFACEDESC2>(m_d3d9.ptr(), format, m_proxy.ptr());
+      BlitToD3D9Surface<IDirectDrawSurface7, DDSURFACEDESC2>(m_d3d9.ptr(), format, GetShadowOrProxied());
     }
 
     return DD_OK;

--- a/src/ddraw/ddraw7/ddraw7_surface.h
+++ b/src/ddraw/ddraw7/ddraw7_surface.h
@@ -123,6 +123,16 @@ namespace dxvk {
 
     HRESULT STDMETHODCALLTYPE GetLOD(LPDWORD lod);
 
+    IDirectDrawSurface7* GetShadowOrProxied();
+
+    void SetShadowSurface(DDraw7Surface* shadowSurf) {
+      m_shadowSurf = shadowSurf;
+    }
+
+    DDraw7Surface* GetShadowSurface() const {
+      return m_shadowSurf.ptr();
+    }
+
     DDrawCommonSurface* GetCommonSurface() const {
       return m_commonSurf.ptr();
     }
@@ -209,6 +219,10 @@ namespace dxvk {
     std::array<IDirectDrawSurface7*, 6> m_cubeMapSurfaces;
 
     Com<d3d9::IDirect3DTexture9>        m_texture9;
+
+    // Offscreen plain surface we use to mask unwanted DDraw interactions, such
+    // as forced swapchain presents caused by blits/locks on primary surfaces
+    Com<DDraw7Surface>                  m_shadowSurf;
 
     // Back buffers will have depth stencil surfaces as attachments (in practice
     // I have never seen more than one depth stencil being attached at a time)

--- a/src/ddraw/ddraw_common_surface.h
+++ b/src/ddraw/ddraw_common_surface.h
@@ -317,6 +317,11 @@ namespace dxvk {
       return m_isGuardableSurface;
     }
 
+    bool Is8BitFormat() const {
+      return m_format9 == d3d9::D3DFMT_R3G3B2
+          || m_format9 == d3d9::D3DFMT_P8;
+    }
+
     HRESULT ValidateRTUsage() const {
       // Render targets require the DDSCAPS_3DDEVICE flag
       if (unlikely(!Is3DSurface())) {
@@ -367,10 +372,10 @@ namespace dxvk {
 
   private:
 
-    bool                      m_dirtyMipMaps  = false;
-    bool                      m_isAttached    = false;
-    bool                      m_isDesc2Set    = false;
-    bool                      m_isDescSet     = false;
+    bool                      m_dirtyMipMaps = false;
+    bool                      m_isAttached   = false;
+    bool                      m_isDesc2Set   = false;
+    bool                      m_isDescSet    = false;
 
     bool                      m_isTextureOrCubeMap      = false;
     bool                      m_isBackBufferOrFlippable = false;

--- a/src/ddraw/ddraw_format.h
+++ b/src/ddraw/ddraw_format.h
@@ -816,7 +816,7 @@ namespace dxvk {
     }
   }
 
-  // reverse blitter, used in the forceProxiedPresent logic
+  // reverse blitter, used in the forceLegacyPresent logic
   template <typename SurfaceType, typename DescType>
   inline void BlitToDDrawSurface(
       SurfaceType* surface,

--- a/src/ddraw/ddraw_gamma.cpp
+++ b/src/ddraw/ddraw_gamma.cpp
@@ -75,7 +75,7 @@ namespace dxvk {
 
     D3DCommonDevice* commonDevice = commonIntf->GetCommonD3DDevice();
     // For proxied pesentation we need to rely on ddraw to handle gamma
-    if (likely(commonDevice != nullptr && !commonIntf->GetOptions()->forceProxiedPresent)) {
+    if (likely(commonDevice != nullptr)) {
       Logger::debug("DDrawGammaControl::GetGammaRamp: Getting gamma ramp via D3D9");
 
       d3d9::IDirect3DDevice9* d3d9Device = commonDevice->GetD3D9Device();
@@ -104,7 +104,7 @@ namespace dxvk {
     if (likely(!commonIntf->GetOptions()->ignoreGammaRamp)) {
       D3DCommonDevice* commonDevice = commonIntf->GetCommonD3DDevice();
       // For proxied pesentation we need to rely on ddraw to handle gamma
-      if (likely(commonDevice != nullptr && !commonIntf->GetOptions()->forceProxiedPresent)) {
+      if (likely(commonDevice != nullptr)) {
         Logger::debug("DDrawGammaControl::SetGammaRamp: Setting gamma ramp via D3D9");
 
         d3d9::IDirect3DDevice9* d3d9Device = commonDevice->GetD3D9Device();

--- a/src/ddraw/ddraw_options.h
+++ b/src/ddraw/ddraw_options.h
@@ -13,8 +13,14 @@ namespace dxvk {
   };
 
   enum class D3DBackBufferGuard {
-    Disabled,
     Enabled,
+    Disabled,
+    Strict
+  };
+
+  enum class D3DLegacyPresentGuard {
+    Auto,
+    Disabled,
     Strict
   };
 
@@ -62,11 +68,14 @@ namespace dxvk {
     /// Upload or skip upload of depth stencils
     bool uploadDepthStencils;
 
-    /// Blits back to the proxied flippable surface and presents with DDraw
-    bool forceProxiedPresent;
+    /// Blits back to the proxied flippable surface and back again for presentation
+    bool forceLegacyPresent;
 
     /// Workaround that uses blits instead of flips for presentation
     bool forceBlitOnFlip;
+
+    /// By default guards against legacy presents while inside of a scene
+    D3DLegacyPresentGuard legacyPresentGuard;
 
     /// Ignore any application set gamma ramp
     bool ignoreGammaRamp;
@@ -107,12 +116,21 @@ namespace dxvk {
       this->backBufferWriteBack   = config.getOption<bool>   ("ddraw.backBufferWriteBack",   false);
       this->depthWriteBack        = config.getOption<bool>   ("ddraw.depthWriteBack",        false);
       this->uploadDepthStencils   = config.getOption<bool>   ("ddraw.uploadDepthStencils",    true);
-      this->forceProxiedPresent   = config.getOption<bool>   ("ddraw.forceProxiedPresent",   false);
+      this->forceLegacyPresent    = config.getOption<bool>   ("ddraw.forceLegacyPresent",    false);
       this->forceBlitOnFlip       = config.getOption<bool>   ("ddraw.forceBlitOnFlip",       false);
       this->ignoreGammaRamp       = config.getOption<bool>   ("ddraw.ignoreGammaRamp",       false);
       this->ignoreExclusiveMode   = config.getOption<bool>   ("ddraw.ignoreExclusiveMode",   false);
       this->autoGenMipMaps        = config.getOption<bool>   ("ddraw.autoGenMipMaps",        false);
       this->apitraceMode          = config.getOption<bool>   ("ddraw.apitraceMode",          false);
+
+      std::string legacyPresentGuardStr = Config::toLower(config.getOption<std::string>("ddraw.legacyPresentGuard", "auto"));
+      if (legacyPresentGuardStr == "strict") {
+        this->legacyPresentGuard = D3DLegacyPresentGuard::Strict;
+      } else if (legacyPresentGuardStr == "disabled") {
+        this->legacyPresentGuard = D3DLegacyPresentGuard::Disabled;
+      } else {
+        this->legacyPresentGuard = D3DLegacyPresentGuard::Auto;
+      }
 
       std::string emulateFSAAStr = Config::toLower(config.getOption<std::string>("ddraw.emulateFSAA", "auto"));
       if (emulateFSAAStr == "true") {

--- a/src/util/config/config.cpp
+++ b/src/util/config/config.cpp
@@ -1399,9 +1399,11 @@ namespace dxvk {
       { "d3d9.maxFrameRate",                 "-60" },
       { "ddraw.backBufferGuard",          "Strict" },
     }} },
-    /* Startopia                                  */
+    /* Startopia                                  *
+     * Fixes missing menu background color        */
     { R"(\\startopia\.exe$)", {{
-      { "ddraw.forceProxiedPresent",        "True" },
+      { "ddraw.forceLegacyPresent",         "True" },
+      { "ddraw.backBufferGuard",        "Disabled" },
     }} },
     /* Escape from Monkey Island                  *
      * Fixes broken physics, and flip logic       */
@@ -1439,37 +1441,37 @@ namespace dxvk {
     }} },
     /* Dungeon Siege                              */
     { R"(\\DungeonSiege\.exe$)", {{
-      { "ddraw.forceProxiedPresent",        "True" },
+      { "ddraw.forceLegacyPresent",         "True" },
       { "ddraw.backBufferWriteBack",        "True" },
     }} },
     /* Empire Earth / Art of Conquest             */
     { R"(\\(Empire Earth|EE-AOC)\.exe$)", {{
-      { "ddraw.forceProxiedPresent",        "True" },
+      { "ddraw.forceLegacyPresent",         "True" },
     }} },
     /* Etherlords                                 *
      * Needs R3G3B2 support for text rendering    */
     { R"(\\Etherlords\.exe$)", {{
-      { "ddraw.forceProxiedPresent",        "True" },
+      { "ddraw.forceLegacyPresent",         "True" },
       { "ddraw.supportR3G3B2",              "True" },
     }} },
     /* Etherlords 2                               *
      * Needs R3G3B2 support for text rendering    */
     { R"(\\Etherlords2\.exe$)", {{
-      { "ddraw.forceProxiedPresent",        "True" },
+      { "ddraw.forceLegacyPresent",         "True" },
       { "ddraw.supportR3G3B2",              "True" },
     }} },
     /* Evil Islands                               */
     { R"(\\Evil Islands\\game\.exe$)", {{
-      { "ddraw.forceProxiedPresent",        "True" },
+      { "ddraw.forceLegacyPresent",         "True" },
     }} },
     /* Star Trek: Armada                          */
     { R"(\\Armada\.exe$)", {{
-      { "ddraw.forceProxiedPresent",        "True" },
+      { "ddraw.forceLegacyPresent",         "True" },
     }} },
     /* SCP - Containment Breach                   *
      * Crashes without multithreading protection  */
     { R"(\\SCP - Containment Breach\.exe$)", {{
-      { "ddraw.forceProxiedPresent",        "True" },
+      { "ddraw.forceLegacyPresent",         "True" },
       { "ddraw.emulateFSAA",                "True" },
       { "ddraw.forceMultiThreaded",         "True" },
     }} },
@@ -1578,7 +1580,7 @@ namespace dxvk {
     }} },
     /* The Mystery of the Druids                  */
     { R"(\\edd\.exe$)", {{
-      { "ddraw.forceProxiedPresent",        "True" },
+      { "ddraw.forceLegacyPresent",         "True" },
     }} },
     /* Silent Hunter II - Broken input handling   */
     { R"(\\Silent Hunter.*\\(Sim|Shell(1)?)\.exe$)", {{
@@ -1586,11 +1588,12 @@ namespace dxvk {
     }} },
     /* Enemy Engaged: Comanche vs Hokum           */
     { R"(\\cohokum\.exe$)", {{
-      { "ddraw.forceProxiedPresent",        "True" },
+      { "ddraw.forceLegacyPresent",         "True" },
     }} },
     /* The Nations (Gold Edition)                 */
     { R"(\\The Nations.*\\bin\\game\.exe$)", {{
-      { "ddraw.forceProxiedPresent",        "True" },
+      { "ddraw.forceLegacyPresent",         "True" },
+      { "ddraw.legacyPresentGuard",       "Strict" },
     }} },
     /* Need for Speed: Porsche Unleashed          *
      * Fixes missing mip maps on car models       */
@@ -1604,7 +1607,7 @@ namespace dxvk {
      * buffer mapping on T&L devices              */
     { R"(\\SoulbringeVC(noeax)?\.exe$)", {{
       { "d3d9.allowDirectBufferMapping",   "False" },
-      { "ddraw.forceProxiedPresent",        "True" },
+      { "ddraw.forceLegacyPresent",         "True" },
     }} },
     /* Star Trek: Deep Space Nine - The Fallen    *
      * Fixes missing mip map uploads              */
@@ -1618,36 +1621,32 @@ namespace dxvk {
     }} },
     /* StarLancer                                 */
     { R"(\\Lancer\.exe$)", {{
-      { "ddraw.forceProxiedPresent",        "True" },
+      { "ddraw.forceLegacyPresent",         "True" },
     }} },
     /* The Settlers IV                            */
     { R"(\\S4_Main\.exe$)", {{
-      { "ddraw.forceProxiedPresent",        "True" },
+      { "ddraw.forceLegacyPresent",         "True" },
     }} },
     /* Spider-Man (2001) - broken cutscenes       */
     { R"(\\SpideyPC\.exe$)", {{
       { "d3d9.maxFrameRate",                  "30" },
     }} },
-    /* Wizards & Warriors                         */
-    { R"(\\deep6\.exe$)", {{
-      { "ddraw.forceProxiedPresent",        "True" },
-    }} },
     /* Age of Wonders: Shadow Magic               */
     { R"(\\AoWSM(Compat)?\.exe$)", {{
-      { "ddraw.forceProxiedPresent",        "True" },
+      { "ddraw.forceLegacyPresent",         "True" },
     }} },
     /* Age of Wonders II: The Wizard's Throne     */
     { R"(\\AoW2\.exe$)", {{
-      { "ddraw.forceProxiedPresent",        "True" },
+      { "ddraw.forceLegacyPresent",         "True" },
     }} },
     /* Hard Truck 2: King of the Road             */
     { R"(\\king\.exe$)", {{
       { "ddraw.colorKeyCompatibility",      "True" },
-      { "ddraw.forceProxiedPresent",        "True" },
+      { "ddraw.forceLegacyPresent",         "True" },
     }} },
     /* Anno 1503                                  */
     { R"(\\1503Startup\.exe$)", {{
-      { "ddraw.forceProxiedPresent",        "True" },
+      { "ddraw.forceLegacyPresent",         "True" },
     }} },
     /* Knight Rider: The Game                     *
      * Fixes in-game vehicle environment maps     *
@@ -1695,13 +1694,17 @@ namespace dxvk {
     }} },
     /* Space Empires V                            */
     { R"(\\SE5\.exe$)", {{
-      { "ddraw.forceProxiedPresent",        "True" },
+      { "ddraw.forceLegacyPresent",         "True" },
     }} },
     /* Will Rock                                  *
      * Fixes missing save game screenshots        */
     { R"(\\WillRock\.exe$)", {{
       { "ddraw.emulateFSAA",                "True" },
       { "ddraw.backBufferWriteBack",        "True" },
+    }} },
+    /* FIFA 2001                                  */
+    { R"(\\fifa2001\.exe$)", {{
+      { "ddraw.forceLegacyPresent",         "True" },
     }} },
 
     /**********************************************/
@@ -1726,11 +1729,11 @@ namespace dxvk {
     }} },
     /* Might and Magic VII: For Blood and Honor   */
     { R"(\\MM7(-Rel)?\.exe$)", {{
-      { "ddraw.forceProxiedPresent",        "True" },
+      { "ddraw.forceLegacyPresent",         "True" },
     }} },
     /* Might and Magic VIII: Day of the Destroyer */
     { R"(\\MM8(-Rel)?\.exe$)", {{
-      { "ddraw.forceProxiedPresent",        "True" },
+      { "ddraw.forceLegacyPresent",         "True" },
     }} },
     /* Omikron: The Nomad Soul                    *
      * Lights and other effects break over 30 FPS.*
@@ -1738,7 +1741,7 @@ namespace dxvk {
      * missing without proxy presentation.        */
     { R"(\\Omikron.*\\Runtime\.exe$)", {{
       { "d3d9.maxFrameRate",                  "30" },
-      { "ddraw.forceProxiedPresent",        "True" },
+      { "ddraw.forceLegacyPresent",         "True" },
     }} },
     /* Urban Chaos                                *
      * Uses windowed present mode in full-screen  *
@@ -1750,7 +1753,7 @@ namespace dxvk {
     /* Redline - Fixes missing weapon mip maps    */
     { R"(\\Redline\.exe$)", {{
       { "ddraw.autoGenMipMaps",             "True" },
-      { "ddraw.forceProxiedPresent",        "True" },
+      { "ddraw.forceLegacyPresent",         "True" },
     }} },
     /* 3DMark 99 (Max) - Enables VSync by default *
      * (probably due to hardware and/or driver    *
@@ -1767,7 +1770,7 @@ namespace dxvk {
     }} },
     /* Dungeon Keeper 2                           */
     { R"(\\DKII(-DX)?\.exe$)", {{
-      { "ddraw.forceProxiedPresent",        "True" },
+      { "ddraw.ignoreExclusiveMode",        "True" },
     }} },
     /* Star Wars: Rogue Squadron 3D               */
     { R"(\\Rogue Squadron\.exe$)", {{
@@ -1775,24 +1778,27 @@ namespace dxvk {
     }} },
     /* Blood II: The Chosen                       */
     { R"(\\Blood.*\\Client\.exe$)", {{
-      { "ddraw.forceProxiedPresent",        "True" },
+      { "d3d9.maxFrameRate",                 "-60" },
+      { "ddraw.forceLegacyPresent",         "True" },
     }} },
     /* Shogo: Mobile Armor Division               */
     { R"(\\Shogo.*\\Client\.exe$)", {{
-      { "ddraw.forceProxiedPresent",        "True" },
+      { "d3d9.maxFrameRate",                 "-60" },
+      { "ddraw.forceLegacyPresent",         "True" },
     }} },
     /* KISS: Psycho Circus - The Nightmare Child  */
     { R"(\\(KISS.*|Psycho.*)\\client\.exe$)", {{
-      { "ddraw.forceProxiedPresent",        "True" },
+      { "d3d9.maxFrameRate",                 "-60" },
+      { "ddraw.forceLegacyPresent",         "True" },
     }} },
     /* Enemy Engaged: Apache vs Havoc             */
     { R"(\\aphavoc\.exe$)", {{
-      { "ddraw.forceProxiedPresent",        "True" },
+      { "ddraw.forceLegacyPresent",         "True" },
     }} },
     /* Star Trek: Starfleet Command               */
     { R"(\\Starfleet\.exe$)", {{
       { "ddraw.forceMultiThreaded",         "True" },
-      { "ddraw.forceProxiedPresent",        "True" },
+      { "ddraw.forceLegacyPresent",         "True" },
     }} },
     /* Expendable                                 */
     { R"(\\Expendable\\go_start\.exe$)", {{
@@ -1800,7 +1806,7 @@ namespace dxvk {
     }} },
     /* F/A-18E Super Hornet                       */
     { R"(\\F18\.exe$)", {{
-      { "ddraw.forceProxiedPresent",        "True" },
+      { "ddraw.forceLegacyPresent",         "True" },
     }} },
     /* Total Annihilation: Kingdoms               */
     { R"(\\KINGDOMS\.icd$)", {{
@@ -1814,11 +1820,11 @@ namespace dxvk {
     /* Gorky 17 - Fixes crash on game start       */
     { R"(\\gorky17\.exe$)", {{
       { "ddraw.depthWriteBack",             "True" },
-      { "ddraw.forceProxiedPresent",        "True" },
+      { "ddraw.forceLegacyPresent",         "True" },
     }} },
     /* Revenant                                   */
     { R"(\\Revenant\.exe$)", {{
-      { "ddraw.forceProxiedPresent",        "True" },
+      { "ddraw.forceLegacyPresent",         "True" },
     }} },
     /* Re-Volt                                    */
     { R"(\\revolt\.exe$)", {{
@@ -1828,10 +1834,6 @@ namespace dxvk {
     { R"(\\Sea Dogs\\ENGINE\.exe$)", {{
       { "ddraw.emulateFSAA",                "True" },
     }} },
-    /* Empire of the Ants                         */
-    { R"(\\Empire of the Ants\\Game\.exe$)", {{
-      { "ddraw.forceProxiedPresent",        "True" },
-    }} },
     /* Slave Zero - will not start in 32-bit      *
      * color mode without D32 support             */
     { R"(\\SlaveZero\.exe$)", {{
@@ -1840,7 +1842,7 @@ namespace dxvk {
     /* Nocturne                                   */
     { R"(\\nocturne\.exe$)", {{
       { "ddraw.depthWriteBack",             "True" },
-      { "ddraw.forceProxiedPresent",        "True" },
+      { "ddraw.forceLegacyPresent",         "True" },
     }} },
     /* Arabian Nights                             *
      * Fixes flickering during level load         */
@@ -1850,12 +1852,13 @@ namespace dxvk {
     /* Metal Fatigue                              *
      * Fixes unit and building transparency       */
     { R"(\\MFatigue\.exe$)", {{
-      { "ddraw.forceProxiedPresent",        "True" },
+      { "ddraw.forceLegacyPresent",         "True" },
       { "ddraw.colorKeyCompatibility",      "True" },
     }} },
     /* Simon The Sorcerer 3D                      *
      * Fixes Z-fighting artifacts with D16        */
     { R"(\\Simon3D\.exe$)", {{
+      { "ddraw.forceLegacyPresent",         "True" },
       { "ddraw.supportD16",                "False" },
     }} },
     /* Crusaders of Might and Magic               */
@@ -1878,11 +1881,22 @@ namespace dxvk {
     { R"(\\POP3D(Demo)?\.exe$)", {{
       { "d3d9.cachedWriteOnlyBuffers",      "True" },
       { "ddraw.colorKeyCompatibility",      "True" },
-      { "ddraw.forceProxiedPresent",        "True" },
+      { "ddraw.forceLegacyPresent",         "True" },
     }} },
     /* Jurassic Park: Trespasser                  */
     { R"(\\trespass\.exe$)", {{
-      { "ddraw.forceProxiedPresent",        "True" },
+      { "ddraw.forceLegacyPresent",         "True" },
+    }} },
+    /* Wizards & Warriors                         */
+    { R"(\\deep6\.exe$)", {{
+      { "ddraw.forceLegacyPresent",         "True" },
+    }} },
+    /* Divine Divinity                            *
+     * Fixes black screen during intros and some  *
+     * absent subtitles during loading screens    */
+    { R"(\\div\.exe$)", {{
+      { "ddraw.backBufferWriteBack",        "True" },
+      { "ddraw.backBufferGuard",        "Disabled" },
     }} },
 
     /**********************************************/
@@ -1890,11 +1904,15 @@ namespace dxvk {
     /**********************************************/
     /* Descent: FreeSpace - The Great War         */
     { R"(\\FS\.exe$)", {{
-      { "ddraw.forceProxiedPresent",        "True" },
+      { "ddraw.forceLegacyPresent",         "True" },
     }} },
     /* Populous: The Beginning                    */
     { R"(\\D3DPopTB(UW)?\.exe$)", {{
-      { "ddraw.forceProxiedPresent",        "True" },
+      { "ddraw.forceLegacyPresent",         "True" },
+    }} },
+    /* Empire of the Ants                         */
+    { R"(\\Empire of the Ants\\Game\.exe$)", {{
+      { "ddraw.forceLegacyPresent",         "True" },
     }} },
     /* N.I.C.E 2 - Fixes main menu flickering     */
     { R"(\\n2_(std|arc)\.exe$)", {{
@@ -1903,7 +1921,7 @@ namespace dxvk {
     }} },
     /* Twisted Metal 2                            */
     { R"(\\tm2\.exe$)", {{
-      { "ddraw.forceProxiedPresent",        "True" },
+      { "ddraw.forceLegacyPresent",         "True" },
     }} },
     /* Mobil 1 Rally Championship                 *
      * Crashes on certain tracks above 30 FPS     */
@@ -1924,29 +1942,32 @@ namespace dxvk {
     }} },
     /* FIFA '99                                   */
     { R"(\\fifa99\.exe$)", {{
+      { "ddraw.forceLegacyPresent",         "True" },
       { "ddraw.emulateFSAA",                "True" },
     }} },
     /* The Longest Journey                        */
     { R"(\\The Longest Journey\\game\.exe$)", {{
-      { "ddraw.forceProxiedPresent",        "True" },
+      { "ddraw.forceLegacyPresent",         "True" },
     }} },
     /* Wing Commander: Prophecy                   */
     { R"(\\prophecy\.exe$)", {{
-      { "ddraw.forceProxiedPresent",        "True" },
+      { "ddraw.forceLegacyPresent",         "True" },
     }} },
     /* Tom Clancy's Rainbow Six                   *
      * Fixes broken color key transparency        */
     { R"(\\RainbowSix\.exe$)", {{
-      { "ddraw.forceProxiedPresent",        "True" },
+      { "ddraw.forceLegacyPresent",         "True" },
       { "ddraw.colorKeyCompatibility",      "True" },
     }} },
     /* Incoming - fixes load screen flickering    */
     { R"(\\incoming\.exe$)", {{
       { "ddraw.forceSingleBackBuffer",      "True" },
     }} },
-    /* Lands of Lore III                          */
+    /* Lands of Lore III                          *
+     * Fixes black screeen during video sequences */
     { R"(\\LOL3\.dat$)", {{
-      { "ddraw.forceProxiedPresent",        "True" },
+      { "ddraw.forceLegacyPresent",         "True" },
+      { "ddraw.backBufferGuard",        "Disabled" },
     }} },
     /* Virtua Fighter 2                           */
     { R"(\\VF2\.exe$)", {{
@@ -1960,15 +1981,19 @@ namespace dxvk {
     }} },
     /* RoBoRumble                                 */
     { R"(\\rr_dx5\.exe$)", {{
-      { "ddraw.forceProxiedPresent",        "True" },
+      { "ddraw.forceLegacyPresent",         "True" },
     }} },
     /* Warhammer: Dark Omen                       *
      * Works around the game trying to attach     *
      * a back buffer to the primary surface       */
     { R"(\\DarkOmen\.exe$)", {{
-      { "ddraw.forceProxiedPresent",        "True" },
+      { "ddraw.forceLegacyPresent",         "True" },
       { "ddraw.emulateFSAA",                "True" },
       { "ddraw.forceBlitOnFlip",            "True" },
+    }} },
+    /* Darkstone                                 */
+    { R"(\\Darkstone\.exe$)", {{
+      { "ddraw.forceLegacyPresent",         "True" },
     }} },
 
     /**********************************************/
@@ -1980,11 +2005,11 @@ namespace dxvk {
     }} },
     /* Star Wars: Jedi Knight: Dark Forces II     */
     { R"(\\JK\.exe$)", {{
-      { "ddraw.forceProxiedPresent",        "True" },
+      { "ddraw.forceLegacyPresent",         "True" },
     }} },
     /* Star Wars: Jedi Knight: Mysteries of the Sith */
     { R"(\\JKM\.exe$)", {{
-      { "ddraw.forceProxiedPresent",        "True" },
+      { "ddraw.forceLegacyPresent",         "True" },
     }} },
     /* Moto Racer 2 - fixes menu flickering       */
     { R"(\\moto\.exe$)", {{
@@ -1992,15 +2017,16 @@ namespace dxvk {
     }} },
     /* Monster Truck Madness                      */
     { R"(\\MONSTER\.EXE$)", {{
-      { "ddraw.forceProxiedPresent",        "True" },
+      { "ddraw.backBufferWriteBack",        "True" },
+      { "ddraw.backBufferGuard",        "Disabled" },
     }} },
     /* Forsaken                                   */
     { R"(\\ForsakenHW\.exe$)", {{
-      { "ddraw.forceProxiedPresent",        "True" },
+      { "ddraw.forceLegacyPresent",         "True" },
     }} },
     /* MDK                                        */
     { R"(\\MDKD3D\.exe$)", {{
-      { "ddraw.forceProxiedPresent",        "True" },
+      { "ddraw.forceLegacyPresent",         "True" },
     }} },
     /* POD                                        *
      * Fixes missing HUD elements                 */


### PR DESCRIPTION
Time to get rid of the janky proxied presentation path and introduce a "legacy" presentation path that uses Vulkan, by moving the final image back to the d3d9 backend before presentation.

The elephant in the room are the shadow surfaces created for each primary surface, in order to allow us to circumvent WineD3D's behavior of presenting during blits/locks/any form of copies on primary surfaces. Mind you, this is *correct* behavior, but gets in our way by causing swapchain in-fighting. We simply side-step the problem by using a shadow offscreen surface for any blits/locks/copies and swap it out for the primary surface where needed, while WineD3D sees no primary surface operations, so remains dormant.

This will cause several regressions, but will also fix a lot of pending issues, and the approach is generally beneficial, as we no longer rely on WineD3D's DDraw swapchain for presentation.