### PR TITLE
[meta] Move all d3d9 objects to common interface objects

### DIFF
--- a/src/ddraw/d3d3/d3d3_device.cpp
+++ b/src/ddraw/d3d3/d3d3_device.cpp
@@ -26,7 +26,7 @@ namespace dxvk {
         d3d9::D3DPRESENT_PARAMETERS Params9,
         Com<d3d9::IDirect3DDevice9>&& pDevice9,
         DWORD CreationFlags9)
-    : DDrawWrappedObject<DDrawSurface, IDirect3DDevice, d3d9::IDirect3DDevice9>(pParent, std::move(d3d3DeviceProxy), std::move(pDevice9))
+    : DDrawWrappedObject<DDrawSurface, IDirect3DDevice>(pParent, std::move(d3d3DeviceProxy))
     , m_commonD3DDevice ( commonD3DDevice )
     , m_multithread ( CreationFlags9 & D3DCREATE_MULTITHREADED )
     , m_desc ( Desc )
@@ -39,33 +39,42 @@ namespace dxvk {
       throw DxvkError("D3D3Device: ERROR! Failed to retrieve the common interface!");
     }
 
-    // Get the bridge interface to D3D9
-    if (unlikely(FAILED(m_d3d9->QueryInterface(__uuidof(IDxvkD3D8Bridge), reinterpret_cast<void**>(&m_bridge))))) {
-      throw DxvkError("D3D3Device: ERROR! Failed to get D3D9 Bridge. d3d9.dll might not be DXVK!");
-    }
+    d3d9::IDirect3DDevice9* device9;
 
     if (likely(m_commonD3DDevice == nullptr)) {
-      m_commonD3DDevice = new D3DCommonDevice(m_commonIntf, deviceGUID, Params9, CreationFlags9,
-                                              m_bridge->DetermineInitialTextureMemory());
+      m_commonD3DDevice = new D3DCommonDevice(m_commonIntf, deviceGUID, Params9, CreationFlags9);
 
-      // Update D3D9 legacy light state
-      m_bridge->SetLegacyLightsState(true);
+      m_commonD3DDevice->SetD3D9Device(std::move(pDevice9));
+      device9 = m_commonD3DDevice->GetD3D9Device();
 
       const D3DOptions* d3dOptions = m_commonIntf->GetOptions();
 
       if (unlikely(d3dOptions->emulateFSAA == FSAAEmulation::Forced)) {
         Logger::warn("D3D3Device: Force enabling AA");
-        m_d3d9->SetRenderState(d3d9::D3DRS_MULTISAMPLEANTIALIAS, TRUE);
+        device9->SetRenderState(d3d9::D3DRS_MULTISAMPLEANTIALIAS, TRUE);
       }
 
       // The default value of D3DRENDERSTATE_TEXTUREMAPBLEND in D3D3 is D3DTBLEND_MODULATE
-      m_d3d9->SetTextureStageState(0, d3d9::D3DTSS_COLORARG1, D3DTA_TEXTURE);
-      m_d3d9->SetTextureStageState(0, d3d9::D3DTSS_ALPHAARG1, D3DTA_TEXTURE);
-      m_d3d9->SetTextureStageState(0, d3d9::D3DTSS_COLOROP,   D3DTOP_MODULATE);
-      m_d3d9->SetTextureStageState(0, d3d9::D3DTSS_ALPHAOP,   D3DTOP_SELECTARG1);
-      m_d3d9->SetTextureStageState(0, d3d9::D3DTSS_COLORARG2, D3DTA_DIFFUSE);
-      m_d3d9->SetTextureStageState(0, d3d9::D3DTSS_ALPHAARG2, D3DTA_DIFFUSE);
+      device9->SetTextureStageState(0, d3d9::D3DTSS_COLORARG1, D3DTA_TEXTURE);
+      device9->SetTextureStageState(0, d3d9::D3DTSS_ALPHAARG1, D3DTA_TEXTURE);
+      device9->SetTextureStageState(0, d3d9::D3DTSS_COLOROP,   D3DTOP_MODULATE);
+      device9->SetTextureStageState(0, d3d9::D3DTSS_ALPHAOP,   D3DTOP_SELECTARG1);
+      device9->SetTextureStageState(0, d3d9::D3DTSS_COLORARG2, D3DTA_DIFFUSE);
+      device9->SetTextureStageState(0, d3d9::D3DTSS_ALPHAARG2, D3DTA_DIFFUSE);
+    } else {
+      device9 = m_commonD3DDevice->GetD3D9Device();
     }
+
+    // Get the bridge interface to D3D9
+    if (unlikely(FAILED(device9->QueryInterface(__uuidof(IDxvkD3D8Bridge), reinterpret_cast<void**>(&m_bridge))))) {
+      throw DxvkError("D3D3Device: ERROR! Failed to get D3D9 Bridge. d3d9.dll might not be DXVK!");
+    }
+
+    if (unlikely(!m_commonD3DDevice->GetTotalTextureMemory()))
+      m_commonD3DDevice->SetTotalTextureMemory(m_bridge->DetermineInitialTextureMemory());
+
+    // Update D3D9 legacy light state
+    m_bridge->SetLegacyLightsState(true);
 
     if (m_commonD3DDevice->GetOrigin() == nullptr)
       m_commonD3DDevice->SetOrigin(this);
@@ -402,7 +411,7 @@ namespace dxvk {
     if (unlikely(m_commonD3DDevice->IsInScene()))
       return D3DERR_SCENE_IN_SCENE;
 
-    HRESULT hr = m_d3d9->BeginScene();
+    HRESULT hr = m_commonD3DDevice->GetD3D9Device()->BeginScene();
 
     if (likely(SUCCEEDED(hr)))
       m_commonD3DDevice->SetInScene(true);
@@ -420,7 +429,7 @@ namespace dxvk {
     if (unlikely(!m_commonD3DDevice->IsInScene()))
       return D3DERR_SCENE_NOT_IN_SCENE;
 
-    HRESULT hr = m_d3d9->EndScene();
+    HRESULT hr = m_commonD3DDevice->GetD3D9Device()->EndScene();
 
     if (likely(SUCCEEDED(hr)))
       m_commonD3DDevice->SetInScene(false);
@@ -475,6 +484,8 @@ namespace dxvk {
 
     if (unlikely(buffer == nullptr || viewport == nullptr))
       return DDERR_INVALIDPARAMS;
+
+    d3d9::IDirect3DDevice9* device9 = m_commonD3DDevice->GetD3D9Device();
 
     D3D3ExecuteBuffer* d3d3ExecuteBuffer = static_cast<D3D3ExecuteBuffer*>(buffer);
     D3D3Viewport* d3d3Viewport = static_cast<D3D3Viewport*>(viewport);
@@ -671,7 +682,7 @@ namespace dxvk {
 
                 pvData.lights = &lights9;
 
-                ProcessVerticesSW(m_d3d9.ptr(), m_commonIntf->GetOptions(), &pvData);
+                ProcessVerticesSW(device9, m_commonIntf->GetOptions(), &pvData);
 
                 break;
               }
@@ -732,7 +743,7 @@ namespace dxvk {
             if (unlikely(FAILED(hr)))
               continue;
 
-            hr = m_d3d9->SetTransform(ConvertTransformState(s.dtstTransformStateType), &matrix);
+            hr = device9->SetTransform(ConvertTransformState(s.dtstTransformStateType), &matrix);
             if (likely(SUCCEEDED(hr))) {
               if (s.dtstTransformStateType == D3DTRANSFORMSTATE_WORLD) {
                 m_worldHandle = s.dwArg[0];
@@ -855,7 +866,7 @@ namespace dxvk {
     }
 
     if (transformType) {
-      HRESULT hr = m_d3d9->SetTransform(ConvertTransformState(transformType), matrix);
+      HRESULT hr = m_commonD3DDevice->GetD3D9Device()->SetTransform(ConvertTransformState(transformType), matrix);
       if (unlikely(FAILED(hr)))
         Logger::warn("D3D3Device::SetMatrix: Failed to update D3D9 transform");
     }
@@ -909,6 +920,8 @@ namespace dxvk {
   }
 
   void D3D3Device::InitializeDS() {
+    d3d9::IDirect3DDevice9* device9 = m_commonD3DDevice->GetD3D9Device();
+
     m_rt->InitializeD3D9RenderTarget();
 
     m_ds = m_rt->GetAttachedDepthStencil();
@@ -928,20 +941,20 @@ namespace dxvk {
         m_ds->GetProxied()->GetSurfaceDesc(&descDS);
         Logger::debug(str::format("D3D3Device::InitializeDS: DepthStencil: ", descDS.dwWidth, "x", descDS.dwHeight));
 
-        HRESULT hrDS9 = m_d3d9->SetDepthStencilSurface(m_ds->GetD3D9());
+        HRESULT hrDS9 = device9->SetDepthStencilSurface(m_ds->GetCommonSurface()->GetD3D9Surface());
         if(unlikely(FAILED(hrDS9))) {
           Logger::err("D3D3Device::InitializeDS: Failed to set D3D9 depth stencil");
         } else {
           // This needs to act like an auto depth stencil of sorts, so manually enable z-buffering
-          m_d3d9->SetRenderState(d3d9::D3DRS_ZENABLE, d3d9::D3DZB_TRUE);
+          device9->SetRenderState(d3d9::D3DRS_ZENABLE, d3d9::D3DZB_TRUE);
         }
       }
     } else if (m_commonD3DDevice->GetD3D5Device() == nullptr &&
                m_commonD3DDevice->GetD3D6Device() == nullptr) {
       Logger::info("D3D3Device::InitializeDS: RT has no depth stencil attached");
-      m_d3d9->SetDepthStencilSurface(nullptr);
+      device9->SetDepthStencilSurface(nullptr);
       // Should be superfluous, but play it safe
-      m_d3d9->SetRenderState(d3d9::D3DRS_ZENABLE, d3d9::D3DZB_FALSE);
+      device9->SetRenderState(d3d9::D3DRS_ZENABLE, d3d9::D3DZB_FALSE);
     }
   }
 
@@ -988,6 +1001,8 @@ namespace dxvk {
   inline HRESULT STDMETHODCALLTYPE D3D3Device::SetLightStateInternal(D3DLIGHTSTATETYPE dwLightStateType, DWORD dwLightState) {
     Logger::debug(">>> D3D3Device::SetLightStateInternal");
 
+    d3d9::IDirect3DDevice9* device9 = m_commonD3DDevice->GetD3D9Device();
+
     switch (dwLightStateType) {
       case D3DLIGHTSTATE_MATERIAL: {
         if (unlikely(!dwLightState)) {
@@ -1003,7 +1018,7 @@ namespace dxvk {
 
           m_commonD3DDevice->SetCurrentMaterialHandle(dwLightState);
           Logger::debug(str::format("D3D3Device::SetLightStateInternal: Applying material nr. ", dwLightState, " to D3D9"));
-          m_d3d9->SetMaterial(material9);
+          device9->SetMaterial(material9);
         } else {
           Logger::warn("D3D3Device::SetLightStateInternal: Unable to set D3D9 material");
         }
@@ -1011,23 +1026,23 @@ namespace dxvk {
         break;
       }
       case D3DLIGHTSTATE_AMBIENT:
-        m_d3d9->SetRenderState(d3d9::D3DRS_AMBIENT, dwLightState);
+        device9->SetRenderState(d3d9::D3DRS_AMBIENT, dwLightState);
         break;
       case D3DLIGHTSTATE_COLORMODEL:
         if (unlikely(dwLightState != D3DCOLOR_RGB))
           Logger::warn("D3D3Device::SetLightStateInternal: Unsupported D3DLIGHTSTATE_COLORMODEL");
         break;
       case D3DLIGHTSTATE_FOGMODE:
-        m_d3d9->SetRenderState(d3d9::D3DRS_FOGVERTEXMODE, dwLightState);
+        device9->SetRenderState(d3d9::D3DRS_FOGVERTEXMODE, dwLightState);
         break;
       case D3DLIGHTSTATE_FOGSTART:
-        m_d3d9->SetRenderState(d3d9::D3DRS_FOGSTART, dwLightState);
+        device9->SetRenderState(d3d9::D3DRS_FOGSTART, dwLightState);
         break;
       case D3DLIGHTSTATE_FOGEND:
-        m_d3d9->SetRenderState(d3d9::D3DRS_FOGEND, dwLightState);
+        device9->SetRenderState(d3d9::D3DRS_FOGEND, dwLightState);
         break;
       case D3DLIGHTSTATE_FOGDENSITY:
-        m_d3d9->SetRenderState(d3d9::D3DRS_FOGDENSITY, dwLightState);
+        device9->SetRenderState(d3d9::D3DRS_FOGDENSITY, dwLightState);
         break;
       default:
         return DDERR_INVALIDPARAMS;
@@ -1046,6 +1061,7 @@ namespace dxvk {
       return D3D_OK;
     }
 
+    d3d9::IDirect3DDevice9* device9 = m_commonD3DDevice->GetD3D9Device();
     d3d9::D3DRENDERSTATETYPE State9 = d3d9::D3DRENDERSTATETYPE(dwRenderStateType);
 
     switch (dwRenderStateType) {
@@ -1084,8 +1100,8 @@ namespace dxvk {
       }
 
       case D3DRENDERSTATE_TEXTUREADDRESS:
-        m_d3d9->SetSamplerState(0, d3d9::D3DSAMP_ADDRESSU, dwRenderState);
-        m_d3d9->SetSamplerState(0, d3d9::D3DSAMP_ADDRESSV, dwRenderState);
+        device9->SetSamplerState(0, d3d9::D3DSAMP_ADDRESSU, dwRenderState);
+        device9->SetSamplerState(0, d3d9::D3DSAMP_ADDRESSV, dwRenderState);
         return D3D_OK;
 
       // Always enabled on later APIs, though default FALSE in D3D3
@@ -1095,11 +1111,11 @@ namespace dxvk {
       // Not implemented in DXVK, but forward it anyway
       case D3DRENDERSTATE_WRAPU: {
         DWORD value9 = 0;
-        m_d3d9->GetRenderState(d3d9::D3DRS_WRAP0, &value9);
+        device9->GetRenderState(d3d9::D3DRS_WRAP0, &value9);
         if (dwRenderState == TRUE) {
-          m_d3d9->SetRenderState(d3d9::D3DRS_WRAP0, value9 & D3DWRAP_U);
+          device9->SetRenderState(d3d9::D3DRS_WRAP0, value9 & D3DWRAP_U);
         } else {
-          m_d3d9->SetRenderState(d3d9::D3DRS_WRAP0, value9 & ~D3DWRAP_U);
+          device9->SetRenderState(d3d9::D3DRS_WRAP0, value9 & ~D3DWRAP_U);
         }
         return D3D_OK;
       }
@@ -1107,11 +1123,11 @@ namespace dxvk {
       // Not implemented in DXVK, but forward it anyway
       case D3DRENDERSTATE_WRAPV: {
         DWORD value9 = 0;
-        m_d3d9->GetRenderState(d3d9::D3DRS_WRAP0, &value9);
+        device9->GetRenderState(d3d9::D3DRS_WRAP0, &value9);
         if (dwRenderState == TRUE) {
-          m_d3d9->SetRenderState(d3d9::D3DRS_WRAP0, value9 & D3DWRAP_V);
+          device9->SetRenderState(d3d9::D3DRS_WRAP0, value9 & D3DWRAP_V);
         } else {
-          m_d3d9->SetRenderState(d3d9::D3DRS_WRAP0, value9 & ~D3DWRAP_V);
+          device9->SetRenderState(d3d9::D3DRS_WRAP0, value9 & ~D3DWRAP_V);
         }
         return D3D_OK;
       }
@@ -1152,7 +1168,7 @@ namespace dxvk {
         switch (dwRenderState) {
           case D3DFILTER_NEAREST:
           case D3DFILTER_LINEAR:
-            m_d3d9->SetSamplerState(0, d3d9::D3DSAMP_MAGFILTER, dwRenderState);
+            device9->SetSamplerState(0, d3d9::D3DSAMP_MAGFILTER, dwRenderState);
             break;
           default:
             break;
@@ -1164,29 +1180,29 @@ namespace dxvk {
         switch (dwRenderState) {
           case D3DFILTER_NEAREST:
           case D3DFILTER_LINEAR:
-            m_d3d9->SetSamplerState(0, d3d9::D3DSAMP_MINFILTER, dwRenderState);
-            m_d3d9->SetSamplerState(0, d3d9::D3DSAMP_MIPFILTER, d3d9::D3DTEXF_NONE);
+            device9->SetSamplerState(0, d3d9::D3DSAMP_MINFILTER, dwRenderState);
+            device9->SetSamplerState(0, d3d9::D3DSAMP_MIPFILTER, d3d9::D3DTEXF_NONE);
             break;
           // "The closest mipmap level is chosen and a point filter is applied."
           case D3DFILTER_MIPNEAREST:
-            m_d3d9->SetSamplerState(0, d3d9::D3DSAMP_MINFILTER, d3d9::D3DTEXF_POINT);
-            m_d3d9->SetSamplerState(0, d3d9::D3DSAMP_MIPFILTER, d3d9::D3DTEXF_POINT);
+            device9->SetSamplerState(0, d3d9::D3DSAMP_MINFILTER, d3d9::D3DTEXF_POINT);
+            device9->SetSamplerState(0, d3d9::D3DSAMP_MIPFILTER, d3d9::D3DTEXF_POINT);
             break;
           // "The closest mipmap level is chosen and a bilinear filter is applied within it."
           case D3DFILTER_MIPLINEAR:
-            m_d3d9->SetSamplerState(0, d3d9::D3DSAMP_MINFILTER, d3d9::D3DTEXF_LINEAR);
-            m_d3d9->SetSamplerState(0, d3d9::D3DSAMP_MIPFILTER, d3d9::D3DTEXF_POINT);
+            device9->SetSamplerState(0, d3d9::D3DSAMP_MINFILTER, d3d9::D3DTEXF_LINEAR);
+            device9->SetSamplerState(0, d3d9::D3DSAMP_MIPFILTER, d3d9::D3DTEXF_POINT);
             break;
           // "The two closest mipmap levels are chosen and then a linear
           //  blend is used between point filtered samples of each level."
           case D3DFILTER_LINEARMIPNEAREST:
-            m_d3d9->SetSamplerState(0, d3d9::D3DSAMP_MINFILTER, d3d9::D3DTEXF_POINT);
-            m_d3d9->SetSamplerState(0, d3d9::D3DSAMP_MIPFILTER, d3d9::D3DTEXF_LINEAR);
+            device9->SetSamplerState(0, d3d9::D3DSAMP_MINFILTER, d3d9::D3DTEXF_POINT);
+            device9->SetSamplerState(0, d3d9::D3DSAMP_MIPFILTER, d3d9::D3DTEXF_LINEAR);
             break;
           // "The two closest mipmap levels are chosen and then combined using a bilinear filter."
           case D3DFILTER_LINEARMIPLINEAR:
-            m_d3d9->SetSamplerState(0, d3d9::D3DSAMP_MINFILTER, d3d9::D3DTEXF_LINEAR);
-            m_d3d9->SetSamplerState(0, d3d9::D3DSAMP_MIPFILTER, d3d9::D3DTEXF_LINEAR);
+            device9->SetSamplerState(0, d3d9::D3DSAMP_MINFILTER, d3d9::D3DTEXF_LINEAR);
+            device9->SetSamplerState(0, d3d9::D3DSAMP_MIPFILTER, d3d9::D3DTEXF_LINEAR);
             break;
           default:
             break;
@@ -1202,12 +1218,12 @@ namespace dxvk {
           //  the colors that would have been used with no texturing."
           case D3DTBLEND_DECAL:
           case D3DTBLEND_COPY:
-            m_d3d9->SetTextureStageState(0, d3d9::D3DTSS_COLORARG1, D3DTA_TEXTURE);
-            m_d3d9->SetTextureStageState(0, d3d9::D3DTSS_ALPHAARG1, D3DTA_TEXTURE);
-            m_d3d9->SetTextureStageState(0, d3d9::D3DTSS_COLOROP,   D3DTOP_SELECTARG1);
-            m_d3d9->SetTextureStageState(0, d3d9::D3DTSS_ALPHAOP,   D3DTOP_SELECTARG1);
-            m_d3d9->SetTextureStageState(0, d3d9::D3DTSS_COLORARG2, D3DTA_CURRENT);
-            m_d3d9->SetTextureStageState(0, d3d9::D3DTSS_ALPHAARG2, D3DTA_CURRENT);
+            device9->SetTextureStageState(0, d3d9::D3DTSS_COLORARG1, D3DTA_TEXTURE);
+            device9->SetTextureStageState(0, d3d9::D3DTSS_ALPHAARG1, D3DTA_TEXTURE);
+            device9->SetTextureStageState(0, d3d9::D3DTSS_COLOROP,   D3DTOP_SELECTARG1);
+            device9->SetTextureStageState(0, d3d9::D3DTSS_ALPHAOP,   D3DTOP_SELECTARG1);
+            device9->SetTextureStageState(0, d3d9::D3DTSS_COLORARG2, D3DTA_CURRENT);
+            device9->SetTextureStageState(0, d3d9::D3DTSS_ALPHAARG2, D3DTA_CURRENT);
             break;
           // "In this mode, the RGB values of the texture are multiplied with the RGB values
           //  that would have been used with no texturing. Any alpha values in the texture
@@ -1215,43 +1231,43 @@ namespace dxvk {
           //  if the texture does not contain an alpha component, alpha values at the vertices
           //  in the source are interpolated between vertices."
           case D3DTBLEND_MODULATE:
-            m_d3d9->SetTextureStageState(0, d3d9::D3DTSS_COLORARG1, D3DTA_TEXTURE);
-            m_d3d9->SetTextureStageState(0, d3d9::D3DTSS_ALPHAARG1, D3DTA_TEXTURE);
-            m_d3d9->SetTextureStageState(0, d3d9::D3DTSS_COLOROP,   D3DTOP_MODULATE);
-            m_d3d9->SetTextureStageState(0, d3d9::D3DTSS_ALPHAOP,   D3DTOP_SELECTARG1);
-            m_d3d9->SetTextureStageState(0, d3d9::D3DTSS_COLORARG2, D3DTA_DIFFUSE);
-            m_d3d9->SetTextureStageState(0, d3d9::D3DTSS_ALPHAARG2, D3DTA_DIFFUSE);
+            device9->SetTextureStageState(0, d3d9::D3DTSS_COLORARG1, D3DTA_TEXTURE);
+            device9->SetTextureStageState(0, d3d9::D3DTSS_ALPHAARG1, D3DTA_TEXTURE);
+            device9->SetTextureStageState(0, d3d9::D3DTSS_COLOROP,   D3DTOP_MODULATE);
+            device9->SetTextureStageState(0, d3d9::D3DTSS_ALPHAOP,   D3DTOP_SELECTARG1);
+            device9->SetTextureStageState(0, d3d9::D3DTSS_COLORARG2, D3DTA_DIFFUSE);
+            device9->SetTextureStageState(0, d3d9::D3DTSS_ALPHAARG2, D3DTA_DIFFUSE);
             break;
           // "In this mode, the RGB and alpha values of the texture are blended with the colors
           //  that would have been used with no texturing, according to the following formulas [...]"
           case D3DTBLEND_DECALALPHA:
-            m_d3d9->SetTextureStageState(0, d3d9::D3DTSS_COLORARG1, D3DTA_TEXTURE);
-            m_d3d9->SetTextureStageState(0, d3d9::D3DTSS_ALPHAARG1, D3DTA_TEXTURE);
-            m_d3d9->SetTextureStageState(0, d3d9::D3DTSS_COLOROP,   D3DTOP_BLENDTEXTUREALPHA);
-            m_d3d9->SetTextureStageState(0, d3d9::D3DTSS_ALPHAOP,   D3DTOP_SELECTARG2);
-            m_d3d9->SetTextureStageState(0, d3d9::D3DTSS_COLORARG2, D3DTA_DIFFUSE);
-            m_d3d9->SetTextureStageState(0, d3d9::D3DTSS_ALPHAARG2, D3DTA_DIFFUSE);
+            device9->SetTextureStageState(0, d3d9::D3DTSS_COLORARG1, D3DTA_TEXTURE);
+            device9->SetTextureStageState(0, d3d9::D3DTSS_ALPHAARG1, D3DTA_TEXTURE);
+            device9->SetTextureStageState(0, d3d9::D3DTSS_COLOROP,   D3DTOP_BLENDTEXTUREALPHA);
+            device9->SetTextureStageState(0, d3d9::D3DTSS_ALPHAOP,   D3DTOP_SELECTARG2);
+            device9->SetTextureStageState(0, d3d9::D3DTSS_COLORARG2, D3DTA_DIFFUSE);
+            device9->SetTextureStageState(0, d3d9::D3DTSS_ALPHAARG2, D3DTA_DIFFUSE);
             break;
           // "In this mode, the RGB values of the texture are multiplied with the RGB values that
           //  would have been used with no texturing, and the alpha values of the texture
           //  are multiplied with the alpha values that would have been used with no texturing."
           case D3DTBLEND_MODULATEALPHA:
-            m_d3d9->SetTextureStageState(0, d3d9::D3DTSS_COLORARG1, D3DTA_TEXTURE);
-            m_d3d9->SetTextureStageState(0, d3d9::D3DTSS_ALPHAARG1, D3DTA_TEXTURE);
-            m_d3d9->SetTextureStageState(0, d3d9::D3DTSS_COLOROP,   D3DTOP_MODULATE);
-            m_d3d9->SetTextureStageState(0, d3d9::D3DTSS_ALPHAOP,   D3DTOP_MODULATE);
-            m_d3d9->SetTextureStageState(0, d3d9::D3DTSS_COLORARG2, D3DTA_DIFFUSE);
-            m_d3d9->SetTextureStageState(0, d3d9::D3DTSS_ALPHAARG2, D3DTA_DIFFUSE);
+            device9->SetTextureStageState(0, d3d9::D3DTSS_COLORARG1, D3DTA_TEXTURE);
+            device9->SetTextureStageState(0, d3d9::D3DTSS_ALPHAARG1, D3DTA_TEXTURE);
+            device9->SetTextureStageState(0, d3d9::D3DTSS_COLOROP,   D3DTOP_MODULATE);
+            device9->SetTextureStageState(0, d3d9::D3DTSS_ALPHAOP,   D3DTOP_MODULATE);
+            device9->SetTextureStageState(0, d3d9::D3DTSS_COLORARG2, D3DTA_DIFFUSE);
+            device9->SetTextureStageState(0, d3d9::D3DTSS_ALPHAARG2, D3DTA_DIFFUSE);
             break;
           // "Add the Gouraud interpolants to the texture lookup with saturation semantics
           //  (that is, if the color value overflows it is set to the maximum possible value)."
           case D3DTBLEND_ADD:
-            m_d3d9->SetTextureStageState(0, d3d9::D3DTSS_COLORARG1, D3DTA_TEXTURE);
-            m_d3d9->SetTextureStageState(0, d3d9::D3DTSS_ALPHAARG1, D3DTA_TEXTURE);
-            m_d3d9->SetTextureStageState(0, d3d9::D3DTSS_COLOROP,   D3DTOP_ADD);
-            m_d3d9->SetTextureStageState(0, d3d9::D3DTSS_ALPHAOP,   D3DTOP_SELECTARG2);
-            m_d3d9->SetTextureStageState(0, d3d9::D3DTSS_COLORARG2, D3DTA_DIFFUSE);
-            m_d3d9->SetTextureStageState(0, d3d9::D3DTSS_ALPHAARG2, D3DTA_DIFFUSE);
+            device9->SetTextureStageState(0, d3d9::D3DTSS_COLORARG1, D3DTA_TEXTURE);
+            device9->SetTextureStageState(0, d3d9::D3DTSS_ALPHAARG1, D3DTA_TEXTURE);
+            device9->SetTextureStageState(0, d3d9::D3DTSS_COLOROP,   D3DTOP_ADD);
+            device9->SetTextureStageState(0, d3d9::D3DTSS_ALPHAOP,   D3DTOP_SELECTARG2);
+            device9->SetTextureStageState(0, d3d9::D3DTSS_COLORARG2, D3DTA_DIFFUSE);
+            device9->SetTextureStageState(0, d3d9::D3DTSS_ALPHAARG2, D3DTA_DIFFUSE);
             break;
           // Unsupported
           default:
@@ -1340,10 +1356,12 @@ namespace dxvk {
     }
 
     // This call will never fail
-    return m_d3d9->SetRenderState(State9, dwRenderState);
+    return device9->SetRenderState(State9, dwRenderState);
   }
 
   inline void D3D3Device::DrawTriangleInternal(D3DTRIANGLE* triangle, uint16_t count, DWORD vertexCount, const D3DTLVERTEX* vertexBuffer) {
+    d3d9::IDirect3DDevice9* device9 = m_commonD3DDevice->GetD3D9Device();
+
     m_rt->InitializeOrUploadD3D9();
     if (likely(m_ds != nullptr))
       m_ds->InitializeOrUploadD3D9();
@@ -1370,9 +1388,9 @@ namespace dxvk {
       vertices.push_back(vertexBuffer[t.v3]);
     }
 
-    if (!vertices.empty() && m_d3d9 != nullptr) {
-      m_d3d9->SetFVF(D3DFVF_TLVERTEX);
-      HRESULT hr = m_d3d9->DrawPrimitiveUP(
+    if (likely(!vertices.empty())) {
+      device9->SetFVF(D3DFVF_TLVERTEX);
+      HRESULT hr = device9->DrawPrimitiveUP(
            d3d9::D3DPT_TRIANGLELIST,
            GetPrimitiveCount(D3DPT_TRIANGLELIST, vertices.size()),
            vertices.data(),
@@ -1392,6 +1410,8 @@ namespace dxvk {
   }
 
   inline void D3D3Device::DrawLineInternal(D3DLINE* line, uint16_t count, DWORD vertexCount, const D3DTLVERTEX* vertexBuffer) {
+    d3d9::IDirect3DDevice9* device9 = m_commonD3DDevice->GetD3D9Device();
+
     m_rt->InitializeOrUploadD3D9();
     if (likely(m_ds != nullptr))
       m_ds->InitializeOrUploadD3D9();
@@ -1408,9 +1428,9 @@ namespace dxvk {
       vertices.push_back(vertexBuffer[l.v2]);
     }
 
-    if (!vertices.empty() && m_d3d9 != nullptr) {
-      m_d3d9->SetFVF(D3DFVF_TLVERTEX);
-      HRESULT hr = m_d3d9->DrawPrimitiveUP(
+    if (likely(!vertices.empty())) {
+      device9->SetFVF(D3DFVF_TLVERTEX);
+      HRESULT hr = device9->DrawPrimitiveUP(
            d3d9::D3DPT_LINELIST,
            GetPrimitiveCount(D3DPT_LINELIST, vertices.size()),
            vertices.data(),
@@ -1430,6 +1450,8 @@ namespace dxvk {
   }
 
   inline void D3D3Device::DrawPointInternal(D3DPOINT* point, uint16_t count, DWORD vertexCount, const D3DTLVERTEX* vertexBuffer) {
+    d3d9::IDirect3DDevice9* device9 = m_commonD3DDevice->GetD3D9Device();
+
     m_rt->InitializeOrUploadD3D9();
     if (likely(m_ds != nullptr))
       m_ds->InitializeOrUploadD3D9();
@@ -1447,9 +1469,9 @@ namespace dxvk {
       }
     }
 
-    if (!vertices.empty() && m_d3d9 != nullptr) {
-      m_d3d9->SetFVF(D3DFVF_TLVERTEX);
-      HRESULT hr = m_d3d9->DrawPrimitiveUP(
+    if (likely(!vertices.empty())) {
+      device9->SetFVF(D3DFVF_TLVERTEX);
+      HRESULT hr = device9->DrawPrimitiveUP(
            d3d9::D3DPT_POINTLIST,
            GetPrimitiveCount(D3DPT_POINTLIST, vertices.size()),
            vertices.data(),
@@ -1468,6 +1490,8 @@ namespace dxvk {
   }
 
   inline void D3D3Device::DrawSpanInternal(D3DSPAN* span, uint16_t count, DWORD vertexCount, const D3DTLVERTEX* vertexBuffer) {
+    d3d9::IDirect3DDevice9* device9 = m_commonD3DDevice->GetD3D9Device();
+
     m_rt->InitializeOrUploadD3D9();
     if (likely(m_ds != nullptr))
       m_ds->InitializeOrUploadD3D9();
@@ -1485,9 +1509,9 @@ namespace dxvk {
       }
     }
 
-    if (!vertices.empty() && m_d3d9 != nullptr) {
-      m_d3d9->SetFVF(D3DFVF_TLVERTEX);
-      HRESULT hr = m_d3d9->DrawPrimitiveUP(
+    if (likely(!vertices.empty())) {
+      device9->SetFVF(D3DFVF_TLVERTEX);
+      HRESULT hr = device9->DrawPrimitiveUP(
            d3d9::D3DPT_LINESTRIP,
            GetPrimitiveCount(D3DPT_LINESTRIP, vertices.size()),
            vertices.data(),
@@ -1525,11 +1549,13 @@ namespace dxvk {
 
     HRESULT hr;
 
+    d3d9::IDirect3DDevice9* device9 = m_commonD3DDevice->GetD3D9Device();
+
     // Unbinding texture stages
     if (surface == nullptr) {
       Logger::debug("D3D3Device::SetTextureInternal: Unbiding D3D9 texture");
 
-      hr = m_d3d9->SetTexture(0, nullptr);
+      hr = device9->SetTexture(0, nullptr);
 
       if (likely(SUCCEEDED(hr))) {
         if (m_commonD3DDevice->GetCurrentTextureHandle() != 0) {
@@ -1547,7 +1573,7 @@ namespace dxvk {
 
     // If textures have been used on a different device, they
     // will get their D3D9 object reinitialized at this point
-    if (unlikely(surface->GetD3D9Device() != m_d3d9.ptr()))
+    if (unlikely(surface->GetCommonD3DDevice() != m_commonD3DDevice.ptr()))
       surface->GetCommonSurface()->DirtyDDrawSurface();
 
     hr = surface->InitializeOrUploadD3D9();
@@ -1560,10 +1586,10 @@ namespace dxvk {
     //if (unlikely(m_commonD3DDevice->GetCurrentTextureHandle() == textureHandle))
       //return D3D_OK;
 
-    d3d9::IDirect3DTexture9* tex9 = surface->GetD3D9Texture();
+    d3d9::IDirect3DTexture9* tex9 = surface->GetCommonSurface()->GetD3D9Texture();
 
     if (likely(tex9 != nullptr)) {
-      hr = m_d3d9->SetTexture(0, tex9);
+      hr = device9->SetTexture(0, tex9);
       if (unlikely(FAILED(hr))) {
         Logger::warn("D3D3Device::SetTextureInternal: Failed to bind D3D9 texture");
         return hr;
@@ -1574,7 +1600,7 @@ namespace dxvk {
       //  alpha values at the vertices in the source are interpolated between vertices."
       if (m_commonD3DDevice->GetTextureMapBlend() == D3DTBLEND_MODULATE) {
         const DWORD textureOp = surface->GetCommonSurface()->IsAlphaFormat() ? D3DTOP_SELECTARG1 : D3DTOP_MODULATE;
-        m_d3d9->SetTextureStageState(0, d3d9::D3DTSS_ALPHAOP, textureOp);
+        device9->SetTextureStageState(0, d3d9::D3DTSS_ALPHAOP, textureOp);
       }
 
       // D3D3 enables color key transparency globally

--- a/src/ddraw/d3d3/d3d3_device.h
+++ b/src/ddraw/d3d3/d3d3_device.h
@@ -25,7 +25,7 @@ namespace dxvk {
   /**
   * \brief D3D3 device implementation
   */
-  class D3D3Device final : public DDrawWrappedObject<DDrawSurface, IDirect3DDevice, d3d9::IDirect3DDevice9> {
+  class D3D3Device final : public DDrawWrappedObject<DDrawSurface, IDirect3DDevice> {
 
   public:
     D3D3Device(

--- a/src/ddraw/d3d3/d3d3_interface.cpp
+++ b/src/ddraw/d3d3/d3d3_interface.cpp
@@ -18,16 +18,22 @@ namespace dxvk {
         D3DCommonInterface* commonD3DIntf,
         Com<IDirect3D>&& d3d3IntfProxy,
         IUnknown* pParent)
-    : DDrawWrappedObject<IUnknown, IDirect3D, d3d9::IDirect3D9>(pParent, std::move(d3d3IntfProxy), std::move(d3d9::Direct3DCreate9(D3D_SDK_VERSION)))
+    : DDrawWrappedObject<IUnknown, IDirect3D>(pParent, std::move(d3d3IntfProxy))
     , m_commonIntf ( commonIntf )
     , m_commonD3DIntf ( commonD3DIntf ) {
-    // Get the bridge interface to D3D9.
-    if (unlikely(FAILED(m_d3d9->QueryInterface(__uuidof(IDxvkD3D8InterfaceBridge), reinterpret_cast<void**>(&m_bridge))))) {
-      throw DxvkError("D3D3Interface: ERROR! Failed to get D3D9 Bridge. d3d9.dll might not be DXVK!");
+    if (m_commonD3DIntf == nullptr) {
+      m_commonD3DIntf = new D3DCommonInterface();
+
+      Com<d3d9::IDirect3D9> d3dIntf9 = d3d9::Direct3DCreate9(D3D_SDK_VERSION);
+      m_commonD3DIntf->SetD3D9Interface(std::move(d3dIntf9));
     }
 
-    if (m_commonD3DIntf == nullptr)
-      m_commonD3DIntf = new D3DCommonInterface();
+    d3d9::IDirect3D9* d3dIntf9 = m_commonD3DIntf->GetD3D9Interface();
+
+    // Get the bridge interface to D3D9.
+    if (unlikely(FAILED(d3dIntf9->QueryInterface(__uuidof(IDxvkD3D8InterfaceBridge), reinterpret_cast<void**>(&m_bridge))))) {
+      throw DxvkError("D3D3Interface: ERROR! Failed to get D3D9 Bridge. d3d9.dll might not be DXVK!");
+    }
 
     m_commonD3DIntf->SetD3D3Interface(this);
 

--- a/src/ddraw/d3d3/d3d3_interface.h
+++ b/src/ddraw/d3d3/d3d3_interface.h
@@ -16,7 +16,7 @@ namespace dxvk {
   /**
   * \brief D3D3 interface implementation
   */
-  class D3D3Interface final : public DDrawWrappedObject<IUnknown, IDirect3D, d3d9::IDirect3D9> {
+  class D3D3Interface final : public DDrawWrappedObject<IUnknown, IDirect3D> {
 
   public:
     D3D3Interface(

--- a/src/ddraw/d3d3/d3d3_material.cpp
+++ b/src/ddraw/d3d3/d3d3_material.cpp
@@ -15,7 +15,7 @@ namespace dxvk {
         Com<IDirect3DMaterial>&& proxyMaterial,
         D3D3Interface* pParent,
         D3DMATERIALHANDLE handle)
-    : DDrawWrappedObject<D3D3Interface, IDirect3DMaterial, IUnknown>(pParent, std::move(proxyMaterial), nullptr) {
+    : DDrawWrappedObject<D3D3Interface, IDirect3DMaterial>(pParent, std::move(proxyMaterial)) {
     m_commonMaterial = new D3DCommonMaterial(handle);
 
     m_commonMaterial->SetD3D3Material(this);

--- a/src/ddraw/d3d3/d3d3_material.h
+++ b/src/ddraw/d3d3/d3d3_material.h
@@ -9,7 +9,7 @@ namespace dxvk {
 
   class D3D3Interface;
 
-  class D3D3Material final : public DDrawWrappedObject<D3D3Interface, IDirect3DMaterial, IUnknown> {
+  class D3D3Material final : public DDrawWrappedObject<D3D3Interface, IDirect3DMaterial> {
 
   public:
 

--- a/src/ddraw/d3d3/d3d3_texture.cpp
+++ b/src/ddraw/d3d3/d3d3_texture.cpp
@@ -12,7 +12,7 @@ namespace dxvk {
         Com<IDirect3DTexture>&& proxyTexture,
         DDrawSurface* pParent,
         D3DTEXTUREHANDLE handle)
-    : DDrawWrappedObject<DDrawSurface, IDirect3DTexture, IUnknown>(pParent, std::move(proxyTexture), nullptr) {
+    : DDrawWrappedObject<DDrawSurface, IDirect3DTexture>(pParent, std::move(proxyTexture)) {
     m_commonTex = new D3DCommonTexture(m_parent->GetCommonSurface(), handle);
 
     m_texCount = ++s_texCount;

--- a/src/ddraw/d3d3/d3d3_texture.h
+++ b/src/ddraw/d3d3/d3d3_texture.h
@@ -9,7 +9,7 @@ namespace dxvk {
 
   class DDrawSurface;
 
-  class D3D3Texture final : public DDrawWrappedObject<DDrawSurface, IDirect3DTexture, IUnknown> {
+  class D3D3Texture final : public DDrawWrappedObject<DDrawSurface, IDirect3DTexture> {
 
   public:
 

--- a/src/ddraw/d3d3/d3d3_viewport.cpp
+++ b/src/ddraw/d3d3/d3d3_viewport.cpp
@@ -21,7 +21,7 @@ namespace dxvk {
         D3DCommonViewport* commonViewport,
         Com<IDirect3DViewport>&& proxyViewport,
         D3D3Interface* pParent)
-    : DDrawWrappedObject<D3D3Interface, IDirect3DViewport, IUnknown>(pParent, std::move(proxyViewport), nullptr)
+    : DDrawWrappedObject<D3D3Interface, IDirect3DViewport>(pParent, std::move(proxyViewport))
     , m_commonViewport ( commonViewport ) {
 
     if (m_commonViewport == nullptr)

--- a/src/ddraw/d3d3/d3d3_viewport.h
+++ b/src/ddraw/d3d3/d3d3_viewport.h
@@ -14,7 +14,7 @@ namespace dxvk {
   class D3D6Viewport;
   class D3D5Viewport;
 
-  class D3D3Viewport final : public DDrawWrappedObject<D3D3Interface, IDirect3DViewport, IUnknown> {
+  class D3D3Viewport final : public DDrawWrappedObject<D3D3Interface, IDirect3DViewport> {
 
   public:
 

--- a/src/ddraw/d3d5/d3d5_device.cpp
+++ b/src/ddraw/d3d5/d3d5_device.cpp
@@ -33,7 +33,7 @@ namespace dxvk {
         Com<d3d9::IDirect3DDevice9>&& pDevice9,
         DDrawSurface* pSurface,
         DWORD CreationFlags9)
-    : DDrawWrappedObject<D3D5Interface, IDirect3DDevice2, d3d9::IDirect3DDevice9>(pParent, std::move(d3d5DeviceProxy), std::move(pDevice9))
+    : DDrawWrappedObject<D3D5Interface, IDirect3DDevice2>(pParent, std::move(d3d5DeviceProxy))
     , m_commonD3DDevice ( commonD3DDevice )
     , m_multithread ( CreationFlags9 & D3DCREATE_MULTITHREADED )
     , m_desc ( Desc )
@@ -46,33 +46,42 @@ namespace dxvk {
       throw DxvkError("D3D5Device: ERROR! Failed to retrieve the common interface!");
     }
 
-    // Get the bridge interface to D3D9
-    if (unlikely(FAILED(m_d3d9->QueryInterface(__uuidof(IDxvkD3D8Bridge), reinterpret_cast<void**>(&m_bridge))))) {
-      throw DxvkError("D3D5Device: ERROR! Failed to get D3D9 Bridge. d3d9.dll might not be DXVK!");
-    }
+    d3d9::IDirect3DDevice9* device9;
 
     if (likely(m_commonD3DDevice == nullptr)) {
-      m_commonD3DDevice = new D3DCommonDevice(m_commonIntf, deviceGUID, Params9, CreationFlags9,
-                                              m_bridge->DetermineInitialTextureMemory());
+      m_commonD3DDevice = new D3DCommonDevice(m_commonIntf, deviceGUID, Params9, CreationFlags9);
 
-      // Update D3D9 legacy light state
-      m_bridge->SetLegacyLightsState(true);
+      m_commonD3DDevice->SetD3D9Device(std::move(pDevice9));
+      device9 = m_commonD3DDevice->GetD3D9Device();
 
       const D3DOptions* d3dOptions = m_commonIntf->GetOptions();
 
       if (unlikely(d3dOptions->emulateFSAA == FSAAEmulation::Forced)) {
         Logger::warn("D3D5Device: Force enabling AA");
-        m_d3d9->SetRenderState(d3d9::D3DRS_MULTISAMPLEANTIALIAS, TRUE);
+        device9->SetRenderState(d3d9::D3DRS_MULTISAMPLEANTIALIAS, TRUE);
       }
 
       // The default value of D3DRENDERSTATE_TEXTUREMAPBLEND in D3D5 is D3DTBLEND_MODULATE
-      m_d3d9->SetTextureStageState(0, d3d9::D3DTSS_COLORARG1, D3DTA_TEXTURE);
-      m_d3d9->SetTextureStageState(0, d3d9::D3DTSS_ALPHAARG1, D3DTA_TEXTURE);
-      m_d3d9->SetTextureStageState(0, d3d9::D3DTSS_COLOROP,   D3DTOP_MODULATE);
-      m_d3d9->SetTextureStageState(0, d3d9::D3DTSS_ALPHAOP,   D3DTOP_SELECTARG1);
-      m_d3d9->SetTextureStageState(0, d3d9::D3DTSS_COLORARG2, D3DTA_DIFFUSE);
-      m_d3d9->SetTextureStageState(0, d3d9::D3DTSS_ALPHAARG2, D3DTA_DIFFUSE);
+      device9->SetTextureStageState(0, d3d9::D3DTSS_COLORARG1, D3DTA_TEXTURE);
+      device9->SetTextureStageState(0, d3d9::D3DTSS_ALPHAARG1, D3DTA_TEXTURE);
+      device9->SetTextureStageState(0, d3d9::D3DTSS_COLOROP,   D3DTOP_MODULATE);
+      device9->SetTextureStageState(0, d3d9::D3DTSS_ALPHAOP,   D3DTOP_SELECTARG1);
+      device9->SetTextureStageState(0, d3d9::D3DTSS_COLORARG2, D3DTA_DIFFUSE);
+      device9->SetTextureStageState(0, d3d9::D3DTSS_ALPHAARG2, D3DTA_DIFFUSE);
+    } else {
+      device9 = m_commonD3DDevice->GetD3D9Device();
     }
+
+    // Get the bridge interface to D3D9
+    if (unlikely(FAILED(device9->QueryInterface(__uuidof(IDxvkD3D8Bridge), reinterpret_cast<void**>(&m_bridge))))) {
+      throw DxvkError("D3D5Device: ERROR! Failed to get D3D9 Bridge. d3d9.dll might not be DXVK!");
+    }
+
+    if (unlikely(!m_commonD3DDevice->GetTotalTextureMemory()))
+      m_commonD3DDevice->SetTotalTextureMemory(m_bridge->DetermineInitialTextureMemory());
+
+    // Update D3D9 legacy light state
+    m_bridge->SetLegacyLightsState(true);
 
     if (m_commonD3DDevice->GetOrigin() == nullptr)
       m_commonD3DDevice->SetOrigin(this);
@@ -144,10 +153,9 @@ namespace dxvk {
 
       // Reuse the existing D3D9 device in situations where games want
       // to get access only to D3D3 execute buffers on a D3D5 device
-      Com<d3d9::IDirect3DDevice9> device9 = m_d3d9.ptr();
       m_device3 = new D3D3Device(m_commonD3DDevice.ptr(), std::move(ppvProxyObject),
                                  m_rt.ptr(), GetD3D3Caps(d3dOptions), m_commonD3DDevice->GetDeviceGUID(),
-                                 m_commonD3DDevice->GetPresentParameters(), std::move(device9),
+                                 m_commonD3DDevice->GetPresentParameters(), nullptr,
                                  m_commonD3DDevice->GetD3D9CreationFlags());
       m_commonD3DDevice->SetD3D3Device(m_device3.ptr());
 
@@ -410,7 +418,7 @@ namespace dxvk {
     if (unlikely(m_commonD3DDevice->IsInScene()))
       return D3DERR_SCENE_IN_SCENE;
 
-    HRESULT hr = m_d3d9->BeginScene();
+    HRESULT hr = m_commonD3DDevice->GetD3D9Device()->BeginScene();
 
     if (likely(SUCCEEDED(hr)))
       m_commonD3DDevice->SetInScene(true);
@@ -428,7 +436,7 @@ namespace dxvk {
     if (unlikely(!m_commonD3DDevice->IsInScene()))
       return D3DERR_SCENE_NOT_IN_SCENE;
 
-    HRESULT hr = m_d3d9->EndScene();
+    HRESULT hr = m_commonD3DDevice->GetD3D9Device()->EndScene();
 
     if (likely(SUCCEEDED(hr)))
       m_commonD3DDevice->SetInScene(false);
@@ -531,7 +539,9 @@ namespace dxvk {
       return hr;
     }
 
-    hr = m_d3d9->SetRenderTarget(0, rt5->GetD3D9());
+    d3d9::IDirect3DDevice9* device9 = m_commonD3DDevice->GetD3D9Device();
+
+    hr = device9->SetRenderTarget(0, rt5->GetCommonSurface()->GetD3D9Surface());
 
     if (likely(SUCCEEDED(hr))) {
       Logger::debug("D3D5Device::SetRenderTarget: Set a new D3D9 RT");
@@ -550,7 +560,7 @@ namespace dxvk {
           return hrDS;
         }
 
-        hrDS = m_d3d9->SetDepthStencilSurface(m_ds->GetD3D9());
+        hrDS = device9->SetDepthStencilSurface(m_ds->GetCommonSurface()->GetD3D9Surface());
         if (unlikely(FAILED(hrDS))) {
           Logger::err("D3D5Device::SetRenderTarget: Failed to set D3D9 DS");
           return hrDS;
@@ -560,7 +570,7 @@ namespace dxvk {
       } else {
         Logger::debug("D3D5Device::SetRenderTarget: RT has no depth stencil attached");
 
-        hrDS = m_d3d9->SetDepthStencilSurface(nullptr);
+        hrDS = device9->SetDepthStencilSurface(nullptr);
         if (unlikely(FAILED(hrDS))) {
           Logger::err("D3D5Device::SetRenderTarget: Failed to clear the D3D9 DS");
           return hrDS;
@@ -674,12 +684,14 @@ namespace dxvk {
 
     // As opposed to D3D7, D3D5 does not error out on
     // unknown or invalid render states.
-    if (unlikely(!IsValidD3D5RenderStateType(dwRenderStateType))) {
+    if (unlikely(!IsValidD3D5RenderStateType(dwRenderStateType)
+              && !m_commonIntf->GetOptions()->apitraceMode)) {
       Logger::debug(str::format("D3D5Device::GetRenderState: Invalid render state ", dwRenderStateType));
       *lpdwRenderState = 0;
       return D3D_OK;
     }
 
+    d3d9::IDirect3DDevice9* device9 = m_commonD3DDevice->GetD3D9Device();
     d3d9::D3DRENDERSTATETYPE State9 = d3d9::D3DRENDERSTATETYPE(dwRenderStateType);
 
     switch (dwRenderStateType) {
@@ -697,7 +709,7 @@ namespace dxvk {
         return D3D_OK;
 
       case D3DRENDERSTATE_TEXTUREADDRESS:
-        m_d3d9->GetSamplerState(0, d3d9::D3DSAMP_ADDRESSU, lpdwRenderState);
+        device9->GetSamplerState(0, d3d9::D3DSAMP_ADDRESSU, lpdwRenderState);
         return D3D_OK;
 
       // Always enabled on later APIs, though default FALSE in D3D5
@@ -708,7 +720,7 @@ namespace dxvk {
       // Not implemented in DXVK, but retrieve it as it were
       case D3DRENDERSTATE_WRAPU: {
         DWORD value9 = 0;
-        m_d3d9->GetRenderState(d3d9::D3DRS_WRAP0, &value9);
+        device9->GetRenderState(d3d9::D3DRS_WRAP0, &value9);
         *lpdwRenderState = value9 & D3DWRAP_U;
         return D3D_OK;
       }
@@ -716,7 +728,7 @@ namespace dxvk {
       // Not implemented in DXVK, but retrieve it as it were
       case D3DRENDERSTATE_WRAPV: {
         DWORD value9 = 0;
-        m_d3d9->GetRenderState(d3d9::D3DRS_WRAP0, &value9);
+        device9->GetRenderState(d3d9::D3DRS_WRAP0, &value9);
         *lpdwRenderState = value9 & D3DWRAP_V;
         return D3D_OK;
       }
@@ -738,14 +750,14 @@ namespace dxvk {
         return D3D_OK;
 
       case D3DRENDERSTATE_TEXTUREMAG:
-        m_d3d9->GetSamplerState(0, d3d9::D3DSAMP_MAGFILTER, lpdwRenderState);
+        device9->GetSamplerState(0, d3d9::D3DSAMP_MAGFILTER, lpdwRenderState);
         return D3D_OK;
 
       case D3DRENDERSTATE_TEXTUREMIN: {
         DWORD minFilter = 0;
         DWORD mipFilter = 0;
-        m_d3d9->GetSamplerState(0, d3d9::D3DSAMP_MINFILTER, &minFilter);
-        m_d3d9->GetSamplerState(0, d3d9::D3DSAMP_MIPFILTER, &mipFilter);
+        device9->GetSamplerState(0, d3d9::D3DSAMP_MINFILTER, &minFilter);
+        device9->GetSamplerState(0, d3d9::D3DSAMP_MIPFILTER, &mipFilter);
         *lpdwRenderState = DecodeTextureMinValues(minFilter, mipFilter);
         return D3D_OK;
       }
@@ -789,30 +801,30 @@ namespace dxvk {
         break;
 
       case D3DRENDERSTATE_BORDERCOLOR:
-        m_d3d9->GetSamplerState(0, d3d9::D3DSAMP_BORDERCOLOR, lpdwRenderState);
+        device9->GetSamplerState(0, d3d9::D3DSAMP_BORDERCOLOR, lpdwRenderState);
         return D3D_OK;
 
       case D3DRENDERSTATE_TEXTUREADDRESSU:
-        m_d3d9->GetSamplerState(0, d3d9::D3DSAMP_ADDRESSU, lpdwRenderState);
+        device9->GetSamplerState(0, d3d9::D3DSAMP_ADDRESSU, lpdwRenderState);
         return D3D_OK;
 
       case D3DRENDERSTATE_TEXTUREADDRESSV:
-        m_d3d9->GetSamplerState(0, d3d9::D3DSAMP_ADDRESSV, lpdwRenderState);
+        device9->GetSamplerState(0, d3d9::D3DSAMP_ADDRESSV, lpdwRenderState);
         return D3D_OK;
 
       case D3DRENDERSTATE_MIPMAPLODBIAS:
-        m_d3d9->GetSamplerState(0, d3d9::D3DSAMP_MIPMAPLODBIAS, lpdwRenderState);
+        device9->GetSamplerState(0, d3d9::D3DSAMP_MIPMAPLODBIAS, lpdwRenderState);
         return D3D_OK;
 
       case D3DRENDERSTATE_ZBIAS: {
         DWORD bias = 0;
-        m_d3d9->GetRenderState(d3d9::D3DRS_DEPTHBIAS, &bias);
+        device9->GetRenderState(d3d9::D3DRS_DEPTHBIAS, &bias);
         *lpdwRenderState = static_cast<DWORD>(bit::cast<float>(bias) * ddrawCaps::ZBIAS_SCALE_INV);
         return D3D_OK;
       }
 
       case D3DRENDERSTATE_ANISOTROPY:
-        m_d3d9->GetSamplerState(0, d3d9::D3DSAMP_MAXANISOTROPY, lpdwRenderState);
+        device9->GetSamplerState(0, d3d9::D3DSAMP_MAXANISOTROPY, lpdwRenderState);
         return D3D_OK;
 
       // Not mentioned in the D3D5 docs, but seen in the wild. D3D6 docs state:
@@ -860,7 +872,7 @@ namespace dxvk {
     }
 
     // This call will never fail
-    return m_d3d9->GetRenderState(State9, lpdwRenderState);
+    return device9->GetRenderState(State9, lpdwRenderState);
   }
 
   HRESULT STDMETHODCALLTYPE D3D5Device::SetRenderState(D3DRENDERSTATETYPE dwRenderStateType, DWORD dwRenderState) {
@@ -875,6 +887,7 @@ namespace dxvk {
       return D3D_OK;
     }
 
+    d3d9::IDirect3DDevice9* device9 = m_commonD3DDevice->GetD3D9Device();
     d3d9::D3DRENDERSTATETYPE State9 = d3d9::D3DRENDERSTATETYPE(dwRenderStateType);
 
     switch (dwRenderStateType) {
@@ -921,8 +934,8 @@ namespace dxvk {
       }
 
       case D3DRENDERSTATE_TEXTUREADDRESS:
-        m_d3d9->SetSamplerState(0, d3d9::D3DSAMP_ADDRESSU, dwRenderState);
-        m_d3d9->SetSamplerState(0, d3d9::D3DSAMP_ADDRESSV, dwRenderState);
+        device9->SetSamplerState(0, d3d9::D3DSAMP_ADDRESSU, dwRenderState);
+        device9->SetSamplerState(0, d3d9::D3DSAMP_ADDRESSV, dwRenderState);
         return D3D_OK;
 
       // Always enabled on later APIs, though default FALSE in D3D5
@@ -932,11 +945,11 @@ namespace dxvk {
       // Not implemented in DXVK, but forward it anyway
       case D3DRENDERSTATE_WRAPU: {
         DWORD value9 = 0;
-        m_d3d9->GetRenderState(d3d9::D3DRS_WRAP0, &value9);
+        device9->GetRenderState(d3d9::D3DRS_WRAP0, &value9);
         if (dwRenderState == TRUE) {
-          m_d3d9->SetRenderState(d3d9::D3DRS_WRAP0, value9 & D3DWRAP_U);
+          device9->SetRenderState(d3d9::D3DRS_WRAP0, value9 & D3DWRAP_U);
         } else {
-          m_d3d9->SetRenderState(d3d9::D3DRS_WRAP0, value9 & ~D3DWRAP_U);
+          device9->SetRenderState(d3d9::D3DRS_WRAP0, value9 & ~D3DWRAP_U);
         }
         return D3D_OK;
       }
@@ -944,11 +957,11 @@ namespace dxvk {
       // Not implemented in DXVK, but forward it anyway
       case D3DRENDERSTATE_WRAPV: {
         DWORD value9 = 0;
-        m_d3d9->GetRenderState(d3d9::D3DRS_WRAP0, &value9);
+        device9->GetRenderState(d3d9::D3DRS_WRAP0, &value9);
         if (dwRenderState == TRUE) {
-          m_d3d9->SetRenderState(d3d9::D3DRS_WRAP0, value9 & D3DWRAP_V);
+          device9->SetRenderState(d3d9::D3DRS_WRAP0, value9 & D3DWRAP_V);
         } else {
-          m_d3d9->SetRenderState(d3d9::D3DRS_WRAP0, value9 & ~D3DWRAP_V);
+          device9->SetRenderState(d3d9::D3DRS_WRAP0, value9 & ~D3DWRAP_V);
         }
         return D3D_OK;
       }
@@ -990,7 +1003,7 @@ namespace dxvk {
         switch (dwRenderState) {
           case D3DFILTER_NEAREST:
           case D3DFILTER_LINEAR:
-            m_d3d9->SetSamplerState(0, d3d9::D3DSAMP_MAGFILTER, dwRenderState);
+            device9->SetSamplerState(0, d3d9::D3DSAMP_MAGFILTER, dwRenderState);
             break;
           default:
             break;
@@ -1002,29 +1015,29 @@ namespace dxvk {
         switch (dwRenderState) {
           case D3DFILTER_NEAREST:
           case D3DFILTER_LINEAR:
-            m_d3d9->SetSamplerState(0, d3d9::D3DSAMP_MINFILTER, dwRenderState);
-            m_d3d9->SetSamplerState(0, d3d9::D3DSAMP_MIPFILTER, d3d9::D3DTEXF_NONE);
+            device9->SetSamplerState(0, d3d9::D3DSAMP_MINFILTER, dwRenderState);
+            device9->SetSamplerState(0, d3d9::D3DSAMP_MIPFILTER, d3d9::D3DTEXF_NONE);
             break;
           // "The closest mipmap level is chosen and a point filter is applied."
           case D3DFILTER_MIPNEAREST:
-            m_d3d9->SetSamplerState(0, d3d9::D3DSAMP_MINFILTER, d3d9::D3DTEXF_POINT);
-            m_d3d9->SetSamplerState(0, d3d9::D3DSAMP_MIPFILTER, d3d9::D3DTEXF_POINT);
+            device9->SetSamplerState(0, d3d9::D3DSAMP_MINFILTER, d3d9::D3DTEXF_POINT);
+            device9->SetSamplerState(0, d3d9::D3DSAMP_MIPFILTER, d3d9::D3DTEXF_POINT);
             break;
           // "The closest mipmap level is chosen and a bilinear filter is applied within it."
           case D3DFILTER_MIPLINEAR:
-            m_d3d9->SetSamplerState(0, d3d9::D3DSAMP_MINFILTER, d3d9::D3DTEXF_LINEAR);
-            m_d3d9->SetSamplerState(0, d3d9::D3DSAMP_MIPFILTER, d3d9::D3DTEXF_POINT);
+            device9->SetSamplerState(0, d3d9::D3DSAMP_MINFILTER, d3d9::D3DTEXF_LINEAR);
+            device9->SetSamplerState(0, d3d9::D3DSAMP_MIPFILTER, d3d9::D3DTEXF_POINT);
             break;
           // "The two closest mipmap levels are chosen and then a linear
           //  blend is used between point filtered samples of each level."
           case D3DFILTER_LINEARMIPNEAREST:
-            m_d3d9->SetSamplerState(0, d3d9::D3DSAMP_MINFILTER, d3d9::D3DTEXF_POINT);
-            m_d3d9->SetSamplerState(0, d3d9::D3DSAMP_MIPFILTER, d3d9::D3DTEXF_LINEAR);
+            device9->SetSamplerState(0, d3d9::D3DSAMP_MINFILTER, d3d9::D3DTEXF_POINT);
+            device9->SetSamplerState(0, d3d9::D3DSAMP_MIPFILTER, d3d9::D3DTEXF_LINEAR);
             break;
           // "The two closest mipmap levels are chosen and then combined using a bilinear filter."
           case D3DFILTER_LINEARMIPLINEAR:
-            m_d3d9->SetSamplerState(0, d3d9::D3DSAMP_MINFILTER, d3d9::D3DTEXF_LINEAR);
-            m_d3d9->SetSamplerState(0, d3d9::D3DSAMP_MIPFILTER, d3d9::D3DTEXF_LINEAR);
+            device9->SetSamplerState(0, d3d9::D3DSAMP_MINFILTER, d3d9::D3DTEXF_LINEAR);
+            device9->SetSamplerState(0, d3d9::D3DSAMP_MIPFILTER, d3d9::D3DTEXF_LINEAR);
             break;
           default:
             break;
@@ -1040,12 +1053,12 @@ namespace dxvk {
           //  the colors that would have been used with no texturing."
           case D3DTBLEND_DECAL:
           case D3DTBLEND_COPY:
-            m_d3d9->SetTextureStageState(0, d3d9::D3DTSS_COLORARG1, D3DTA_TEXTURE);
-            m_d3d9->SetTextureStageState(0, d3d9::D3DTSS_ALPHAARG1, D3DTA_TEXTURE);
-            m_d3d9->SetTextureStageState(0, d3d9::D3DTSS_COLOROP,   D3DTOP_SELECTARG1);
-            m_d3d9->SetTextureStageState(0, d3d9::D3DTSS_ALPHAOP,   D3DTOP_SELECTARG1);
-            m_d3d9->SetTextureStageState(0, d3d9::D3DTSS_COLORARG2, D3DTA_CURRENT);
-            m_d3d9->SetTextureStageState(0, d3d9::D3DTSS_ALPHAARG2, D3DTA_CURRENT);
+            device9->SetTextureStageState(0, d3d9::D3DTSS_COLORARG1, D3DTA_TEXTURE);
+            device9->SetTextureStageState(0, d3d9::D3DTSS_ALPHAARG1, D3DTA_TEXTURE);
+            device9->SetTextureStageState(0, d3d9::D3DTSS_COLOROP,   D3DTOP_SELECTARG1);
+            device9->SetTextureStageState(0, d3d9::D3DTSS_ALPHAOP,   D3DTOP_SELECTARG1);
+            device9->SetTextureStageState(0, d3d9::D3DTSS_COLORARG2, D3DTA_CURRENT);
+            device9->SetTextureStageState(0, d3d9::D3DTSS_ALPHAARG2, D3DTA_CURRENT);
             break;
           // "In this mode, the RGB values of the texture are multiplied with the RGB values
           //  that would have been used with no texturing. Any alpha values in the texture
@@ -1053,43 +1066,43 @@ namespace dxvk {
           //  if the texture does not contain an alpha component, alpha values at the vertices
           //  in the source are interpolated between vertices."
           case D3DTBLEND_MODULATE:
-            m_d3d9->SetTextureStageState(0, d3d9::D3DTSS_COLORARG1, D3DTA_TEXTURE);
-            m_d3d9->SetTextureStageState(0, d3d9::D3DTSS_ALPHAARG1, D3DTA_TEXTURE);
-            m_d3d9->SetTextureStageState(0, d3d9::D3DTSS_COLOROP,   D3DTOP_MODULATE);
-            m_d3d9->SetTextureStageState(0, d3d9::D3DTSS_ALPHAOP,   D3DTOP_SELECTARG1);
-            m_d3d9->SetTextureStageState(0, d3d9::D3DTSS_COLORARG2, D3DTA_DIFFUSE);
-            m_d3d9->SetTextureStageState(0, d3d9::D3DTSS_ALPHAARG2, D3DTA_DIFFUSE);
+            device9->SetTextureStageState(0, d3d9::D3DTSS_COLORARG1, D3DTA_TEXTURE);
+            device9->SetTextureStageState(0, d3d9::D3DTSS_ALPHAARG1, D3DTA_TEXTURE);
+            device9->SetTextureStageState(0, d3d9::D3DTSS_COLOROP,   D3DTOP_MODULATE);
+            device9->SetTextureStageState(0, d3d9::D3DTSS_ALPHAOP,   D3DTOP_SELECTARG1);
+            device9->SetTextureStageState(0, d3d9::D3DTSS_COLORARG2, D3DTA_DIFFUSE);
+            device9->SetTextureStageState(0, d3d9::D3DTSS_ALPHAARG2, D3DTA_DIFFUSE);
             break;
           // "In this mode, the RGB and alpha values of the texture are blended with the colors
           //  that would have been used with no texturing, according to the following formulas [...]"
           case D3DTBLEND_DECALALPHA:
-            m_d3d9->SetTextureStageState(0, d3d9::D3DTSS_COLORARG1, D3DTA_TEXTURE);
-            m_d3d9->SetTextureStageState(0, d3d9::D3DTSS_ALPHAARG1, D3DTA_TEXTURE);
-            m_d3d9->SetTextureStageState(0, d3d9::D3DTSS_COLOROP,   D3DTOP_BLENDTEXTUREALPHA);
-            m_d3d9->SetTextureStageState(0, d3d9::D3DTSS_ALPHAOP,   D3DTOP_SELECTARG2);
-            m_d3d9->SetTextureStageState(0, d3d9::D3DTSS_COLORARG2, D3DTA_DIFFUSE);
-            m_d3d9->SetTextureStageState(0, d3d9::D3DTSS_ALPHAARG2, D3DTA_DIFFUSE);
+            device9->SetTextureStageState(0, d3d9::D3DTSS_COLORARG1, D3DTA_TEXTURE);
+            device9->SetTextureStageState(0, d3d9::D3DTSS_ALPHAARG1, D3DTA_TEXTURE);
+            device9->SetTextureStageState(0, d3d9::D3DTSS_COLOROP,   D3DTOP_BLENDTEXTUREALPHA);
+            device9->SetTextureStageState(0, d3d9::D3DTSS_ALPHAOP,   D3DTOP_SELECTARG2);
+            device9->SetTextureStageState(0, d3d9::D3DTSS_COLORARG2, D3DTA_DIFFUSE);
+            device9->SetTextureStageState(0, d3d9::D3DTSS_ALPHAARG2, D3DTA_DIFFUSE);
             break;
           // "In this mode, the RGB values of the texture are multiplied with the RGB values that
           //  would have been used with no texturing, and the alpha values of the texture
           //  are multiplied with the alpha values that would have been used with no texturing."
           case D3DTBLEND_MODULATEALPHA:
-            m_d3d9->SetTextureStageState(0, d3d9::D3DTSS_COLORARG1, D3DTA_TEXTURE);
-            m_d3d9->SetTextureStageState(0, d3d9::D3DTSS_ALPHAARG1, D3DTA_TEXTURE);
-            m_d3d9->SetTextureStageState(0, d3d9::D3DTSS_COLOROP,   D3DTOP_MODULATE);
-            m_d3d9->SetTextureStageState(0, d3d9::D3DTSS_ALPHAOP,   D3DTOP_MODULATE);
-            m_d3d9->SetTextureStageState(0, d3d9::D3DTSS_COLORARG2, D3DTA_DIFFUSE);
-            m_d3d9->SetTextureStageState(0, d3d9::D3DTSS_ALPHAARG2, D3DTA_DIFFUSE);
+            device9->SetTextureStageState(0, d3d9::D3DTSS_COLORARG1, D3DTA_TEXTURE);
+            device9->SetTextureStageState(0, d3d9::D3DTSS_ALPHAARG1, D3DTA_TEXTURE);
+            device9->SetTextureStageState(0, d3d9::D3DTSS_COLOROP,   D3DTOP_MODULATE);
+            device9->SetTextureStageState(0, d3d9::D3DTSS_ALPHAOP,   D3DTOP_MODULATE);
+            device9->SetTextureStageState(0, d3d9::D3DTSS_COLORARG2, D3DTA_DIFFUSE);
+            device9->SetTextureStageState(0, d3d9::D3DTSS_ALPHAARG2, D3DTA_DIFFUSE);
             break;
           // "Add the Gouraud interpolants to the texture lookup with saturation semantics
           //  (that is, if the color value overflows it is set to the maximum possible value)."
           case D3DTBLEND_ADD:
-            m_d3d9->SetTextureStageState(0, d3d9::D3DTSS_COLORARG1, D3DTA_TEXTURE);
-            m_d3d9->SetTextureStageState(0, d3d9::D3DTSS_ALPHAARG1, D3DTA_TEXTURE);
-            m_d3d9->SetTextureStageState(0, d3d9::D3DTSS_COLOROP,   D3DTOP_ADD);
-            m_d3d9->SetTextureStageState(0, d3d9::D3DTSS_ALPHAOP,   D3DTOP_SELECTARG2);
-            m_d3d9->SetTextureStageState(0, d3d9::D3DTSS_COLORARG2, D3DTA_DIFFUSE);
-            m_d3d9->SetTextureStageState(0, d3d9::D3DTSS_ALPHAARG2, D3DTA_DIFFUSE);
+            device9->SetTextureStageState(0, d3d9::D3DTSS_COLORARG1, D3DTA_TEXTURE);
+            device9->SetTextureStageState(0, d3d9::D3DTSS_ALPHAARG1, D3DTA_TEXTURE);
+            device9->SetTextureStageState(0, d3d9::D3DTSS_COLOROP,   D3DTOP_ADD);
+            device9->SetTextureStageState(0, d3d9::D3DTSS_ALPHAOP,   D3DTOP_SELECTARG2);
+            device9->SetTextureStageState(0, d3d9::D3DTSS_COLORARG2, D3DTA_DIFFUSE);
+            device9->SetTextureStageState(0, d3d9::D3DTSS_ALPHAARG2, D3DTA_DIFFUSE);
             break;
           // Unsupported
           default:
@@ -1162,19 +1175,19 @@ namespace dxvk {
         break;
 
       case D3DRENDERSTATE_BORDERCOLOR:
-        m_d3d9->SetSamplerState(0, d3d9::D3DSAMP_BORDERCOLOR, dwRenderState);
+        device9->SetSamplerState(0, d3d9::D3DSAMP_BORDERCOLOR, dwRenderState);
         return D3D_OK;
 
       case D3DRENDERSTATE_TEXTUREADDRESSU:
-        m_d3d9->SetSamplerState(0, d3d9::D3DSAMP_ADDRESSU, dwRenderState);
+        device9->SetSamplerState(0, d3d9::D3DSAMP_ADDRESSU, dwRenderState);
         return D3D_OK;
 
       case D3DRENDERSTATE_TEXTUREADDRESSV:
-        m_d3d9->SetSamplerState(0, d3d9::D3DSAMP_ADDRESSV, dwRenderState);
+        device9->SetSamplerState(0, d3d9::D3DSAMP_ADDRESSV, dwRenderState);
         return D3D_OK;
 
       case D3DRENDERSTATE_MIPMAPLODBIAS:
-        m_d3d9->SetSamplerState(0, d3d9::D3DSAMP_MIPMAPLODBIAS, dwRenderState);
+        device9->SetSamplerState(0, d3d9::D3DSAMP_MIPMAPLODBIAS, dwRenderState);
         return D3D_OK;
 
       case D3DRENDERSTATE_ZBIAS:
@@ -1183,7 +1196,7 @@ namespace dxvk {
         break;
 
       case D3DRENDERSTATE_ANISOTROPY:
-        m_d3d9->SetSamplerState(0, d3d9::D3DSAMP_MAXANISOTROPY, dwRenderState);
+        device9->SetSamplerState(0, d3d9::D3DSAMP_MAXANISOTROPY, dwRenderState);
         return D3D_OK;
 
       // Not mentioned in the D3D5 docs, but seen in the wild. D3D6 docs state:
@@ -1235,7 +1248,7 @@ namespace dxvk {
     }
 
     // This call will never fail
-    return m_d3d9->SetRenderState(State9, dwRenderState);
+    return device9->SetRenderState(State9, dwRenderState);
   }
 
   HRESULT STDMETHODCALLTYPE D3D5Device::GetLightState(D3DLIGHTSTATETYPE dwLightStateType, LPDWORD lpdwLightState) {
@@ -1243,27 +1256,29 @@ namespace dxvk {
 
     Logger::debug(">>> D3D5Device::GetLightState");
 
+    d3d9::IDirect3DDevice9* device9 = m_commonD3DDevice->GetD3D9Device();
+
     switch (dwLightStateType) {
       case D3DLIGHTSTATE_MATERIAL:
         *lpdwLightState = m_commonD3DDevice->GetCurrentMaterialHandle();
         break;
       case D3DLIGHTSTATE_AMBIENT:
-        m_d3d9->GetRenderState(d3d9::D3DRS_AMBIENT, lpdwLightState);
+        device9->GetRenderState(d3d9::D3DRS_AMBIENT, lpdwLightState);
         break;
       case D3DLIGHTSTATE_COLORMODEL:
         *lpdwLightState = D3DCOLOR_RGB;
         break;
       case D3DLIGHTSTATE_FOGMODE:
-        m_d3d9->GetRenderState(d3d9::D3DRS_FOGVERTEXMODE, lpdwLightState);
+        device9->GetRenderState(d3d9::D3DRS_FOGVERTEXMODE, lpdwLightState);
         break;
       case D3DLIGHTSTATE_FOGSTART:
-        m_d3d9->GetRenderState(d3d9::D3DRS_FOGSTART, lpdwLightState);
+        device9->GetRenderState(d3d9::D3DRS_FOGSTART, lpdwLightState);
         break;
       case D3DLIGHTSTATE_FOGEND:
-        m_d3d9->GetRenderState(d3d9::D3DRS_FOGEND, lpdwLightState);
+        device9->GetRenderState(d3d9::D3DRS_FOGEND, lpdwLightState);
         break;
       case D3DLIGHTSTATE_FOGDENSITY:
-        m_d3d9->GetRenderState(d3d9::D3DRS_FOGDENSITY, lpdwLightState);
+        device9->GetRenderState(d3d9::D3DRS_FOGDENSITY, lpdwLightState);
         break;
       default:
         return DDERR_INVALIDPARAMS;
@@ -1276,6 +1291,8 @@ namespace dxvk {
     D3DDeviceLock lock = LockDevice();
 
     Logger::debug(">>> D3D5Device::SetLightState");
+
+    d3d9::IDirect3DDevice9* device9 = m_commonD3DDevice->GetD3D9Device();
 
     switch (dwLightStateType) {
       case D3DLIGHTSTATE_MATERIAL: {
@@ -1290,28 +1307,28 @@ namespace dxvk {
 
         m_commonD3DDevice->SetCurrentMaterialHandle(dwLightState);
         Logger::debug(str::format("D3D5Device::SetLightState: Applying material nr. ", dwLightState, " to D3D9"));
-        m_d3d9->SetMaterial(material9);
+        device9->SetMaterial(material9);
 
         break;
       }
       case D3DLIGHTSTATE_AMBIENT:
-        m_d3d9->SetRenderState(d3d9::D3DRS_AMBIENT, dwLightState);
+        device9->SetRenderState(d3d9::D3DRS_AMBIENT, dwLightState);
         break;
       case D3DLIGHTSTATE_COLORMODEL:
         if (unlikely(dwLightState != D3DCOLOR_RGB))
           Logger::warn("D3D5Device::SetLightState: Unsupported D3DLIGHTSTATE_COLORMODEL");
         break;
       case D3DLIGHTSTATE_FOGMODE:
-        m_d3d9->SetRenderState(d3d9::D3DRS_FOGVERTEXMODE, dwLightState);
+        device9->SetRenderState(d3d9::D3DRS_FOGVERTEXMODE, dwLightState);
         break;
       case D3DLIGHTSTATE_FOGSTART:
-        m_d3d9->SetRenderState(d3d9::D3DRS_FOGSTART, dwLightState);
+        device9->SetRenderState(d3d9::D3DRS_FOGSTART, dwLightState);
         break;
       case D3DLIGHTSTATE_FOGEND:
-        m_d3d9->SetRenderState(d3d9::D3DRS_FOGEND, dwLightState);
+        device9->SetRenderState(d3d9::D3DRS_FOGEND, dwLightState);
         break;
       case D3DLIGHTSTATE_FOGDENSITY:
-        m_d3d9->SetRenderState(d3d9::D3DRS_FOGDENSITY, dwLightState);
+        device9->SetRenderState(d3d9::D3DRS_FOGDENSITY, dwLightState);
         break;
       default:
         return DDERR_INVALIDPARAMS;
@@ -1322,17 +1339,17 @@ namespace dxvk {
 
   HRESULT STDMETHODCALLTYPE D3D5Device::SetTransform(D3DTRANSFORMSTATETYPE state, D3DMATRIX *matrix) {
     Logger::debug(">>> D3D5Device::SetTransform");
-    return m_d3d9->SetTransform(ConvertTransformState(state), matrix);
+    return m_commonD3DDevice->GetD3D9Device()->SetTransform(ConvertTransformState(state), matrix);
   }
 
   HRESULT STDMETHODCALLTYPE D3D5Device::GetTransform(D3DTRANSFORMSTATETYPE state, D3DMATRIX *matrix) {
     Logger::debug(">>> D3D5Device::GetTransform");
-    return m_d3d9->GetTransform(ConvertTransformState(state), matrix);
+    return m_commonD3DDevice->GetD3D9Device()->GetTransform(ConvertTransformState(state), matrix);
   }
 
   HRESULT STDMETHODCALLTYPE D3D5Device::MultiplyTransform(D3DTRANSFORMSTATETYPE state, D3DMATRIX *matrix) {
     Logger::debug(">>> D3D5Device::MultiplyTransform");
-    return m_d3d9->MultiplyTransform(ConvertTransformState(state), matrix);
+    return m_commonD3DDevice->GetD3D9Device()->MultiplyTransform(ConvertTransformState(state), matrix);
   }
 
   HRESULT STDMETHODCALLTYPE D3D5Device::DrawPrimitive(D3DPRIMITIVETYPE primitive_type, D3DVERTEXTYPE vertex_type, void *vertices, DWORD vertex_count, DWORD flags) {
@@ -1348,6 +1365,8 @@ namespace dxvk {
     if (unlikely(vertices == nullptr))
       return DDERR_INVALIDPARAMS;
 
+    d3d9::IDirect3DDevice9* device9 = m_commonD3DDevice->GetD3D9Device();
+
     m_rt->InitializeOrUploadD3D9();
     if (likely(m_ds != nullptr))
       m_ds->InitializeOrUploadD3D9();
@@ -1357,8 +1376,8 @@ namespace dxvk {
     HandlePreDrawFlags(flags, vertex_type5);
     HandlePreDrawLegacyProjection(flags);
 
-    m_d3d9->SetFVF(vertex_type5);
-    HRESULT hr = m_d3d9->DrawPrimitiveUP(
+    device9->SetFVF(vertex_type5);
+    HRESULT hr = device9->DrawPrimitiveUP(
                      d3d9::D3DPRIMITIVETYPE(primitive_type),
                      GetPrimitiveCount(primitive_type, vertex_count),
                      vertices,
@@ -1390,6 +1409,8 @@ namespace dxvk {
     if (unlikely(vertices == nullptr || indices == nullptr))
       return DDERR_INVALIDPARAMS;
 
+    d3d9::IDirect3DDevice9* device9 = m_commonD3DDevice->GetD3D9Device();
+
     m_rt->InitializeOrUploadD3D9();
     if (likely(m_ds != nullptr))
       m_ds->InitializeOrUploadD3D9();
@@ -1399,8 +1420,8 @@ namespace dxvk {
     HandlePreDrawFlags(flags, fvf5);
     HandlePreDrawLegacyProjection(flags);
 
-    m_d3d9->SetFVF(fvf5);
-    HRESULT hr = m_d3d9->DrawIndexedPrimitiveUP(
+    device9->SetFVF(fvf5);
+    HRESULT hr = device9->DrawIndexedPrimitiveUP(
                       d3d9::D3DPRIMITIVETYPE(primitive_type),
                       0,
                       vertex_count,
@@ -1439,7 +1460,7 @@ namespace dxvk {
       return DDERR_INVALIDPARAMS;
 
     d3d9::D3DVIEWPORT9 viewport9;
-    if (SUCCEEDED(m_d3d9->GetViewport(&viewport9))) {
+    if (SUCCEEDED(m_commonD3DDevice->GetD3D9Device()->GetViewport(&viewport9))) {
       clip_status->dwFlags = D3DCLIPSTATUS_EXTENTS2;
       clip_status->dwStatus = 0;
       clip_status->minx = viewport9.X;
@@ -1454,6 +1475,8 @@ namespace dxvk {
   }
 
   void D3D5Device::InitializeDS() {
+    d3d9::IDirect3DDevice9* device9 = m_commonD3DDevice->GetD3D9Device();
+
     m_rt->InitializeD3D9RenderTarget();
 
     m_ds = m_rt->GetAttachedDepthStencil();
@@ -1472,19 +1495,19 @@ namespace dxvk {
         m_ds->GetProxied()->GetSurfaceDesc(&descDS);
         Logger::debug(str::format("D3D5Device::InitializeDS: DepthStencil: ", descDS.dwWidth, "x", descDS.dwHeight));
 
-        HRESULT hrDS9 = m_d3d9->SetDepthStencilSurface(m_ds->GetD3D9());
+        HRESULT hrDS9 = device9->SetDepthStencilSurface(m_ds->GetCommonSurface()->GetD3D9Surface());
         if(unlikely(FAILED(hrDS9))) {
           Logger::err("D3D5Device::InitializeDS: Failed to set D3D9 depth stencil");
         } else {
           // This needs to act like an auto depth stencil of sorts, so manually enable z-buffering
-          m_d3d9->SetRenderState(d3d9::D3DRS_ZENABLE, d3d9::D3DZB_TRUE);
+          device9->SetRenderState(d3d9::D3DRS_ZENABLE, d3d9::D3DZB_TRUE);
         }
       }
     } else {
       Logger::info("D3D5Device::InitializeDS: RT has no depth stencil attached");
-      m_d3d9->SetDepthStencilSurface(nullptr);
+      device9->SetDepthStencilSurface(nullptr);
       // Should be superfluous, but play it safe
-      m_d3d9->SetRenderState(d3d9::D3DRS_ZENABLE, d3d9::D3DZB_FALSE);
+      device9->SetRenderState(d3d9::D3DRS_ZENABLE, d3d9::D3DZB_FALSE);
     }
   }
 
@@ -1533,11 +1556,13 @@ namespace dxvk {
 
     HRESULT hr;
 
+    d3d9::IDirect3DDevice9* device9 = m_commonD3DDevice->GetD3D9Device();
+
     // Unbinding texture stages
     if (surface == nullptr) {
       Logger::debug("D3D5Device::SetTextureInternal: Unbiding D3D9 texture");
 
-      hr = m_d3d9->SetTexture(0, nullptr);
+      hr = device9->SetTexture(0, nullptr);
 
       if (likely(SUCCEEDED(hr))) {
         if (m_commonD3DDevice->GetCurrentTextureHandle() != 0) {
@@ -1555,7 +1580,7 @@ namespace dxvk {
 
     // If textures have been used on a different device, they
     // will get their D3D9 object reinitialized at this point
-    if (unlikely(surface->GetD3D9Device() != m_d3d9.ptr()))
+    if (unlikely(surface->GetCommonD3DDevice() != m_commonD3DDevice.ptr()))
       surface->GetCommonSurface()->DirtyDDrawSurface();
 
     hr = surface->InitializeOrUploadD3D9();
@@ -1568,10 +1593,10 @@ namespace dxvk {
     //if (unlikely(m_commonD3DDevice->GetCurrentTextureHandle() == textureHandle))
       //return D3D_OK;
 
-    d3d9::IDirect3DTexture9* tex9 = surface->GetD3D9Texture();
+    d3d9::IDirect3DTexture9* tex9 = surface->GetCommonSurface()->GetD3D9Texture();
 
     if (likely(tex9 != nullptr)) {
-      hr = m_d3d9->SetTexture(0, tex9);
+      hr = device9->SetTexture(0, tex9);
       if (unlikely(FAILED(hr))) {
         Logger::warn("D3D5Device::SetTextureInternal: Failed to bind D3D9 texture");
         return hr;
@@ -1582,7 +1607,7 @@ namespace dxvk {
       //  alpha values at the vertices in the source are interpolated between vertices."
       if (m_commonD3DDevice->GetTextureMapBlend() == D3DTBLEND_MODULATE) {
         const DWORD textureOp = surface->GetCommonSurface()->IsAlphaFormat() ? D3DTOP_SELECTARG1 : D3DTOP_MODULATE;
-        m_d3d9->SetTextureStageState(0, d3d9::D3DTSS_ALPHAOP, textureOp);
+        device9->SetTextureStageState(0, d3d9::D3DTSS_ALPHAOP, textureOp);
       }
 
       const bool colorKeyEnable = m_commonD3DDevice->GetColorKeyEnable();

--- a/src/ddraw/d3d5/d3d5_device.h
+++ b/src/ddraw/d3d5/d3d5_device.h
@@ -27,7 +27,7 @@ namespace dxvk {
   /**
   * \brief D3D5 device implementation
   */
-  class D3D5Device final : public DDrawWrappedObject<D3D5Interface, IDirect3DDevice2, d3d9::IDirect3DDevice9> {
+  class D3D5Device final : public DDrawWrappedObject<D3D5Interface, IDirect3DDevice2> {
 
   public:
     D3D5Device(
@@ -152,10 +152,12 @@ namespace dxvk {
       if (m_commonD3DDevice->GetCurrentMaterialHandle() == 0 ||
           (drawFlags & D3DDP_DONOTLIGHT) ||
          !(vertexTypeDesc & D3DFVF_NORMAL)) {
-        m_d3d9->GetRenderState(d3d9::D3DRS_LIGHTING, &m_lighting);
+        d3d9::IDirect3DDevice9* device9 = m_commonD3DDevice->GetD3D9Device();
+
+        device9->GetRenderState(d3d9::D3DRS_LIGHTING, &m_lighting);
         if (m_lighting) {
           //Logger::debug("D3D5Device: Disabling lighting");
-          m_d3d9->SetRenderState(d3d9::D3DRS_LIGHTING, FALSE);
+          device9->SetRenderState(d3d9::D3DRS_LIGHTING, FALSE);
         }
       }
     }
@@ -164,8 +166,10 @@ namespace dxvk {
       if ((m_commonD3DDevice->GetCurrentMaterialHandle() == 0 ||
           (drawFlags & D3DDP_DONOTLIGHT) ||
          !(vertexTypeDesc & D3DFVF_NORMAL)) && m_lighting) {
+        d3d9::IDirect3DDevice9* device9 = m_commonD3DDevice->GetD3D9Device();
+
         //Logger::debug("D3D5Device: Enabling lighting");
-        m_d3d9->SetRenderState(d3d9::D3DRS_LIGHTING, TRUE);
+        device9->SetRenderState(d3d9::D3DRS_LIGHTING, TRUE);
       }
     }
 
@@ -174,17 +178,21 @@ namespace dxvk {
         m_legacyProjection = m_currentViewport->GetCommonViewport()->GetLegacyProjectionMatrix(drawFlags);
 
         if (m_legacyProjection != nullptr) {
+          d3d9::IDirect3DDevice9* device9 = m_commonD3DDevice->GetD3D9Device();
+
           //Logger::debug("D3D5Device: Applying legacy projection");
-          m_d3d9->GetTransform(d3d9::D3DTS_PROJECTION, &m_projectionMatrix);
-          m_d3d9->MultiplyTransform(d3d9::D3DTS_PROJECTION, m_legacyProjection);
+          device9->GetTransform(d3d9::D3DTS_PROJECTION, &m_projectionMatrix);
+          device9->MultiplyTransform(d3d9::D3DTS_PROJECTION, m_legacyProjection);
         }
       }
     }
 
     inline void HandlePostDrawLegacyProjection() {
       if (m_legacyProjection != nullptr) {
+        d3d9::IDirect3DDevice9* device9 = m_commonD3DDevice->GetD3D9Device();
+
         //Logger::debug("D3D5Device: Reverting legacy projection");
-        m_d3d9->SetTransform(d3d9::D3DTS_PROJECTION, &m_projectionMatrix);
+        device9->SetTransform(d3d9::D3DTS_PROJECTION, &m_projectionMatrix);
       }
     }
 

--- a/src/ddraw/d3d5/d3d5_interface.cpp
+++ b/src/ddraw/d3d5/d3d5_interface.cpp
@@ -22,16 +22,22 @@ namespace dxvk {
         D3DCommonInterface* commonD3DIntf,
         Com<IDirect3D2>&& d3d5IntfProxy,
         IUnknown* pParent)
-    : DDrawWrappedObject<IUnknown, IDirect3D2, d3d9::IDirect3D9>(pParent, std::move(d3d5IntfProxy), std::move(d3d9::Direct3DCreate9(D3D_SDK_VERSION)))
+    : DDrawWrappedObject<IUnknown, IDirect3D2>(pParent, std::move(d3d5IntfProxy))
     , m_commonIntf ( m_commonIntf )
     , m_commonD3DIntf ( commonD3DIntf ) {
-    // Get the bridge interface to D3D9.
-    if (unlikely(FAILED(m_d3d9->QueryInterface(__uuidof(IDxvkD3D8InterfaceBridge), reinterpret_cast<void**>(&m_bridge))))) {
-      throw DxvkError("D3D5Interface: ERROR! Failed to get D3D9 Bridge. d3d9.dll might not be DXVK!");
+    if (m_commonD3DIntf == nullptr) {
+      m_commonD3DIntf = new D3DCommonInterface();
+
+      Com<d3d9::IDirect3D9> d3dIntf9 = d3d9::Direct3DCreate9(D3D_SDK_VERSION);
+      m_commonD3DIntf->SetD3D9Interface(std::move(d3dIntf9));
     }
 
-    if (m_commonD3DIntf == nullptr)
-      m_commonD3DIntf = new D3DCommonInterface();
+    d3d9::IDirect3D9* d3dIntf9 = m_commonD3DIntf->GetD3D9Interface();
+
+    // Get the bridge interface to D3D9.
+    if (unlikely(FAILED(d3dIntf9->QueryInterface(__uuidof(IDxvkD3D8InterfaceBridge), reinterpret_cast<void**>(&m_bridge))))) {
+      throw DxvkError("D3D5Interface: ERROR! Failed to get D3D9 Bridge. d3d9.dll might not be DXVK!");
+    }
 
     m_commonD3DIntf->SetD3D5Interface(this);
 
@@ -379,6 +385,8 @@ namespace dxvk {
   HRESULT STDMETHODCALLTYPE D3D5Interface::CreateDevice(REFCLSID rclsid, LPDIRECTDRAWSURFACE lpDDS, LPDIRECT3DDEVICE2 *lplpD3DDevice) {
     Logger::debug(">>> D3D5Interface::CreateDevice");
 
+    d3d9::IDirect3D9* d3dIntf9 = m_commonD3DIntf->GetD3D9Interface();
+
     if (unlikely(lplpD3DDevice == nullptr))
       return DDERR_INVALIDPARAMS;
 
@@ -483,11 +491,11 @@ namespace dxvk {
     // Determine the supported AA sample count by querying the D3D9 interface
     d3d9::D3DMULTISAMPLE_TYPE multiSampleType = d3d9::D3DMULTISAMPLE_NONE;
     if (likely(d3dOptions->emulateFSAA != FSAAEmulation::Disabled)) {
-      HRESULT hr4S = m_d3d9->CheckDeviceMultiSampleType(0, d3d9::D3DDEVTYPE_HAL, backBufferFormat,
-                                                        TRUE, d3d9::D3DMULTISAMPLE_4_SAMPLES, NULL);
+      HRESULT hr4S = d3dIntf9->CheckDeviceMultiSampleType(0, d3d9::D3DDEVTYPE_HAL, backBufferFormat,
+                                                          TRUE, d3d9::D3DMULTISAMPLE_4_SAMPLES, NULL);
       if (unlikely(FAILED(hr4S))) {
-        HRESULT hr2S = m_d3d9->CheckDeviceMultiSampleType(0, d3d9::D3DDEVTYPE_HAL, backBufferFormat,
-                                                          TRUE, d3d9::D3DMULTISAMPLE_2_SAMPLES, NULL);
+        HRESULT hr2S = d3dIntf9->CheckDeviceMultiSampleType(0, d3d9::D3DDEVTYPE_HAL, backBufferFormat,
+                                                            TRUE, d3d9::D3DMULTISAMPLE_2_SAMPLES, NULL);
         if (unlikely(FAILED(hr2S))) {
           Logger::warn("D3D5Interface::CreateDevice: No MSAA support has been detected");
         } else {
@@ -538,7 +546,7 @@ namespace dxvk {
     params.PresentationInterval       = D3DPRESENT_INTERVAL_DEFAULT; // A D3D5 device always uses VSync
 
     Com<d3d9::IDirect3DDevice9> device9;
-    hr = m_d3d9->CreateDevice(
+    hr = d3dIntf9->CreateDevice(
       D3DADAPTER_DEFAULT,
       d3d9::D3DDEVTYPE_HAL,
       hWnd,

--- a/src/ddraw/d3d5/d3d5_interface.h
+++ b/src/ddraw/d3d5/d3d5_interface.h
@@ -16,7 +16,7 @@ namespace dxvk {
   /**
   * \brief D3D5 interface implementation
   */
-  class D3D5Interface final : public DDrawWrappedObject<IUnknown, IDirect3D2, d3d9::IDirect3D9> {
+  class D3D5Interface final : public DDrawWrappedObject<IUnknown, IDirect3D2> {
 
   public:
     D3D5Interface(

--- a/src/ddraw/d3d5/d3d5_material.cpp
+++ b/src/ddraw/d3d5/d3d5_material.cpp
@@ -15,7 +15,7 @@ namespace dxvk {
         Com<IDirect3DMaterial2>&& proxyMaterial,
         D3D5Interface* pParent,
         D3DMATERIALHANDLE handle)
-    : DDrawWrappedObject<D3D5Interface, IDirect3DMaterial2, IUnknown>(pParent, std::move(proxyMaterial), nullptr) {
+    : DDrawWrappedObject<D3D5Interface, IDirect3DMaterial2>(pParent, std::move(proxyMaterial)) {
     m_commonMaterial = new D3DCommonMaterial(handle);
 
     m_commonMaterial->SetD3D5Material(this);

--- a/src/ddraw/d3d5/d3d5_material.h
+++ b/src/ddraw/d3d5/d3d5_material.h
@@ -9,7 +9,7 @@ namespace dxvk {
 
   class D3D5Interface;
 
-  class D3D5Material final : public DDrawWrappedObject<D3D5Interface, IDirect3DMaterial2, IUnknown> {
+  class D3D5Material final : public DDrawWrappedObject<D3D5Interface, IDirect3DMaterial2> {
 
   public:
 

--- a/src/ddraw/d3d5/d3d5_texture.cpp
+++ b/src/ddraw/d3d5/d3d5_texture.cpp
@@ -12,7 +12,7 @@ namespace dxvk {
         Com<IDirect3DTexture2>&& proxyTexture,
         DDrawSurface* pParent,
         D3DTEXTUREHANDLE handle)
-    : DDrawWrappedObject<DDrawSurface, IDirect3DTexture2, IUnknown>(pParent, std::move(proxyTexture), nullptr) {
+    : DDrawWrappedObject<DDrawSurface, IDirect3DTexture2>(pParent, std::move(proxyTexture)) {
     m_commonTex = new D3DCommonTexture(m_parent->GetCommonSurface(), handle);
 
     m_texCount = ++s_texCount;

--- a/src/ddraw/d3d5/d3d5_texture.h
+++ b/src/ddraw/d3d5/d3d5_texture.h
@@ -9,7 +9,7 @@ namespace dxvk {
 
   class DDrawSurface;
 
-  class D3D5Texture final : public DDrawWrappedObject<DDrawSurface, IDirect3DTexture2, IUnknown> {
+  class D3D5Texture final : public DDrawWrappedObject<DDrawSurface, IDirect3DTexture2> {
 
   public:
 

--- a/src/ddraw/d3d5/d3d5_viewport.cpp
+++ b/src/ddraw/d3d5/d3d5_viewport.cpp
@@ -21,7 +21,7 @@ namespace dxvk {
         D3DCommonViewport* commonViewport,
         Com<IDirect3DViewport2>&& proxyViewport,
         D3D5Interface* pParent)
-    : DDrawWrappedObject<D3D5Interface, IDirect3DViewport2, IUnknown>(pParent, std::move(proxyViewport), nullptr)
+    : DDrawWrappedObject<D3D5Interface, IDirect3DViewport2>(pParent, std::move(proxyViewport))
     , m_commonViewport ( commonViewport ) {
 
     if (m_commonViewport == nullptr)

--- a/src/ddraw/d3d5/d3d5_viewport.h
+++ b/src/ddraw/d3d5/d3d5_viewport.h
@@ -15,7 +15,7 @@ namespace dxvk {
   class D3D6Viewport;
   class D3D3Viewport;
 
-  class D3D5Viewport final : public DDrawWrappedObject<D3D5Interface, IDirect3DViewport2, IUnknown> {
+  class D3D5Viewport final : public DDrawWrappedObject<D3D5Interface, IDirect3DViewport2> {
 
   public:
 

--- a/src/ddraw/d3d6/d3d6_buffer.cpp
+++ b/src/ddraw/d3d6/d3d6_buffer.cpp
@@ -17,7 +17,7 @@ namespace dxvk {
         D3D6Interface* pParent,
         DWORD creationFlags,
         D3DVERTEXBUFFERDESC desc)
-    : DDrawWrappedObject<D3D6Interface, IDirect3DVertexBuffer, d3d9::IDirect3DVertexBuffer9>(pParent, nullptr, nullptr)
+    : DDrawWrappedObject<D3D6Interface, IDirect3DVertexBuffer>(pParent, nullptr)
     , m_commonIntf ( pParent->GetCommonInterface() )
     , m_creationFlags ( creationFlags )
     , m_desc ( desc )
@@ -54,7 +54,7 @@ namespace dxvk {
     if (unlikely(IsOptimized()))
       return D3DERR_VERTEXBUFFEROPTIMIZED;
 
-    RefreshD3D6Device();
+    RefreshD3DDevice();
     if (unlikely(!IsInitialized())) {
       HRESULT hrInit = InitializeD3D9();
       if (unlikely(FAILED(hrInit)))
@@ -64,7 +64,7 @@ namespace dxvk {
     if (data_size != nullptr)
       *data_size = m_size;
 
-    HRESULT hr = m_d3d9->Lock(0, 0, data, ConvertD3D6LockFlags(flags, false));
+    HRESULT hr = m_vb9->Lock(0, 0, data, ConvertD3D6LockFlags(flags, false));
 
     if (likely(SUCCEEDED(hr)))
       m_locked = true;
@@ -75,14 +75,14 @@ namespace dxvk {
   HRESULT STDMETHODCALLTYPE D3D6VertexBuffer::Unlock() {
     Logger::debug(">>> D3D6VertexBuffer::Unlock");
 
-    RefreshD3D6Device();
+    RefreshD3DDevice();
     if (unlikely(!IsInitialized())) {
       HRESULT hrInit = InitializeD3D9();
       if (unlikely(FAILED(hrInit)))
         return hrInit;
     }
 
-    HRESULT hr = m_d3d9->Unlock();
+    HRESULT hr = m_vb9->Unlock();
 
     if (likely(SUCCEEDED(hr)))
       m_locked = false;
@@ -107,7 +107,7 @@ namespace dxvk {
     D3D6Device* device = static_cast<D3D6Device*>(lpD3DDevice);
     D3D6VertexBuffer* vb = static_cast<D3D6VertexBuffer*>(lpSrcBuffer);
 
-    vb->RefreshD3D6Device();
+    vb->RefreshD3DDevice();
     if (unlikely(vb->GetDevice() == nullptr || device != vb->GetDevice())) {
       Logger::err("D3D6VertexBuffer::ProcessVertices: Incompatible or null device");
       return DDERR_GENERIC;
@@ -123,7 +123,7 @@ namespace dxvk {
     }
 
     // Check and initialize the destination buffer (this buffer)
-    RefreshD3D6Device();
+    d3d9::IDirect3DDevice9* device9 = RefreshD3DDevice();
     if (unlikely(!IsInitialized())) {
       hrInit = InitializeD3D9();
       if (unlikely(FAILED(hrInit)))
@@ -140,13 +140,14 @@ namespace dxvk {
       uint8_t *inData = nullptr;
       uint8_t *outData = nullptr;
 
-      HRESULT hr = vb->GetD3D9()->Lock(dwSrcIndex * vb->GetStride(), dwCount * vb->GetStride(), reinterpret_cast<void**>(&inData), D3DLOCK_READONLY|D3DLOCK_NOSYSLOCK);
+      HRESULT hr = vb->GetD3D9VertexBuffer()->Lock(dwSrcIndex * vb->GetStride(), dwCount * vb->GetStride(),
+                                                   reinterpret_cast<void**>(&inData), D3DLOCK_READONLY|D3DLOCK_NOSYSLOCK);
       if (unlikely(FAILED(hr))) {
         Logger::err("D3D6VertexBuffer::ProcessVertices: Failed to lock source buffer");
         return D3DERR_VERTEXBUFFERLOCKED;
       }
 
-      hr = m_d3d9->Lock(dwDestIndex * m_stride, dwCount * m_stride, reinterpret_cast<void**>(&outData), D3DLOCK_NOSYSLOCK);
+      hr = m_vb9->Lock(dwDestIndex * m_stride, dwCount * m_stride, reinterpret_cast<void**>(&outData), D3DLOCK_NOSYSLOCK);
       if (unlikely(FAILED(hr))) {
         Logger::err("D3D6VertexBuffer::ProcessVertices: Failed to lock destination buffer");
         vb->Unlock();
@@ -185,17 +186,17 @@ namespace dxvk {
 
       pvData.lights = &lights9;
 
-      ProcessVerticesSW(device->GetD3D9(), m_commonIntf->GetOptions(), &pvData);
+      ProcessVerticesSW(device9, m_commonIntf->GetOptions(), &pvData);
 
-      m_d3d9->Unlock();
+      m_vb9->Unlock();
       vb->Unlock();
 
     } else {
       HandlePreProcessVerticesFlags(dwVertexOp);
 
-      device->GetD3D9()->SetFVF(vb->GetFVF());
-      device->GetD3D9()->SetStreamSource(0, vb->GetD3D9(), 0, vb->GetStride());
-      hr = device->GetD3D9()->ProcessVertices(dwSrcIndex, dwDestIndex, dwCount, m_d3d9.ptr(), nullptr, dwFlags);
+      device9->SetFVF(vb->GetFVF());
+      device9->SetStreamSource(0, vb->GetD3D9VertexBuffer(), 0, vb->GetStride());
+      hr = device9->ProcessVertices(dwSrcIndex, dwDestIndex, dwCount, m_vb9.ptr(), nullptr, dwFlags);
       if (unlikely(FAILED(hr))) {
         Logger::err("D3D6VertexBuffer::ProcessVertices: Failed call to D3D9 ProcessVertices");
       }
@@ -230,6 +231,8 @@ namespace dxvk {
       return DDERR_GENERIC;
     }
 
+    d3d9::IDirect3DDevice9* device9 = m_d3d6Device->GetCommonD3DDevice()->GetD3D9Device();
+
     d3d9::D3DPOOL pool = d3d9::D3DPOOL_DEFAULT;
 
     if (m_desc.dwCaps & D3DVBCAPS_SYSTEMMEMORY)
@@ -240,7 +243,7 @@ namespace dxvk {
     Logger::debug(str::format("D3D6VertexBuffer::InitializeD3D9: Placing in: ", poolPlacement));
 
     const DWORD usage = ConvertD3D6UsageFlags(m_desc.dwCaps, m_creationFlags);
-    HRESULT hr = m_d3d6Device->GetD3D9()->CreateVertexBuffer(m_size, usage, m_desc.dwFVF, pool, &m_d3d9, nullptr);
+    HRESULT hr = device9->CreateVertexBuffer(m_size, usage, m_desc.dwFVF, pool, &m_vb9, nullptr);
 
     if (unlikely(FAILED(hr))) {
       Logger::err("D3D6VertexBuffer::InitializeD3D9: Failed to create D3D9 vertex buffer");
@@ -252,18 +255,44 @@ namespace dxvk {
     return DD_OK;
   }
 
-  void D3D6VertexBuffer::RefreshD3D6Device() {
-    D3DCommonDevice* commonDevice = m_commonIntf->GetCommonD3DDevice();
+  d3d9::IDirect3DDevice9* D3D6VertexBuffer::RefreshD3DDevice() {
+    D3DCommonDevice* commonD3DDevice = m_commonIntf->GetCommonD3DDevice();
 
-    D3D6Device* d3d6Device = commonDevice != nullptr ? commonDevice->GetD3D6Device() : nullptr;
+    D3D6Device* d3d6Device = commonD3DDevice != nullptr ? commonD3DDevice->GetD3D6Device() : nullptr;
     if (unlikely(m_d3d6Device != d3d6Device)) {
       // Check if the device has been recreated and reset all D3D9 resources
       if (unlikely(m_d3d6Device != nullptr)) {
-        Logger::debug("D3D6VertexBuffer::RefreshD3D6Device: Device context has changed, clearing D3D9 buffers");
-        m_d3d9 = nullptr;
+        Logger::debug("D3D6VertexBuffer::RefreshD3DDevice: Device context has changed, clearing D3D9 buffers");
+        m_vb9 = nullptr;
       }
       m_d3d6Device = d3d6Device;
     }
+
+    return commonD3DDevice != nullptr ? commonD3DDevice->GetD3D9Device() : nullptr;
+  }
+
+  inline void D3D6VertexBuffer::HandlePreProcessVerticesFlags(DWORD pvFlags) {
+    // Disable lighting if the D3DVOP_LIGHT isn't specified
+    if (!(pvFlags & D3DVOP_LIGHT)) {
+      d3d9::IDirect3DDevice9* device9 = m_d3d6Device->GetCommonD3DDevice()->GetD3D9Device();
+
+      device9->GetRenderState(d3d9::D3DRS_LIGHTING, &m_lighting);
+      if (m_lighting) {
+        //Logger::debug("D3D6VertexBuffer: Disabling lighting");
+        device9->SetRenderState(d3d9::D3DRS_LIGHTING, FALSE);
+      }
+    }
+    m_d3d6Device->HandlePreDrawLegacyProjection(0);
+  }
+
+  inline void D3D6VertexBuffer::HandlePostProcessVerticesFlags(DWORD pvFlags) {
+    if (!(pvFlags & D3DVOP_LIGHT) && m_lighting) {
+      d3d9::IDirect3DDevice9* device9 = m_d3d6Device->GetCommonD3DDevice()->GetD3D9Device();
+
+      //Logger::debug("D3D6VertexBuffer: Enabling lighting");
+      device9->SetRenderState(d3d9::D3DRS_LIGHTING, TRUE);
+    }
+    m_d3d6Device->HandlePostDrawLegacyProjection();
   }
 
 }

--- a/src/ddraw/d3d6/d3d6_buffer.h
+++ b/src/ddraw/d3d6/d3d6_buffer.h
@@ -10,7 +10,7 @@
 
 namespace dxvk {
 
-  class D3D6VertexBuffer final : public DDrawWrappedObject<D3D6Interface, IDirect3DVertexBuffer, d3d9::IDirect3DVertexBuffer9> {
+  class D3D6VertexBuffer final : public DDrawWrappedObject<D3D6Interface, IDirect3DVertexBuffer> {
 
   public:
 
@@ -33,7 +33,15 @@ namespace dxvk {
 
     HRESULT InitializeD3D9();
 
-    void RefreshD3D6Device();
+    d3d9::IDirect3DDevice9* RefreshD3DDevice();
+
+    bool IsInitialized() const {
+      return m_vb9 != nullptr;
+    }
+
+    d3d9::IDirect3DVertexBuffer9* GetD3D9VertexBuffer() const {
+      return m_vb9.ptr();
+    }
 
     DWORD GetFVF() const {
       return m_desc.dwFVF;
@@ -57,28 +65,12 @@ namespace dxvk {
 
   private:
 
+    inline void HandlePreProcessVerticesFlags(DWORD pvFlags);
+
+    inline void HandlePostProcessVerticesFlags(DWORD pvFlags);
+
     inline bool IsOptimized() const {
       return m_desc.dwCaps & D3DVBCAPS_OPTIMIZED;
-    }
-
-    inline void HandlePreProcessVerticesFlags(DWORD pvFlags) {
-      // Disable lighting if the D3DVOP_LIGHT isn't specified
-      if (!(pvFlags & D3DVOP_LIGHT)) {
-        m_d3d6Device->GetD3D9()->GetRenderState(d3d9::D3DRS_LIGHTING, &m_lighting);
-        if (m_lighting) {
-          //Logger::debug("D3D6VertexBuffer: Disabling lighting");
-          m_d3d6Device->GetD3D9()->SetRenderState(d3d9::D3DRS_LIGHTING, FALSE);
-        }
-      }
-      m_d3d6Device->HandlePreDrawLegacyProjection(0);
-    }
-
-    inline void HandlePostProcessVerticesFlags(DWORD pvFlags) {
-      if (!(pvFlags & D3DVOP_LIGHT) && m_lighting) {
-        //Logger::debug("D3D6VertexBuffer: Enabling lighting");
-        m_d3d6Device->GetD3D9()->SetRenderState(d3d9::D3DRS_LIGHTING, TRUE);
-      }
-      m_d3d6Device->HandlePostDrawLegacyProjection();
     }
 
     inline void ListBufferDetails() const {
@@ -88,22 +80,24 @@ namespace dxvk {
       Logger::debug(str::format("   Vertices: ", m_size / m_stride));
     }
 
-    bool                  m_locked  = false;
+    bool                              m_locked  = false;
 
-    static uint32_t       s_buffCount;
-    uint32_t              m_buffCount  = 0;
+    static uint32_t                   s_buffCount;
+    uint32_t                          m_buffCount  = 0;
 
-    DDrawCommonInterface* m_commonIntf = nullptr;
+    DDrawCommonInterface*             m_commonIntf = nullptr;
 
-    D3D6Device*           m_d3d6Device = nullptr;
+    D3D6Device*                       m_d3d6Device = nullptr;
 
-    DWORD                 m_lighting   = FALSE;
+    Com<d3d9::IDirect3DVertexBuffer9> m_vb9;
 
-    DWORD                 m_creationFlags = 0;
-    D3DVERTEXBUFFERDESC   m_desc;
+    DWORD                             m_lighting   = FALSE;
 
-    UINT                  m_stride = 0;
-    UINT                  m_size   = 0;
+    DWORD                             m_creationFlags = 0;
+    D3DVERTEXBUFFERDESC               m_desc;
+
+    UINT                              m_stride = 0;
+    UINT                              m_size   = 0;
 
   };
 

--- a/src/ddraw/d3d6/d3d6_device.cpp
+++ b/src/ddraw/d3d6/d3d6_device.cpp
@@ -26,7 +26,7 @@ namespace dxvk {
         Com<d3d9::IDirect3DDevice9>&& pDevice9,
         DDraw4Surface* pSurface,
         DWORD CreationFlags9)
-    : DDrawWrappedObject<D3D6Interface, IDirect3DDevice3, d3d9::IDirect3DDevice9>(pParent, std::move(d3d6DeviceProxy), std::move(pDevice9))
+    : DDrawWrappedObject<D3D6Interface, IDirect3DDevice3>(pParent, std::move(d3d6DeviceProxy))
     , m_commonD3DDevice ( commonD3DDevice )
     , m_multithread ( CreationFlags9 & D3DCREATE_MULTITHREADED )
     , m_desc ( Desc )
@@ -39,9 +39,30 @@ namespace dxvk {
       throw DxvkError("D3D6Device: ERROR! Failed to retrieve the common interface!");
     }
 
-    // Get the bridge interface to D3D9
-    if (unlikely(FAILED(m_d3d9->QueryInterface(__uuidof(IDxvkD3D8Bridge), reinterpret_cast<void**>(&m_bridge))))) {
-      throw DxvkError("D3D6Device: ERROR! Failed to get D3D9 Bridge. d3d9.dll might not be DXVK!");
+    d3d9::IDirect3DDevice9* device9;
+
+    if (likely(m_commonD3DDevice == nullptr)) {
+      m_commonD3DDevice = new D3DCommonDevice(m_commonIntf, deviceGUID, Params9, CreationFlags9);
+
+      m_commonD3DDevice->SetD3D9Device(std::move(pDevice9));
+      device9 = m_commonD3DDevice->GetD3D9Device();
+
+      const D3DOptions* d3dOptions = m_commonIntf->GetOptions();
+
+      if (unlikely(d3dOptions->emulateFSAA == FSAAEmulation::Forced)) {
+        Logger::warn("D3D6Device: Force enabling AA");
+        device9->SetRenderState(d3d9::D3DRS_MULTISAMPLEANTIALIAS, TRUE);
+      }
+
+      // The default value of D3DRENDERSTATE_TEXTUREMAPBLEND in D3D6 is D3DTBLEND_MODULATE
+      device9->SetTextureStageState(0, d3d9::D3DTSS_COLORARG1, D3DTA_TEXTURE);
+      device9->SetTextureStageState(0, d3d9::D3DTSS_ALPHAARG1, D3DTA_TEXTURE);
+      device9->SetTextureStageState(0, d3d9::D3DTSS_COLOROP,   D3DTOP_MODULATE);
+      device9->SetTextureStageState(0, d3d9::D3DTSS_ALPHAOP,   D3DTOP_SELECTARG1);
+      device9->SetTextureStageState(0, d3d9::D3DTSS_COLORARG2, D3DTA_DIFFUSE);
+      device9->SetTextureStageState(0, d3d9::D3DTSS_ALPHAARG2, D3DTA_DIFFUSE);
+    } else {
+      device9 = m_commonD3DDevice->GetD3D9Device();
     }
 
     // Common D3D9 index buffers
@@ -49,28 +70,16 @@ namespace dxvk {
       throw DxvkError("D3D6Device: ERROR! Failed to initialize D3D9 index buffers.");
     }
 
-    if (likely(m_commonD3DDevice == nullptr)) {
-      m_commonD3DDevice = new D3DCommonDevice(m_commonIntf, deviceGUID, Params9, CreationFlags9,
-                                              m_bridge->DetermineInitialTextureMemory());
-
-      // Update D3D9 legacy light state
-      m_bridge->SetLegacyLightsState(true);
-
-      const D3DOptions* d3dOptions = m_commonIntf->GetOptions();
-
-      if (unlikely(d3dOptions->emulateFSAA == FSAAEmulation::Forced)) {
-        Logger::warn("D3D6Device: Force enabling AA");
-        m_d3d9->SetRenderState(d3d9::D3DRS_MULTISAMPLEANTIALIAS, TRUE);
-      }
-
-      // The default value of D3DRENDERSTATE_TEXTUREMAPBLEND in D3D6 is D3DTBLEND_MODULATE
-      m_d3d9->SetTextureStageState(0, d3d9::D3DTSS_COLORARG1, D3DTA_TEXTURE);
-      m_d3d9->SetTextureStageState(0, d3d9::D3DTSS_ALPHAARG1, D3DTA_TEXTURE);
-      m_d3d9->SetTextureStageState(0, d3d9::D3DTSS_COLOROP,   D3DTOP_MODULATE);
-      m_d3d9->SetTextureStageState(0, d3d9::D3DTSS_ALPHAOP,   D3DTOP_SELECTARG1);
-      m_d3d9->SetTextureStageState(0, d3d9::D3DTSS_COLORARG2, D3DTA_DIFFUSE);
-      m_d3d9->SetTextureStageState(0, d3d9::D3DTSS_ALPHAARG2, D3DTA_DIFFUSE);
+    // Get the bridge interface to D3D9
+    if (unlikely(FAILED(device9->QueryInterface(__uuidof(IDxvkD3D8Bridge), reinterpret_cast<void**>(&m_bridge))))) {
+      throw DxvkError("D3D6Device: ERROR! Failed to get D3D9 Bridge. d3d9.dll might not be DXVK!");
     }
+
+    if (unlikely(!m_commonD3DDevice->GetTotalTextureMemory()))
+      m_commonD3DDevice->SetTotalTextureMemory(m_bridge->DetermineInitialTextureMemory());
+
+    // Update D3D9 legacy light state
+    m_bridge->SetLegacyLightsState(true);
 
     if (m_commonD3DDevice->GetOrigin() == nullptr)
       m_commonD3DDevice->SetOrigin(this);
@@ -160,11 +169,10 @@ namespace dxvk {
 
       // Reuse the existing D3D9 device in situations where games want
       // to get access only to D3D3 execute buffers on a D3D6 device
-      Com<d3d9::IDirect3DDevice9> device9 = m_d3d9.ptr();
       m_device3 = new D3D3Device(m_commonD3DDevice.ptr(), std::move(ppvProxyObject),
                                  m_rt->GetCommonSurface()->GetDDSurface(), GetD3D3Caps(d3dOptions),
                                  m_commonD3DDevice->GetDeviceGUID(), m_commonD3DDevice->GetPresentParameters(),
-                                 std::move(device9), m_commonD3DDevice->GetD3D9CreationFlags());
+                                 nullptr, m_commonD3DDevice->GetD3D9CreationFlags());
       m_commonD3DDevice->SetD3D3Device(m_device3.ptr());
 
       // On native this is the same object, so no need to ref
@@ -192,12 +200,11 @@ namespace dxvk {
       // TODO: Make sure the RT has an existing DDrawSurface,
       // and QueryInterface for one if that's not the case
 
-      Com<d3d9::IDirect3DDevice9> device9 = m_d3d9.ptr();
       m_device5 = new D3D5Device(m_commonD3DDevice.ptr(), std::move(ppvProxyObject),
                                  m_commonD3DDevice->GetCommonD3DInterface()->GetD3D5Interface(),
                                  GetD3D5Caps(m_commonD3DDevice->GetDeviceGUID(), d3dOptions),
                                  m_commonD3DDevice->GetDeviceGUID(), m_commonD3DDevice->GetPresentParameters(),
-                                 std::move(device9), m_rt->GetCommonSurface()->GetDDSurface(),
+                                 nullptr, m_rt->GetCommonSurface()->GetDDSurface(),
                                  m_commonD3DDevice->GetD3D9CreationFlags());
       m_commonD3DDevice->SetD3D5Device(m_device5.ptr());
 
@@ -440,7 +447,7 @@ namespace dxvk {
     if (unlikely(m_commonD3DDevice->IsInScene()))
       return D3DERR_SCENE_IN_SCENE;
 
-    HRESULT hr = m_d3d9->BeginScene();
+    HRESULT hr = m_commonD3DDevice->GetD3D9Device()->BeginScene();
 
     if (likely(SUCCEEDED(hr)))
       m_commonD3DDevice->SetInScene(true);
@@ -458,7 +465,7 @@ namespace dxvk {
     if (unlikely(!m_commonD3DDevice->IsInScene()))
       return D3DERR_SCENE_NOT_IN_SCENE;
 
-    HRESULT hr = m_d3d9->EndScene();
+    HRESULT hr = m_commonD3DDevice->GetD3D9Device()->EndScene();
 
     if (likely(SUCCEEDED(hr)))
       m_commonD3DDevice->SetInScene(false);
@@ -561,7 +568,9 @@ namespace dxvk {
       return hr;
     }
 
-    hr = m_d3d9->SetRenderTarget(0, rt6->GetD3D9());
+    d3d9::IDirect3DDevice9* device9 = m_commonD3DDevice->GetD3D9Device();
+
+    hr = device9->SetRenderTarget(0, rt6->GetCommonSurface()->GetD3D9Surface());
 
     if (likely(SUCCEEDED(hr))) {
       Logger::debug("D3D6Device::SetRenderTarget: Set a new D3D9 RT");
@@ -580,7 +589,7 @@ namespace dxvk {
           return hrDS;
         }
 
-        hrDS = m_d3d9->SetDepthStencilSurface(m_ds->GetD3D9());
+        hrDS = device9->SetDepthStencilSurface(m_ds->GetCommonSurface()->GetD3D9Surface());
         if (unlikely(FAILED(hrDS))) {
           Logger::err("D3D6Device::SetRenderTarget: Failed to set D3D9 DS");
           return hrDS;
@@ -590,7 +599,7 @@ namespace dxvk {
       } else {
         Logger::debug("D3D6Device::SetRenderTarget: RT has no depth stencil attached");
 
-        hrDS = m_d3d9->SetDepthStencilSurface(nullptr);
+        hrDS = device9->SetDepthStencilSurface(nullptr);
         if (unlikely(FAILED(hrDS))) {
           Logger::err("D3D6Device::SetRenderTarget: Failed to clear the D3D9 DS");
           return hrDS;
@@ -713,12 +722,14 @@ namespace dxvk {
 
     // As opposed to D3D7, D3D6 does not error out on
     // unknown or invalid render states.
-    if (unlikely(!IsValidD3D6RenderStateType(dwRenderStateType))) {
+    if (unlikely(!IsValidD3D6RenderStateType(dwRenderStateType)
+              && !m_commonIntf->GetOptions()->apitraceMode)) {
       Logger::debug(str::format("D3D6Device::GetRenderState: Invalid render state ", dwRenderStateType));
       *lpdwRenderState = 0;
       return D3D_OK;
     }
 
+    d3d9::IDirect3DDevice9* device9 = m_commonD3DDevice->GetD3D9Device();
     d3d9::D3DRENDERSTATETYPE State9 = d3d9::D3DRENDERSTATETYPE(dwRenderStateType);
 
     switch (dwRenderStateType) {
@@ -736,7 +747,7 @@ namespace dxvk {
         return D3D_OK;
 
       case D3DRENDERSTATE_TEXTUREADDRESS:
-        m_d3d9->GetSamplerState(0, d3d9::D3DSAMP_ADDRESSU, lpdwRenderState);
+        device9->GetSamplerState(0, d3d9::D3DSAMP_ADDRESSU, lpdwRenderState);
         return D3D_OK;
 
       // Always enabled on later APIs, default TRUE in D3D6
@@ -747,7 +758,7 @@ namespace dxvk {
       // Not implemented in DXVK, but retrieve it as it were
       case D3DRENDERSTATE_WRAPU: {
         DWORD value9 = 0;
-        m_d3d9->GetRenderState(d3d9::D3DRS_WRAP0, &value9);
+        device9->GetRenderState(d3d9::D3DRS_WRAP0, &value9);
         *lpdwRenderState = value9 & D3DWRAP_U;
         return D3D_OK;
       }
@@ -755,7 +766,7 @@ namespace dxvk {
       // Not implemented in DXVK, but retrieve it as it were
       case D3DRENDERSTATE_WRAPV: {
         DWORD value9 = 0;
-        m_d3d9->GetRenderState(d3d9::D3DRS_WRAP0, &value9);
+        device9->GetRenderState(d3d9::D3DRS_WRAP0, &value9);
         *lpdwRenderState = value9 & D3DWRAP_V;
         return D3D_OK;
       }
@@ -777,14 +788,14 @@ namespace dxvk {
         return D3D_OK;
 
       case D3DRENDERSTATE_TEXTUREMAG:
-        m_d3d9->GetSamplerState(0, d3d9::D3DSAMP_MAGFILTER, lpdwRenderState);
+        device9->GetSamplerState(0, d3d9::D3DSAMP_MAGFILTER, lpdwRenderState);
         return D3D_OK;
 
       case D3DRENDERSTATE_TEXTUREMIN: {
         DWORD minFilter = 0;
         DWORD mipFilter = 0;
-        m_d3d9->GetSamplerState(0, d3d9::D3DSAMP_MINFILTER, &minFilter);
-        m_d3d9->GetSamplerState(0, d3d9::D3DSAMP_MIPFILTER, &mipFilter);
+        device9->GetSamplerState(0, d3d9::D3DSAMP_MINFILTER, &minFilter);
+        device9->GetSamplerState(0, d3d9::D3DSAMP_MIPFILTER, &mipFilter);
         *lpdwRenderState = DecodeTextureMinValues(minFilter, mipFilter);
         return D3D_OK;
       }
@@ -820,30 +831,30 @@ namespace dxvk {
         return D3D_OK;
 
       case D3DRENDERSTATE_BORDERCOLOR:
-        m_d3d9->GetSamplerState(0, d3d9::D3DSAMP_BORDERCOLOR, lpdwRenderState);
+        device9->GetSamplerState(0, d3d9::D3DSAMP_BORDERCOLOR, lpdwRenderState);
         return D3D_OK;
 
       case D3DRENDERSTATE_TEXTUREADDRESSU:
-        m_d3d9->GetSamplerState(0, d3d9::D3DSAMP_ADDRESSU, lpdwRenderState);
+        device9->GetSamplerState(0, d3d9::D3DSAMP_ADDRESSU, lpdwRenderState);
         return D3D_OK;
 
       case D3DRENDERSTATE_TEXTUREADDRESSV:
-        m_d3d9->GetSamplerState(0, d3d9::D3DSAMP_ADDRESSV, lpdwRenderState);
+        device9->GetSamplerState(0, d3d9::D3DSAMP_ADDRESSV, lpdwRenderState);
         return D3D_OK;
 
       case D3DRENDERSTATE_MIPMAPLODBIAS:
-        m_d3d9->GetSamplerState(0, d3d9::D3DSAMP_MIPMAPLODBIAS, lpdwRenderState);
+        device9->GetSamplerState(0, d3d9::D3DSAMP_MIPMAPLODBIAS, lpdwRenderState);
         return D3D_OK;
 
       case D3DRENDERSTATE_ZBIAS: {
         DWORD bias = 0;
-        m_d3d9->GetRenderState(d3d9::D3DRS_DEPTHBIAS, &bias);
+        device9->GetRenderState(d3d9::D3DRS_DEPTHBIAS, &bias);
         *lpdwRenderState = static_cast<DWORD>(bit::cast<float>(bias) * ddrawCaps::ZBIAS_SCALE_INV);
         return D3D_OK;
       }
 
       case D3DRENDERSTATE_ANISOTROPY:
-        m_d3d9->GetSamplerState(0, d3d9::D3DSAMP_MAXANISOTROPY, lpdwRenderState);
+        device9->GetSamplerState(0, d3d9::D3DSAMP_MAXANISOTROPY, lpdwRenderState);
         return D3D_OK;
 
       // "Batched primitives are implicitly flushed when rendering with the
@@ -893,7 +904,7 @@ namespace dxvk {
     }
 
     // This call will never fail
-    return m_d3d9->GetRenderState(State9, lpdwRenderState);
+    return device9->GetRenderState(State9, lpdwRenderState);
   }
 
   HRESULT STDMETHODCALLTYPE D3D6Device::SetRenderState(D3DRENDERSTATETYPE dwRenderStateType, DWORD dwRenderState) {
@@ -908,6 +919,7 @@ namespace dxvk {
       return D3D_OK;
     }
 
+    d3d9::IDirect3DDevice9* device9 = m_commonD3DDevice->GetD3D9Device();
     d3d9::D3DRENDERSTATETYPE State9 = d3d9::D3DRENDERSTATETYPE(dwRenderStateType);
 
     switch (dwRenderStateType) {
@@ -938,8 +950,8 @@ namespace dxvk {
       }
 
       case D3DRENDERSTATE_TEXTUREADDRESS:
-        m_d3d9->SetSamplerState(0, d3d9::D3DSAMP_ADDRESSU, dwRenderState);
-        m_d3d9->SetSamplerState(0, d3d9::D3DSAMP_ADDRESSV, dwRenderState);
+        device9->SetSamplerState(0, d3d9::D3DSAMP_ADDRESSU, dwRenderState);
+        device9->SetSamplerState(0, d3d9::D3DSAMP_ADDRESSV, dwRenderState);
         return D3D_OK;
 
       // Always enabled on later APIs, default TRUE in D3D6
@@ -949,11 +961,11 @@ namespace dxvk {
       // Not implemented in DXVK, but forward it anyway
       case D3DRENDERSTATE_WRAPU: {
         DWORD value9 = 0;
-        m_d3d9->GetRenderState(d3d9::D3DRS_WRAP0, &value9);
+        device9->GetRenderState(d3d9::D3DRS_WRAP0, &value9);
         if (dwRenderState == TRUE) {
-          m_d3d9->SetRenderState(d3d9::D3DRS_WRAP0, value9 & D3DWRAP_U);
+          device9->SetRenderState(d3d9::D3DRS_WRAP0, value9 & D3DWRAP_U);
         } else {
-          m_d3d9->SetRenderState(d3d9::D3DRS_WRAP0, value9 & ~D3DWRAP_U);
+          device9->SetRenderState(d3d9::D3DRS_WRAP0, value9 & ~D3DWRAP_U);
         }
         return D3D_OK;
       }
@@ -961,11 +973,11 @@ namespace dxvk {
       // Not implemented in DXVK, but forward it anyway
       case D3DRENDERSTATE_WRAPV: {
         DWORD value9 = 0;
-        m_d3d9->GetRenderState(d3d9::D3DRS_WRAP0, &value9);
+        device9->GetRenderState(d3d9::D3DRS_WRAP0, &value9);
         if (dwRenderState == TRUE) {
-          m_d3d9->SetRenderState(d3d9::D3DRS_WRAP0, value9 & D3DWRAP_V);
+          device9->SetRenderState(d3d9::D3DRS_WRAP0, value9 & D3DWRAP_V);
         } else {
-          m_d3d9->SetRenderState(d3d9::D3DRS_WRAP0, value9 & ~D3DWRAP_V);
+          device9->SetRenderState(d3d9::D3DRS_WRAP0, value9 & ~D3DWRAP_V);
         }
         return D3D_OK;
       }
@@ -1008,7 +1020,7 @@ namespace dxvk {
         switch (dwRenderState) {
           case D3DFILTER_NEAREST:
           case D3DFILTER_LINEAR:
-            m_d3d9->SetSamplerState(0, d3d9::D3DSAMP_MAGFILTER, dwRenderState);
+            device9->SetSamplerState(0, d3d9::D3DSAMP_MAGFILTER, dwRenderState);
             break;
           default:
             break;
@@ -1020,29 +1032,29 @@ namespace dxvk {
         switch (dwRenderState) {
           case D3DFILTER_NEAREST:
           case D3DFILTER_LINEAR:
-            m_d3d9->SetSamplerState(0, d3d9::D3DSAMP_MINFILTER, dwRenderState);
-            m_d3d9->SetSamplerState(0, d3d9::D3DSAMP_MIPFILTER, d3d9::D3DTEXF_NONE);
+            device9->SetSamplerState(0, d3d9::D3DSAMP_MINFILTER, dwRenderState);
+            device9->SetSamplerState(0, d3d9::D3DSAMP_MIPFILTER, d3d9::D3DTEXF_NONE);
             break;
           // "The closest mipmap level is chosen and a point filter is applied."
           case D3DFILTER_MIPNEAREST:
-            m_d3d9->SetSamplerState(0, d3d9::D3DSAMP_MINFILTER, d3d9::D3DTEXF_POINT);
-            m_d3d9->SetSamplerState(0, d3d9::D3DSAMP_MIPFILTER, d3d9::D3DTEXF_POINT);
+            device9->SetSamplerState(0, d3d9::D3DSAMP_MINFILTER, d3d9::D3DTEXF_POINT);
+            device9->SetSamplerState(0, d3d9::D3DSAMP_MIPFILTER, d3d9::D3DTEXF_POINT);
             break;
           // "The closest mipmap level is chosen and a bilinear filter is applied within it."
           case D3DFILTER_MIPLINEAR:
-            m_d3d9->SetSamplerState(0, d3d9::D3DSAMP_MINFILTER, d3d9::D3DTEXF_LINEAR);
-            m_d3d9->SetSamplerState(0, d3d9::D3DSAMP_MIPFILTER, d3d9::D3DTEXF_POINT);
+            device9->SetSamplerState(0, d3d9::D3DSAMP_MINFILTER, d3d9::D3DTEXF_LINEAR);
+            device9->SetSamplerState(0, d3d9::D3DSAMP_MIPFILTER, d3d9::D3DTEXF_POINT);
             break;
           // "The two closest mipmap levels are chosen and then a linear
           //  blend is used between point filtered samples of each level."
           case D3DFILTER_LINEARMIPNEAREST:
-            m_d3d9->SetSamplerState(0, d3d9::D3DSAMP_MINFILTER, d3d9::D3DTEXF_POINT);
-            m_d3d9->SetSamplerState(0, d3d9::D3DSAMP_MIPFILTER, d3d9::D3DTEXF_LINEAR);
+            device9->SetSamplerState(0, d3d9::D3DSAMP_MINFILTER, d3d9::D3DTEXF_POINT);
+            device9->SetSamplerState(0, d3d9::D3DSAMP_MIPFILTER, d3d9::D3DTEXF_LINEAR);
             break;
           // "The two closest mipmap levels are chosen and then combined using a bilinear filter."
           case D3DFILTER_LINEARMIPLINEAR:
-            m_d3d9->SetSamplerState(0, d3d9::D3DSAMP_MINFILTER, d3d9::D3DTEXF_LINEAR);
-            m_d3d9->SetSamplerState(0, d3d9::D3DSAMP_MIPFILTER, d3d9::D3DTEXF_LINEAR);
+            device9->SetSamplerState(0, d3d9::D3DSAMP_MINFILTER, d3d9::D3DTEXF_LINEAR);
+            device9->SetSamplerState(0, d3d9::D3DSAMP_MIPFILTER, d3d9::D3DTEXF_LINEAR);
             break;
           default:
             break;
@@ -1058,12 +1070,12 @@ namespace dxvk {
           //  the colors that would have been used with no texturing."
           case D3DTBLEND_DECAL:
           case D3DTBLEND_COPY:
-            m_d3d9->SetTextureStageState(0, d3d9::D3DTSS_COLORARG1, D3DTA_TEXTURE);
-            m_d3d9->SetTextureStageState(0, d3d9::D3DTSS_ALPHAARG1, D3DTA_TEXTURE);
-            m_d3d9->SetTextureStageState(0, d3d9::D3DTSS_COLOROP,   D3DTOP_SELECTARG1);
-            m_d3d9->SetTextureStageState(0, d3d9::D3DTSS_ALPHAOP,   D3DTOP_SELECTARG1);
-            m_d3d9->SetTextureStageState(0, d3d9::D3DTSS_COLORARG2, D3DTA_CURRENT);
-            m_d3d9->SetTextureStageState(0, d3d9::D3DTSS_ALPHAARG2, D3DTA_CURRENT);
+            device9->SetTextureStageState(0, d3d9::D3DTSS_COLORARG1, D3DTA_TEXTURE);
+            device9->SetTextureStageState(0, d3d9::D3DTSS_ALPHAARG1, D3DTA_TEXTURE);
+            device9->SetTextureStageState(0, d3d9::D3DTSS_COLOROP,   D3DTOP_SELECTARG1);
+            device9->SetTextureStageState(0, d3d9::D3DTSS_ALPHAOP,   D3DTOP_SELECTARG1);
+            device9->SetTextureStageState(0, d3d9::D3DTSS_COLORARG2, D3DTA_CURRENT);
+            device9->SetTextureStageState(0, d3d9::D3DTSS_ALPHAARG2, D3DTA_CURRENT);
             break;
           // "In this mode, the RGB values of the texture are multiplied with the RGB values
           //  that would have been used with no texturing. Any alpha values in the texture
@@ -1071,43 +1083,43 @@ namespace dxvk {
           //  if the texture does not contain an alpha component, alpha values at the vertices
           //  in the source are interpolated between vertices."
           case D3DTBLEND_MODULATE:
-            m_d3d9->SetTextureStageState(0, d3d9::D3DTSS_COLORARG1, D3DTA_TEXTURE);
-            m_d3d9->SetTextureStageState(0, d3d9::D3DTSS_ALPHAARG1, D3DTA_TEXTURE);
-            m_d3d9->SetTextureStageState(0, d3d9::D3DTSS_COLOROP,   D3DTOP_MODULATE);
-            m_d3d9->SetTextureStageState(0, d3d9::D3DTSS_ALPHAOP,   D3DTOP_SELECTARG1);
-            m_d3d9->SetTextureStageState(0, d3d9::D3DTSS_COLORARG2, D3DTA_DIFFUSE);
-            m_d3d9->SetTextureStageState(0, d3d9::D3DTSS_ALPHAARG2, D3DTA_DIFFUSE);
+            device9->SetTextureStageState(0, d3d9::D3DTSS_COLORARG1, D3DTA_TEXTURE);
+            device9->SetTextureStageState(0, d3d9::D3DTSS_ALPHAARG1, D3DTA_TEXTURE);
+            device9->SetTextureStageState(0, d3d9::D3DTSS_COLOROP,   D3DTOP_MODULATE);
+            device9->SetTextureStageState(0, d3d9::D3DTSS_ALPHAOP,   D3DTOP_SELECTARG1);
+            device9->SetTextureStageState(0, d3d9::D3DTSS_COLORARG2, D3DTA_DIFFUSE);
+            device9->SetTextureStageState(0, d3d9::D3DTSS_ALPHAARG2, D3DTA_DIFFUSE);
             break;
           // "In this mode, the RGB and alpha values of the texture are blended with the colors
           //  that would have been used with no texturing, according to the following formulas [...]"
           case D3DTBLEND_DECALALPHA:
-            m_d3d9->SetTextureStageState(0, d3d9::D3DTSS_COLORARG1, D3DTA_TEXTURE);
-            m_d3d9->SetTextureStageState(0, d3d9::D3DTSS_ALPHAARG1, D3DTA_TEXTURE);
-            m_d3d9->SetTextureStageState(0, d3d9::D3DTSS_COLOROP,   D3DTOP_BLENDTEXTUREALPHA);
-            m_d3d9->SetTextureStageState(0, d3d9::D3DTSS_ALPHAOP,   D3DTOP_SELECTARG2);
-            m_d3d9->SetTextureStageState(0, d3d9::D3DTSS_COLORARG2, D3DTA_DIFFUSE);
-            m_d3d9->SetTextureStageState(0, d3d9::D3DTSS_ALPHAARG2, D3DTA_DIFFUSE);
+            device9->SetTextureStageState(0, d3d9::D3DTSS_COLORARG1, D3DTA_TEXTURE);
+            device9->SetTextureStageState(0, d3d9::D3DTSS_ALPHAARG1, D3DTA_TEXTURE);
+            device9->SetTextureStageState(0, d3d9::D3DTSS_COLOROP,   D3DTOP_BLENDTEXTUREALPHA);
+            device9->SetTextureStageState(0, d3d9::D3DTSS_ALPHAOP,   D3DTOP_SELECTARG2);
+            device9->SetTextureStageState(0, d3d9::D3DTSS_COLORARG2, D3DTA_DIFFUSE);
+            device9->SetTextureStageState(0, d3d9::D3DTSS_ALPHAARG2, D3DTA_DIFFUSE);
             break;
           // "In this mode, the RGB values of the texture are multiplied with the RGB values that
           //  would have been used with no texturing, and the alpha values of the texture
           //  are multiplied with the alpha values that would have been used with no texturing."
           case D3DTBLEND_MODULATEALPHA:
-            m_d3d9->SetTextureStageState(0, d3d9::D3DTSS_COLORARG1, D3DTA_TEXTURE);
-            m_d3d9->SetTextureStageState(0, d3d9::D3DTSS_ALPHAARG1, D3DTA_TEXTURE);
-            m_d3d9->SetTextureStageState(0, d3d9::D3DTSS_COLOROP,   D3DTOP_MODULATE);
-            m_d3d9->SetTextureStageState(0, d3d9::D3DTSS_ALPHAOP,   D3DTOP_MODULATE);
-            m_d3d9->SetTextureStageState(0, d3d9::D3DTSS_COLORARG2, D3DTA_DIFFUSE);
-            m_d3d9->SetTextureStageState(0, d3d9::D3DTSS_ALPHAARG2, D3DTA_DIFFUSE);
+            device9->SetTextureStageState(0, d3d9::D3DTSS_COLORARG1, D3DTA_TEXTURE);
+            device9->SetTextureStageState(0, d3d9::D3DTSS_ALPHAARG1, D3DTA_TEXTURE);
+            device9->SetTextureStageState(0, d3d9::D3DTSS_COLOROP,   D3DTOP_MODULATE);
+            device9->SetTextureStageState(0, d3d9::D3DTSS_ALPHAOP,   D3DTOP_MODULATE);
+            device9->SetTextureStageState(0, d3d9::D3DTSS_COLORARG2, D3DTA_DIFFUSE);
+            device9->SetTextureStageState(0, d3d9::D3DTSS_ALPHAARG2, D3DTA_DIFFUSE);
             break;
           // "Add the Gouraud interpolants to the texture lookup with saturation semantics
           //  (that is, if the color value overflows it is set to the maximum possible value)."
           case D3DTBLEND_ADD:
-            m_d3d9->SetTextureStageState(0, d3d9::D3DTSS_COLORARG1, D3DTA_TEXTURE);
-            m_d3d9->SetTextureStageState(0, d3d9::D3DTSS_ALPHAARG1, D3DTA_TEXTURE);
-            m_d3d9->SetTextureStageState(0, d3d9::D3DTSS_COLOROP,   D3DTOP_ADD);
-            m_d3d9->SetTextureStageState(0, d3d9::D3DTSS_ALPHAOP,   D3DTOP_SELECTARG2);
-            m_d3d9->SetTextureStageState(0, d3d9::D3DTSS_COLORARG2, D3DTA_DIFFUSE);
-            m_d3d9->SetTextureStageState(0, d3d9::D3DTSS_ALPHAARG2, D3DTA_DIFFUSE);
+            device9->SetTextureStageState(0, d3d9::D3DTSS_COLORARG1, D3DTA_TEXTURE);
+            device9->SetTextureStageState(0, d3d9::D3DTSS_ALPHAARG1, D3DTA_TEXTURE);
+            device9->SetTextureStageState(0, d3d9::D3DTSS_COLOROP,   D3DTOP_ADD);
+            device9->SetTextureStageState(0, d3d9::D3DTSS_ALPHAOP,   D3DTOP_SELECTARG2);
+            device9->SetTextureStageState(0, d3d9::D3DTSS_COLORARG2, D3DTA_DIFFUSE);
+            device9->SetTextureStageState(0, d3d9::D3DTSS_ALPHAARG2, D3DTA_DIFFUSE);
             break;
           // Unsupported
           default:
@@ -1166,19 +1178,19 @@ namespace dxvk {
       }
 
       case D3DRENDERSTATE_BORDERCOLOR:
-        m_d3d9->SetSamplerState(0, d3d9::D3DSAMP_BORDERCOLOR, dwRenderState);
+        device9->SetSamplerState(0, d3d9::D3DSAMP_BORDERCOLOR, dwRenderState);
         return D3D_OK;
 
       case D3DRENDERSTATE_TEXTUREADDRESSU:
-        m_d3d9->SetSamplerState(0, d3d9::D3DSAMP_ADDRESSU, dwRenderState);
+        device9->SetSamplerState(0, d3d9::D3DSAMP_ADDRESSU, dwRenderState);
         return D3D_OK;
 
       case D3DRENDERSTATE_TEXTUREADDRESSV:
-        m_d3d9->SetSamplerState(0, d3d9::D3DSAMP_ADDRESSV, dwRenderState);
+        device9->SetSamplerState(0, d3d9::D3DSAMP_ADDRESSV, dwRenderState);
         return D3D_OK;
 
       case D3DRENDERSTATE_MIPMAPLODBIAS:
-        m_d3d9->SetSamplerState(0, d3d9::D3DSAMP_MIPMAPLODBIAS, dwRenderState);
+        device9->SetSamplerState(0, d3d9::D3DSAMP_MIPMAPLODBIAS, dwRenderState);
         return D3D_OK;
 
       case D3DRENDERSTATE_ZBIAS:
@@ -1187,7 +1199,7 @@ namespace dxvk {
         break;
 
       case D3DRENDERSTATE_ANISOTROPY:
-        m_d3d9->SetSamplerState(0, d3d9::D3DSAMP_MAXANISOTROPY, dwRenderState);
+        device9->SetSamplerState(0, d3d9::D3DSAMP_MAXANISOTROPY, dwRenderState);
         return D3D_OK;
 
       // "Batched primitives are implicitly flushed when rendering with the
@@ -1243,7 +1255,7 @@ namespace dxvk {
     }
 
     // This call will never fail
-    return m_d3d9->SetRenderState(State9, dwRenderState);
+    return device9->SetRenderState(State9, dwRenderState);
   }
 
   HRESULT STDMETHODCALLTYPE D3D6Device::GetLightState(D3DLIGHTSTATETYPE dwLightStateType, LPDWORD lpdwLightState) {
@@ -1251,30 +1263,32 @@ namespace dxvk {
 
     Logger::debug(">>> D3D6Device::GetLightState");
 
+    d3d9::IDirect3DDevice9* device9 = m_commonD3DDevice->GetD3D9Device();
+
     switch (dwLightStateType) {
       case D3DLIGHTSTATE_MATERIAL:
         *lpdwLightState = m_commonD3DDevice->GetCurrentMaterialHandle();
         break;
       case D3DLIGHTSTATE_AMBIENT:
-        m_d3d9->GetRenderState(d3d9::D3DRS_AMBIENT, lpdwLightState);
+        device9->GetRenderState(d3d9::D3DRS_AMBIENT, lpdwLightState);
         break;
       case D3DLIGHTSTATE_COLORMODEL:
         *lpdwLightState = D3DCOLOR_RGB;
         break;
       case D3DLIGHTSTATE_FOGMODE:
-        m_d3d9->GetRenderState(d3d9::D3DRS_FOGVERTEXMODE, lpdwLightState);
+        device9->GetRenderState(d3d9::D3DRS_FOGVERTEXMODE, lpdwLightState);
         break;
       case D3DLIGHTSTATE_FOGSTART:
-        m_d3d9->GetRenderState(d3d9::D3DRS_FOGSTART, lpdwLightState);
+        device9->GetRenderState(d3d9::D3DRS_FOGSTART, lpdwLightState);
         break;
       case D3DLIGHTSTATE_FOGEND:
-        m_d3d9->GetRenderState(d3d9::D3DRS_FOGEND, lpdwLightState);
+        device9->GetRenderState(d3d9::D3DRS_FOGEND, lpdwLightState);
         break;
       case D3DLIGHTSTATE_FOGDENSITY:
-        m_d3d9->GetRenderState(d3d9::D3DRS_FOGDENSITY, lpdwLightState);
+        device9->GetRenderState(d3d9::D3DRS_FOGDENSITY, lpdwLightState);
         break;
       case D3DLIGHTSTATE_COLORVERTEX:
-        m_d3d9->GetRenderState(d3d9::D3DRS_COLORVERTEX, lpdwLightState);
+        device9->GetRenderState(d3d9::D3DRS_COLORVERTEX, lpdwLightState);
         break;
       default:
         return DDERR_INVALIDPARAMS;
@@ -1287,6 +1301,8 @@ namespace dxvk {
     D3DDeviceLock lock = LockDevice();
 
     Logger::debug(">>> D3D6Device::SetLightState");
+
+    d3d9::IDirect3DDevice9* device9 = m_commonD3DDevice->GetD3D9Device();
 
     switch (dwLightStateType) {
       case D3DLIGHTSTATE_MATERIAL: {
@@ -1301,31 +1317,31 @@ namespace dxvk {
 
         m_commonD3DDevice->SetCurrentMaterialHandle(dwLightState);
         Logger::debug(str::format("D3D6Device::SetLightState: Applying material nr. ", dwLightState, " to D3D9"));
-        m_d3d9->SetMaterial(material9);
+        device9->SetMaterial(material9);
 
         break;
       }
       case D3DLIGHTSTATE_AMBIENT:
-        m_d3d9->SetRenderState(d3d9::D3DRS_AMBIENT, dwLightState);
+        device9->SetRenderState(d3d9::D3DRS_AMBIENT, dwLightState);
         break;
       case D3DLIGHTSTATE_COLORMODEL:
         if (unlikely(dwLightState != D3DCOLOR_RGB))
           Logger::warn("D3D6Device::SetLightState: Unsupported D3DLIGHTSTATE_COLORMODEL");
         break;
       case D3DLIGHTSTATE_FOGMODE:
-        m_d3d9->SetRenderState(d3d9::D3DRS_FOGVERTEXMODE, dwLightState);
+        device9->SetRenderState(d3d9::D3DRS_FOGVERTEXMODE, dwLightState);
         break;
       case D3DLIGHTSTATE_FOGSTART:
-        m_d3d9->SetRenderState(d3d9::D3DRS_FOGSTART, dwLightState);
+        device9->SetRenderState(d3d9::D3DRS_FOGSTART, dwLightState);
         break;
       case D3DLIGHTSTATE_FOGEND:
-        m_d3d9->SetRenderState(d3d9::D3DRS_FOGEND, dwLightState);
+        device9->SetRenderState(d3d9::D3DRS_FOGEND, dwLightState);
         break;
       case D3DLIGHTSTATE_FOGDENSITY:
-        m_d3d9->SetRenderState(d3d9::D3DRS_FOGDENSITY, dwLightState);
+        device9->SetRenderState(d3d9::D3DRS_FOGDENSITY, dwLightState);
         break;
       case D3DLIGHTSTATE_COLORVERTEX:
-        m_d3d9->SetRenderState(d3d9::D3DRS_COLORVERTEX, dwLightState);
+        device9->SetRenderState(d3d9::D3DRS_COLORVERTEX, dwLightState);
         break;
       default:
         return DDERR_INVALIDPARAMS;
@@ -1336,17 +1352,17 @@ namespace dxvk {
 
   HRESULT STDMETHODCALLTYPE D3D6Device::SetTransform(D3DTRANSFORMSTATETYPE state, D3DMATRIX *matrix) {
     Logger::debug(">>> D3D6Device::SetTransform");
-    return m_d3d9->SetTransform(ConvertTransformState(state), matrix);
+    return m_commonD3DDevice->GetD3D9Device()->SetTransform(ConvertTransformState(state), matrix);
   }
 
   HRESULT STDMETHODCALLTYPE D3D6Device::GetTransform(D3DTRANSFORMSTATETYPE state, D3DMATRIX *matrix) {
     Logger::debug(">>> D3D6Device::GetTransform");
-    return m_d3d9->GetTransform(ConvertTransformState(state), matrix);
+    return m_commonD3DDevice->GetD3D9Device()->GetTransform(ConvertTransformState(state), matrix);
   }
 
   HRESULT STDMETHODCALLTYPE D3D6Device::MultiplyTransform(D3DTRANSFORMSTATETYPE state, D3DMATRIX *matrix) {
     Logger::debug(">>> D3D6Device::MultiplyTransform");
-    return m_d3d9->MultiplyTransform(ConvertTransformState(state), matrix);
+    return m_commonD3DDevice->GetD3D9Device()->MultiplyTransform(ConvertTransformState(state), matrix);
   }
 
   HRESULT STDMETHODCALLTYPE D3D6Device::DrawPrimitive(D3DPRIMITIVETYPE primitive_type, DWORD vertex_type, void *vertices, DWORD vertex_count, DWORD flags) {
@@ -1362,6 +1378,8 @@ namespace dxvk {
     if (unlikely(vertices == nullptr))
       return DDERR_INVALIDPARAMS;
 
+    d3d9::IDirect3DDevice9* device9 = m_commonD3DDevice->GetD3D9Device();
+
     m_rt->InitializeOrUploadD3D9();
     if (likely(m_ds != nullptr))
       m_ds->InitializeOrUploadD3D9();
@@ -1369,8 +1387,8 @@ namespace dxvk {
     HandlePreDrawFlags(flags, vertex_type);
     HandlePreDrawLegacyProjection(flags);
 
-    m_d3d9->SetFVF(vertex_type);
-    HRESULT hr = m_d3d9->DrawPrimitiveUP(
+    device9->SetFVF(vertex_type);
+    HRESULT hr = device9->DrawPrimitiveUP(
                      d3d9::D3DPRIMITIVETYPE(primitive_type),
                      GetPrimitiveCount(primitive_type, vertex_count),
                      vertices,
@@ -1402,6 +1420,8 @@ namespace dxvk {
     if (unlikely(vertices == nullptr || indices == nullptr))
       return DDERR_INVALIDPARAMS;
 
+    d3d9::IDirect3DDevice9* device9 = m_commonD3DDevice->GetD3D9Device();
+
     m_rt->InitializeOrUploadD3D9();
     if (likely(m_ds != nullptr))
       m_ds->InitializeOrUploadD3D9();
@@ -1409,8 +1429,8 @@ namespace dxvk {
     HandlePreDrawFlags(flags, fvf);
     HandlePreDrawLegacyProjection(flags);
 
-    m_d3d9->SetFVF(fvf);
-    HRESULT hr = m_d3d9->DrawIndexedPrimitiveUP(
+    device9->SetFVF(fvf);
+    HRESULT hr = device9->DrawIndexedPrimitiveUP(
                       d3d9::D3DPRIMITIVETYPE(primitive_type),
                       0,
                       vertex_count,
@@ -1449,7 +1469,7 @@ namespace dxvk {
       return DDERR_INVALIDPARAMS;
 
     d3d9::D3DVIEWPORT9 viewport9;
-    if (SUCCEEDED(m_d3d9->GetViewport(&viewport9))) {
+    if (SUCCEEDED(m_commonD3DDevice->GetD3D9Device()->GetViewport(&viewport9))) {
       clip_status->dwFlags = D3DCLIPSTATUS_EXTENTS2;
       clip_status->dwStatus = 0;
       clip_status->minx = viewport9.X;
@@ -1476,6 +1496,8 @@ namespace dxvk {
     if (unlikely(strided_data == nullptr))
       return DDERR_INVALIDPARAMS;
 
+    d3d9::IDirect3DDevice9* device9 = m_commonD3DDevice->GetD3D9Device();
+
     m_rt->InitializeOrUploadD3D9();
     if (likely(m_ds != nullptr))
       m_ds->InitializeOrUploadD3D9();
@@ -1486,8 +1508,8 @@ namespace dxvk {
     HandlePreDrawFlags(flags, fvf);
     HandlePreDrawLegacyProjection(flags);
 
-    m_d3d9->SetFVF(fvf);
-    HRESULT hr = m_d3d9->DrawPrimitiveUP(
+    device9->SetFVF(fvf);
+    HRESULT hr = device9->DrawPrimitiveUP(
                      d3d9::D3DPRIMITIVETYPE(primitive_type),
                      GetPrimitiveCount(primitive_type, vertex_count),
                      pvb.vertexData.data(),
@@ -1519,6 +1541,8 @@ namespace dxvk {
     if (unlikely(strided_data == nullptr || indices == nullptr))
       return DDERR_INVALIDPARAMS;
 
+    d3d9::IDirect3DDevice9* device9 = m_commonD3DDevice->GetD3D9Device();
+
     m_rt->InitializeOrUploadD3D9();
     if (likely(m_ds != nullptr))
       m_ds->InitializeOrUploadD3D9();
@@ -1529,8 +1553,8 @@ namespace dxvk {
     HandlePreDrawFlags(flags, fvf);
     HandlePreDrawLegacyProjection(flags);
 
-    m_d3d9->SetFVF(fvf);
-    HRESULT hr = m_d3d9->DrawIndexedPrimitiveUP(
+    device9->SetFVF(fvf);
+    HRESULT hr = device9->DrawIndexedPrimitiveUP(
                       d3d9::D3DPRIMITIVETYPE(primitive_type),
                       0,
                       vertex_count,
@@ -1573,6 +1597,8 @@ namespace dxvk {
       return D3DERR_VERTEXBUFFERLOCKED;
     }
 
+    d3d9::IDirect3DDevice9* device9 = m_commonD3DDevice->GetD3D9Device();
+
     m_rt->InitializeOrUploadD3D9();
     if (likely(m_ds != nullptr))
       m_ds->InitializeOrUploadD3D9();
@@ -1580,9 +1606,9 @@ namespace dxvk {
     HandlePreDrawFlags(flags, vb6->GetFVF());
     HandlePreDrawLegacyProjection(flags);
 
-    m_d3d9->SetFVF(vb6->GetFVF());
-    m_d3d9->SetStreamSource(0, vb6->GetD3D9(), 0, vb6->GetStride());
-    HRESULT hr = m_d3d9->DrawPrimitive(
+    device9->SetFVF(vb6->GetFVF());
+    device9->SetStreamSource(0, vb6->GetD3D9VertexBuffer(), 0, vb6->GetStride());
+    HRESULT hr = device9->DrawPrimitive(
                            d3d9::D3DPRIMITIVETYPE(primitive_type),
                            start_vertex,
                            GetPrimitiveCount(primitive_type, vertex_count));
@@ -1631,6 +1657,8 @@ namespace dxvk {
       }
     }
 
+    d3d9::IDirect3DDevice9* device9 = m_commonD3DDevice->GetD3D9Device();
+
     m_rt->InitializeOrUploadD3D9();
     if (likely(m_ds != nullptr))
       m_ds->InitializeOrUploadD3D9();
@@ -1642,10 +1670,10 @@ namespace dxvk {
 
     UploadIndices(ib9, indices, index_count);
     m_ib9_uploads[ibIndex]++;
-    m_d3d9->SetIndices(ib9);
-    m_d3d9->SetFVF(vb6->GetFVF());
-    m_d3d9->SetStreamSource(0, vb6->GetD3D9(), 0, vb6->GetStride());
-    HRESULT hr = m_d3d9->DrawIndexedPrimitive(
+    device9->SetIndices(ib9);
+    device9->SetFVF(vb6->GetFVF());
+    device9->SetStreamSource(0, vb6->GetD3D9VertexBuffer(), 0, vb6->GetStride());
+    HRESULT hr = device9->DrawIndexedPrimitive(
                     d3d9::D3DPRIMITIVETYPE(primitive_type),
                     0,
                     0,
@@ -1714,13 +1742,15 @@ namespace dxvk {
       return DDERR_INVALIDPARAMS;
     }
 
+    d3d9::IDirect3DDevice9* device9 = m_commonD3DDevice->GetD3D9Device();
+
     HRESULT hr;
 
     // Unbinding texture stages
     if (texture == nullptr) {
       Logger::debug("D3D6Device::SetTexture: Unbiding D3D9 texture");
 
-      hr = m_d3d9->SetTexture(stage, nullptr);
+      hr = device9->SetTexture(stage, nullptr);
 
       if (likely(SUCCEEDED(hr))) {
         if (m_textures[stage] != nullptr) {
@@ -1744,7 +1774,7 @@ namespace dxvk {
 
     // If textures have been used on a different device, they
     // will get their D3D9 object reinitialized at this point
-    if (unlikely(surface6->GetD3D9Device() != m_d3d9.ptr()))
+    if (unlikely(surface6->GetCommonD3DDevice() != m_commonD3DDevice.ptr()))
       surface6->GetCommonSurface()->DirtyDDrawSurface();
 
     hr = surface6->InitializeOrUploadD3D9();
@@ -1757,10 +1787,10 @@ namespace dxvk {
     //if (unlikely(m_textures[stage] == texture6))
       //return D3D_OK;
 
-    d3d9::IDirect3DTexture9* tex9 = surface6->GetD3D9Texture();
+    d3d9::IDirect3DTexture9* tex9 = surface6->GetCommonSurface()->GetD3D9Texture();
 
     if (likely(tex9 != nullptr)) {
-      hr = m_d3d9->SetTexture(stage, tex9);
+      hr = device9->SetTexture(stage, tex9);
       if (unlikely(FAILED(hr))) {
         Logger::warn("D3D6Device::SetTexture: Failed to bind D3D9 texture");
         return hr;
@@ -1772,7 +1802,7 @@ namespace dxvk {
         //  alpha values at the vertices in the source are interpolated between vertices."
         if (m_commonD3DDevice->GetTextureMapBlend() == D3DTBLEND_MODULATE && !m_alphaOpSet) {
           const DWORD textureOp = surface6->GetCommonSurface()->IsAlphaFormat() ? D3DTOP_SELECTARG1 : D3DTOP_MODULATE;
-          m_d3d9->SetTextureStageState(0, d3d9::D3DTSS_ALPHAOP, textureOp);
+          device9->SetTextureStageState(0, d3d9::D3DTSS_ALPHAOP, textureOp);
         }
 
         const bool colorKeyEnable = m_commonD3DDevice->GetColorKeyEnable();
@@ -1797,10 +1827,12 @@ namespace dxvk {
     if (unlikely(lpdwState == nullptr))
       return DDERR_INVALIDPARAMS;
 
+    d3d9::IDirect3DDevice9* device9 = m_commonD3DDevice->GetD3D9Device();
+
     // In the case of D3DTSS_ADDRESS, which is exclusive to D3D7
     // and D3D6, simply return based on D3DTSS_ADDRESSU
     if (d3dTexStageStateType == D3DTSS_ADDRESS) {
-      return m_d3d9->GetSamplerState(dwStage, d3d9::D3DSAMP_ADDRESSU, lpdwState);
+      return device9->GetSamplerState(dwStage, d3d9::D3DSAMP_ADDRESSU, lpdwState);
     }
 
     d3d9::D3DSAMPLERSTATETYPE stateType = ConvertSamplerStateType(d3dTexStageStateType);
@@ -1811,25 +1843,27 @@ namespace dxvk {
       if (stateType == d3d9::D3DSAMP_MAGFILTER ||
           stateType == d3d9::D3DSAMP_MINFILTER || stateType == d3d9::D3DSAMP_MIPFILTER) {
         DWORD dwStateProxy9 = 0;
-        HRESULT hr = m_d3d9->GetSamplerState(dwStage, stateType, &dwStateProxy9);
+        HRESULT hr = device9->GetSamplerState(dwStage, stateType, &dwStateProxy9);
         *lpdwState = DecodeD3D9TexFilterValues(d3dTexStageStateType, dwStateProxy9);
         return hr;
       } else {
-        return m_d3d9->GetSamplerState(dwStage, stateType, lpdwState);
+        return device9->GetSamplerState(dwStage, stateType, lpdwState);
       }
     } else {
-      return m_d3d9->GetTextureStageState(dwStage, d3d9::D3DTEXTURESTAGESTATETYPE(d3dTexStageStateType), lpdwState);
+      return device9->GetTextureStageState(dwStage, d3d9::D3DTEXTURESTAGESTATETYPE(d3dTexStageStateType), lpdwState);
     }
   }
 
   HRESULT STDMETHODCALLTYPE D3D6Device::SetTextureStageState(DWORD dwStage, D3DTEXTURESTAGESTATETYPE d3dTexStageStateType, DWORD dwState) {
     Logger::debug(">>> D3D6Device::SetTextureStageState");
 
+    d3d9::IDirect3DDevice9* device9 = m_commonD3DDevice->GetD3D9Device();
+
     // In the case of D3DTSS_ADDRESS, which is exclusive to D3D7
     // and D3D6, we need to set up both D3DTSS_ADDRESSU and D3DTSS_ADDRESSV
     if (d3dTexStageStateType == D3DTSS_ADDRESS) {
-      m_d3d9->SetSamplerState(dwStage, d3d9::D3DSAMP_ADDRESSU, dwState);
-      return m_d3d9->SetSamplerState(dwStage, d3d9::D3DSAMP_ADDRESSV, dwState);
+      device9->SetSamplerState(dwStage, d3d9::D3DSAMP_ADDRESSU, dwState);
+      return device9->SetSamplerState(dwStage, d3d9::D3DSAMP_ADDRESSV, dwState);
     }
 
     if (!m_alphaOpSet && d3dTexStageStateType == D3DTSS_ALPHAOP)
@@ -1843,19 +1877,19 @@ namespace dxvk {
       if (stateType == d3d9::D3DSAMP_MAGFILTER ||
           stateType == d3d9::D3DSAMP_MINFILTER || stateType == d3d9::D3DSAMP_MIPFILTER) {
         const DWORD dwState9 = DecodeD3D7TexFilterValues(d3dTexStageStateType, dwState);
-        return m_d3d9->SetSamplerState(dwStage, stateType, dwState9);
+        return device9->SetSamplerState(dwStage, stateType, dwState9);
       } else {
-        return m_d3d9->SetSamplerState(dwStage, stateType, dwState);
+        return device9->SetSamplerState(dwStage, stateType, dwState);
       }
     } else {
-      return m_d3d9->SetTextureStageState(dwStage, d3d9::D3DTEXTURESTAGESTATETYPE(d3dTexStageStateType), dwState);
+      return device9->SetTextureStageState(dwStage, d3d9::D3DTEXTURESTAGESTATETYPE(d3dTexStageStateType), dwState);
     }
   }
 
   HRESULT STDMETHODCALLTYPE D3D6Device::ValidateDevice(LPDWORD lpdwPasses) {
     Logger::debug(">>> D3D6Device::ValidateDevice");
 
-    HRESULT hr = m_d3d9->ValidateDevice(lpdwPasses);
+    HRESULT hr = m_commonD3DDevice->GetD3D9Device()->ValidateDevice(lpdwPasses);
     if (unlikely(FAILED(hr)))
       return DDERR_INVALIDPARAMS;
 
@@ -1863,6 +1897,8 @@ namespace dxvk {
   }
 
   void D3D6Device::InitializeDS() {
+    d3d9::IDirect3DDevice9* device9 = m_commonD3DDevice->GetD3D9Device();
+
     m_rt->InitializeD3D9RenderTarget();
 
     m_ds = m_rt->GetAttachedDepthStencil();
@@ -1881,19 +1917,19 @@ namespace dxvk {
         m_ds->GetProxied()->GetSurfaceDesc(&descDS);
         Logger::debug(str::format("D3D6Device::InitializeDS: DepthStencil: ", descDS.dwWidth, "x", descDS.dwHeight));
 
-        HRESULT hrDS9 = m_d3d9->SetDepthStencilSurface(m_ds->GetD3D9());
+        HRESULT hrDS9 = device9->SetDepthStencilSurface(m_ds->GetCommonSurface()->GetD3D9Surface());
         if(unlikely(FAILED(hrDS9))) {
           Logger::err("D3D6Device::InitializeDS: Failed to set D3D9 depth stencil");
         } else {
           // This needs to act like an auto depth stencil of sorts, so manually enable z-buffering
-          m_d3d9->SetRenderState(d3d9::D3DRS_ZENABLE, d3d9::D3DZB_TRUE);
+          device9->SetRenderState(d3d9::D3DRS_ZENABLE, d3d9::D3DZB_TRUE);
         }
       }
     } else {
       Logger::info("D3D6Device::InitializeDS: RT has no depth stencil attached");
-      m_d3d9->SetDepthStencilSurface(nullptr);
+      device9->SetDepthStencilSurface(nullptr);
       // Should be superfluous, but play it safe
-      m_d3d9->SetRenderState(d3d9::D3DRS_ZENABLE, d3d9::D3DZB_FALSE);
+      device9->SetRenderState(d3d9::D3DRS_ZENABLE, d3d9::D3DZB_FALSE);
     }
   }
 
@@ -1921,7 +1957,7 @@ namespace dxvk {
       Logger::err("D3D6Device::ResetD3D9Swapchain: Failed to reset the D3D9 swapchain");
     } else {
       // TODO: Cache and reset all surfaces tied to the D3D9 backbuffers
-      m_rt->SetD3D9(nullptr);
+      m_rt->GetCommonSurface()->SetD3D9Surface(nullptr);
       // Note that the D3D9 depth stencil survives a swapchain reset,
       // so there's no need to worry about it in this case
     }
@@ -1932,13 +1968,15 @@ namespace dxvk {
   inline HRESULT D3D6Device::InitializeIndexBuffers() {
     static constexpr DWORD Usage = D3DUSAGE_DYNAMIC | D3DUSAGE_WRITEONLY;
 
+    d3d9::IDirect3DDevice9* device9 = m_commonD3DDevice->GetD3D9Device();
+
     for (uint8_t ibIndex = 0; ibIndex < ddrawCaps::IndexBufferCount ; ibIndex++) {
       const UINT ibSize = ddrawCaps::IndexCount[ibIndex] * sizeof(WORD);
 
       Logger::debug(str::format("D3D6Device::InitializeIndexBuffer: Creating D3D9 index buffer, size: ", ibSize));
 
-      HRESULT hr = m_d3d9->CreateIndexBuffer(ibSize, Usage, d3d9::D3DFMT_INDEX16,
-                                             d3d9::D3DPOOL_DEFAULT, &m_ib9[ibIndex], nullptr);
+      HRESULT hr = device9->CreateIndexBuffer(ibSize, Usage, d3d9::D3DFMT_INDEX16,
+                                              d3d9::D3DPOOL_DEFAULT, &m_ib9[ibIndex], nullptr);
       if (unlikely(FAILED(hr)))
         return hr;
     }

--- a/src/ddraw/d3d6/d3d6_device.h
+++ b/src/ddraw/d3d6/d3d6_device.h
@@ -31,7 +31,7 @@ namespace dxvk {
   /**
   * \brief D3D6 device implementation
   */
-  class D3D6Device final : public DDrawWrappedObject<D3D6Interface, IDirect3DDevice3, d3d9::IDirect3DDevice9> {
+  class D3D6Device final : public DDrawWrappedObject<D3D6Interface, IDirect3DDevice3> {
 
   public:
     D3D6Device(
@@ -162,17 +162,20 @@ namespace dxvk {
         m_legacyProjection = m_currentViewport->GetCommonViewport()->GetLegacyProjectionMatrix(drawFlags);
 
         if (m_legacyProjection != nullptr) {
+          d3d9::IDirect3DDevice9* device9 = m_commonD3DDevice->GetD3D9Device();
           //Logger::debug("D3D6Device: Applying legacy projection");
-          m_d3d9->GetTransform(d3d9::D3DTS_PROJECTION, &m_projectionMatrix);
-          m_d3d9->MultiplyTransform(d3d9::D3DTS_PROJECTION, m_legacyProjection);
+          device9->GetTransform(d3d9::D3DTS_PROJECTION, &m_projectionMatrix);
+          device9->MultiplyTransform(d3d9::D3DTS_PROJECTION, m_legacyProjection);
         }
       }
     }
 
     void HandlePostDrawLegacyProjection() {
       if (m_legacyProjection != nullptr) {
+        d3d9::IDirect3DDevice9* device9 = m_commonD3DDevice->GetD3D9Device();
+
         //Logger::debug("D3D6Device: Reverting legacy projection");
-        m_d3d9->SetTransform(d3d9::D3DTS_PROJECTION, &m_projectionMatrix);
+        device9->SetTransform(d3d9::D3DTS_PROJECTION, &m_projectionMatrix);
       }
     }
 
@@ -205,10 +208,12 @@ namespace dxvk {
       if (m_commonD3DDevice->GetCurrentMaterialHandle() == 0 ||
           (drawFlags & D3DDP_DONOTLIGHT) ||
          !(vertexTypeDesc & D3DFVF_NORMAL)) {
-        m_d3d9->GetRenderState(d3d9::D3DRS_LIGHTING, &m_lighting);
+        d3d9::IDirect3DDevice9* device9 = m_commonD3DDevice->GetD3D9Device();
+
+        device9->GetRenderState(d3d9::D3DRS_LIGHTING, &m_lighting);
         if (m_lighting) {
           //Logger::debug("D3D6Device: Disabling lighting");
-          m_d3d9->SetRenderState(d3d9::D3DRS_LIGHTING, FALSE);
+          device9->SetRenderState(d3d9::D3DRS_LIGHTING, FALSE);
         }
       }
     }
@@ -217,8 +222,10 @@ namespace dxvk {
       if ((m_commonD3DDevice->GetCurrentMaterialHandle() == 0 ||
           (drawFlags & D3DDP_DONOTLIGHT) ||
          !(vertexTypeDesc & D3DFVF_NORMAL)) && m_lighting) {
+        d3d9::IDirect3DDevice9* device9 = m_commonD3DDevice->GetD3D9Device();
+
         //Logger::debug("D3D6Device: Enabling lighting");
-        m_d3d9->SetRenderState(d3d9::D3DRS_LIGHTING, TRUE);
+        device9->SetRenderState(d3d9::D3DRS_LIGHTING, TRUE);
       }
     }
 

--- a/src/ddraw/d3d6/d3d6_interface.cpp
+++ b/src/ddraw/d3d6/d3d6_interface.cpp
@@ -22,16 +22,22 @@ namespace dxvk {
         D3DCommonInterface* commonD3DIntf,
         Com<IDirect3D3>&& d3d6IntfProxy,
         IUnknown* pParent)
-    : DDrawWrappedObject<IUnknown, IDirect3D3, d3d9::IDirect3D9>(pParent, std::move(d3d6IntfProxy), std::move(d3d9::Direct3DCreate9(D3D_SDK_VERSION)))
+    : DDrawWrappedObject<IUnknown, IDirect3D3>(pParent, std::move(d3d6IntfProxy))
     , m_commonIntf ( commonIntf )
     , m_commonD3DIntf ( commonD3DIntf ) {
-    // Get the bridge interface to D3D9.
-    if (unlikely(FAILED(m_d3d9->QueryInterface(__uuidof(IDxvkD3D8InterfaceBridge), reinterpret_cast<void**>(&m_bridge))))) {
-      throw DxvkError("D3D6Interface: ERROR! Failed to get D3D9 Bridge. d3d9.dll might not be DXVK!");
+    if (m_commonD3DIntf == nullptr) {
+      m_commonD3DIntf = new D3DCommonInterface();
+
+      Com<d3d9::IDirect3D9> d3dIntf9 = d3d9::Direct3DCreate9(D3D_SDK_VERSION);
+      m_commonD3DIntf->SetD3D9Interface(std::move(d3dIntf9));
     }
 
-    if (m_commonD3DIntf == nullptr)
-      m_commonD3DIntf = new D3DCommonInterface();
+    d3d9::IDirect3D9* d3dIntf9 = m_commonD3DIntf->GetD3D9Interface();
+
+    // Get the bridge interface to D3D9.
+    if (unlikely(FAILED(d3dIntf9->QueryInterface(__uuidof(IDxvkD3D8InterfaceBridge), reinterpret_cast<void**>(&m_bridge))))) {
+      throw DxvkError("D3D6Interface: ERROR! Failed to get D3D9 Bridge. d3d9.dll might not be DXVK!");
+    }
 
     m_commonD3DIntf->SetD3D6Interface(this);
 
@@ -341,6 +347,8 @@ namespace dxvk {
   HRESULT STDMETHODCALLTYPE D3D6Interface::CreateDevice(REFCLSID rclsid, LPDIRECTDRAWSURFACE4 lpDDS, LPDIRECT3DDEVICE3 *lplpD3DDevice, IUnknown *pUnkOuter) {
     Logger::debug(">>> D3D6Interface::CreateDevice");
 
+    d3d9::IDirect3D9* d3dIntf9 = m_commonD3DIntf->GetD3D9Interface();
+
     if (unlikely(lplpD3DDevice == nullptr))
       return DDERR_INVALIDPARAMS;
 
@@ -425,11 +433,11 @@ namespace dxvk {
     // Determine the supported AA sample count by querying the D3D9 interface
     d3d9::D3DMULTISAMPLE_TYPE multiSampleType = d3d9::D3DMULTISAMPLE_NONE;
     if (likely(d3dOptions->emulateFSAA != FSAAEmulation::Disabled)) {
-      HRESULT hr4S = m_d3d9->CheckDeviceMultiSampleType(0, d3d9::D3DDEVTYPE_HAL, backBufferFormat,
-                                                        TRUE, d3d9::D3DMULTISAMPLE_4_SAMPLES, NULL);
+      HRESULT hr4S = d3dIntf9->CheckDeviceMultiSampleType(0, d3d9::D3DDEVTYPE_HAL, backBufferFormat,
+                                                          TRUE, d3d9::D3DMULTISAMPLE_4_SAMPLES, NULL);
       if (unlikely(FAILED(hr4S))) {
-        HRESULT hr2S = m_d3d9->CheckDeviceMultiSampleType(0, d3d9::D3DDEVTYPE_HAL, backBufferFormat,
-                                                          TRUE, d3d9::D3DMULTISAMPLE_2_SAMPLES, NULL);
+        HRESULT hr2S = d3dIntf9->CheckDeviceMultiSampleType(0, d3d9::D3DDEVTYPE_HAL, backBufferFormat,
+                                                            TRUE, d3d9::D3DMULTISAMPLE_2_SAMPLES, NULL);
         if (unlikely(FAILED(hr2S))) {
           Logger::warn("D3D6Interface::CreateDevice: No MSAA support has been detected");
         } else {
@@ -483,7 +491,7 @@ namespace dxvk {
     params.PresentationInterval       = vBlankStatus ? D3DPRESENT_INTERVAL_DEFAULT : D3DPRESENT_INTERVAL_IMMEDIATE;
 
     Com<d3d9::IDirect3DDevice9> device9;
-    hr = m_d3d9->CreateDevice(
+    hr = d3dIntf9->CreateDevice(
       D3DADAPTER_DEFAULT,
       d3d9::D3DDEVTYPE_HAL,
       hWnd,

--- a/src/ddraw/d3d6/d3d6_interface.h
+++ b/src/ddraw/d3d6/d3d6_interface.h
@@ -16,7 +16,7 @@ namespace dxvk {
   /**
   * \brief D3D6 interface implementation
   */
-  class D3D6Interface final : public DDrawWrappedObject<IUnknown, IDirect3D3, d3d9::IDirect3D9> {
+  class D3D6Interface final : public DDrawWrappedObject<IUnknown, IDirect3D3> {
 
   public:
     D3D6Interface(

--- a/src/ddraw/d3d6/d3d6_material.cpp
+++ b/src/ddraw/d3d6/d3d6_material.cpp
@@ -15,7 +15,7 @@ namespace dxvk {
         Com<IDirect3DMaterial3>&& proxyMaterial,
         D3D6Interface* pParent,
         D3DMATERIALHANDLE handle)
-    : DDrawWrappedObject<D3D6Interface, IDirect3DMaterial3, IUnknown>(pParent, std::move(proxyMaterial), nullptr) {
+    : DDrawWrappedObject<D3D6Interface, IDirect3DMaterial3>(pParent, std::move(proxyMaterial)) {
     m_commonMaterial = new D3DCommonMaterial(handle);
 
     m_commonMaterial->SetD3D6Material(this);

--- a/src/ddraw/d3d6/d3d6_material.h
+++ b/src/ddraw/d3d6/d3d6_material.h
@@ -9,7 +9,7 @@ namespace dxvk {
 
   class D3D6Interface;
 
-  class D3D6Material final : public DDrawWrappedObject<D3D6Interface, IDirect3DMaterial3, IUnknown> {
+  class D3D6Material final : public DDrawWrappedObject<D3D6Interface, IDirect3DMaterial3> {
 
   public:
 

--- a/src/ddraw/d3d6/d3d6_texture.cpp
+++ b/src/ddraw/d3d6/d3d6_texture.cpp
@@ -10,7 +10,7 @@ namespace dxvk {
         Com<IDirect3DTexture2>&& proxyTexture,
         DDraw4Surface* pParent,
         D3DTEXTUREHANDLE handle)
-    : DDrawWrappedObject<DDraw4Surface, IDirect3DTexture2, IUnknown>(pParent, std::move(proxyTexture), nullptr) {
+    : DDrawWrappedObject<DDraw4Surface, IDirect3DTexture2>(pParent, std::move(proxyTexture)) {
     m_commonTex = new D3DCommonTexture(m_parent->GetCommonSurface(), handle);
 
     m_texCount = ++s_texCount;

--- a/src/ddraw/d3d6/d3d6_texture.h
+++ b/src/ddraw/d3d6/d3d6_texture.h
@@ -9,7 +9,7 @@ namespace dxvk {
 
   class DDraw4Surface;
 
-  class D3D6Texture final : public DDrawWrappedObject<DDraw4Surface, IDirect3DTexture2, IUnknown> {
+  class D3D6Texture final : public DDrawWrappedObject<DDraw4Surface, IDirect3DTexture2> {
 
   public:
 

--- a/src/ddraw/d3d6/d3d6_viewport.cpp
+++ b/src/ddraw/d3d6/d3d6_viewport.cpp
@@ -21,7 +21,7 @@ namespace dxvk {
         D3DCommonViewport* commonViewport,
         Com<IDirect3DViewport3>&& proxyViewport,
         D3D6Interface* pParent)
-    : DDrawWrappedObject<D3D6Interface, IDirect3DViewport3, IUnknown>(pParent, std::move(proxyViewport), nullptr)
+    : DDrawWrappedObject<D3D6Interface, IDirect3DViewport3>(pParent, std::move(proxyViewport))
     , m_commonViewport ( commonViewport ) {
 
     if (m_commonViewport == nullptr)

--- a/src/ddraw/d3d6/d3d6_viewport.h
+++ b/src/ddraw/d3d6/d3d6_viewport.h
@@ -15,7 +15,7 @@ namespace dxvk {
   class D3D5Viewport;
   class D3D3Viewport;
 
-  class D3D6Viewport final : public DDrawWrappedObject<D3D6Interface, IDirect3DViewport3, IUnknown> {
+  class D3D6Viewport final : public DDrawWrappedObject<D3D6Interface, IDirect3DViewport3> {
 
   public:
 

--- a/src/ddraw/d3d7/d3d7_buffer.cpp
+++ b/src/ddraw/d3d7/d3d7_buffer.cpp
@@ -16,7 +16,7 @@ namespace dxvk {
   D3D7VertexBuffer::D3D7VertexBuffer(
         D3D7Interface* pParent,
         D3DVERTEXBUFFERDESC desc)
-    : DDrawWrappedObject<D3D7Interface, IDirect3DVertexBuffer7, d3d9::IDirect3DVertexBuffer9>(pParent, nullptr, nullptr)
+    : DDrawWrappedObject<D3D7Interface, IDirect3DVertexBuffer7>(pParent, nullptr)
     , m_commonIntf ( pParent->GetCommonInterface() )
     , m_desc ( desc )
     , m_stride ( GetFVFSize(desc.dwFVF) )
@@ -56,7 +56,7 @@ namespace dxvk {
     if (unlikely(IsOptimized()))
       return D3DERR_VERTEXBUFFEROPTIMIZED;
 
-    RefreshD3D7Device();
+    RefreshD3DDevice();
     if (unlikely(!IsInitialized())) {
       HRESULT hrInit = InitializeD3D9();
       if (unlikely(FAILED(hrInit)))
@@ -66,7 +66,7 @@ namespace dxvk {
     if (data_size != nullptr)
       *data_size = m_size;
 
-    HRESULT hr = m_d3d9->Lock(0, 0, data, ConvertD3D7LockFlags(flags, m_legacyDiscard, false));
+    HRESULT hr = m_vb9->Lock(0, 0, data, ConvertD3D7LockFlags(flags, m_legacyDiscard, false));
 
     if (likely(SUCCEEDED(hr)))
       m_locked = true;
@@ -77,14 +77,14 @@ namespace dxvk {
   HRESULT STDMETHODCALLTYPE D3D7VertexBuffer::Unlock() {
     Logger::debug(">>> D3D7VertexBuffer::Unlock");
 
-    RefreshD3D7Device();
+    RefreshD3DDevice();
     if (unlikely(!IsInitialized())) {
       HRESULT hrInit = InitializeD3D9();
       if (unlikely(FAILED(hrInit)))
         return hrInit;
     }
 
-    HRESULT hr = m_d3d9->Unlock();
+    HRESULT hr = m_vb9->Unlock();
 
     if (likely(SUCCEEDED(hr)))
       m_locked = false;
@@ -109,7 +109,7 @@ namespace dxvk {
     D3D7Device* device = static_cast<D3D7Device*>(lpD3DDevice);
     D3D7VertexBuffer* vb = static_cast<D3D7VertexBuffer*>(lpSrcBuffer);
 
-    vb->RefreshD3D7Device();
+    vb->RefreshD3DDevice();
     if (unlikely(vb->GetDevice() == nullptr || device != vb->GetDevice())) {
       Logger::err("D3D7VertexBuffer::ProcessVertices: Incompatible or null device");
       return DDERR_GENERIC;
@@ -125,7 +125,7 @@ namespace dxvk {
     }
 
     // Check and initialize the destination buffer (this buffer)
-    RefreshD3D7Device();
+    d3d9::IDirect3DDevice9* device9 = RefreshD3DDevice();
     if (unlikely(!IsInitialized())) {
       hrInit = InitializeD3D9();
       if (unlikely(FAILED(hrInit)))
@@ -142,13 +142,14 @@ namespace dxvk {
       uint8_t *inData = nullptr;
       uint8_t *outData = nullptr;
 
-      hr = vb->GetD3D9()->Lock(dwSrcIndex * vb->GetStride(), dwCount * vb->GetStride(), reinterpret_cast<void**>(&inData), D3DLOCK_READONLY|D3DLOCK_NOSYSLOCK);
+      hr = vb->GetD3D9VertexBuffer()->Lock(dwSrcIndex * vb->GetStride(), dwCount * vb->GetStride(),
+                                           reinterpret_cast<void**>(&inData), D3DLOCK_READONLY|D3DLOCK_NOSYSLOCK);
       if (unlikely(FAILED(hr))) {
         Logger::err("D3D7VertexBuffer::ProcessVertices: Failed to lock source buffer");
         return D3DERR_VERTEXBUFFERLOCKED;
       }
 
-      hr = m_d3d9->Lock(dwDestIndex * m_stride, dwCount * m_stride, reinterpret_cast<void**>(&outData), D3DLOCK_NOSYSLOCK);
+      hr = m_vb9->Lock(dwDestIndex * m_stride, dwCount * m_stride, reinterpret_cast<void**>(&outData), D3DLOCK_NOSYSLOCK);
       if (unlikely(FAILED(hr))) {
         Logger::err("D3D7VertexBuffer::ProcessVertices: Failed to lock destination buffer");
         vb->Unlock();
@@ -174,17 +175,17 @@ namespace dxvk {
       std::vector<d3d9::D3DLIGHT9> lights9 = device->GetLights();
       pvData.lights = &lights9;
 
-      ProcessVerticesSW(device->GetD3D9(), m_commonIntf->GetOptions(), &pvData);
+      ProcessVerticesSW(device9, m_commonIntf->GetOptions(), &pvData);
 
-      m_d3d9->Unlock();
+      m_vb9->Unlock();
       vb->Unlock();
 
     } else {
       HandlePreProcessVerticesFlags(dwVertexOp);
 
-      device->GetD3D9()->SetFVF(vb->GetFVF());
-      device->GetD3D9()->SetStreamSource(0, vb->GetD3D9(), 0, vb->GetStride());
-      hr = device->GetD3D9()->ProcessVertices(dwSrcIndex, dwDestIndex, dwCount, m_d3d9.ptr(), nullptr, dwFlags);
+      device9->SetFVF(vb->GetFVF());
+      device9->SetStreamSource(0, vb->GetD3D9VertexBuffer(), 0, vb->GetStride());
+      hr = device9->ProcessVertices(dwSrcIndex, dwDestIndex, dwCount, m_vb9.ptr(), nullptr, dwFlags);
       if (unlikely(FAILED(hr))) {
         Logger::err("D3D7VertexBuffer::ProcessVertices: Failed call to D3D9 ProcessVertices");
       }
@@ -206,7 +207,7 @@ namespace dxvk {
 
     D3D7Device* device = static_cast<D3D7Device*>(lpD3DDevice);
 
-    RefreshD3D7Device();
+    RefreshD3DDevice();
     if(unlikely(m_d3d7Device == nullptr || device != m_d3d7Device)) {
       Logger::err(">>> D3D7VertexBuffer::ProcessVerticesStrided: Incompatible or null device");
       return DDERR_GENERIC;
@@ -254,6 +255,8 @@ namespace dxvk {
       return DDERR_GENERIC;
     }
 
+    d3d9::IDirect3DDevice9* device9 = m_d3d7Device->GetCommonD3DDevice()->GetD3D9Device();
+
     d3d9::D3DPOOL pool = d3d9::D3DPOOL_DEFAULT;
 
     if (m_desc.dwCaps & D3DVBCAPS_SYSTEMMEMORY)
@@ -266,7 +269,7 @@ namespace dxvk {
     const DWORD usage = ConvertD3D7UsageFlags(m_desc.dwCaps);
     m_legacyDiscard = m_commonIntf->GetOptions()->forceLegacyDiscard &&
                       (usage & D3DUSAGE_DYNAMIC) && (usage & D3DUSAGE_WRITEONLY);
-    HRESULT hr = m_d3d7Device->GetD3D9()->CreateVertexBuffer(m_size, usage, m_desc.dwFVF, pool, &m_d3d9, nullptr);
+    HRESULT hr = device9->CreateVertexBuffer(m_size, usage, m_desc.dwFVF, pool, &m_vb9, nullptr);
 
     if (unlikely(FAILED(hr))) {
       Logger::err("D3D7VertexBuffer::InitializeD3D9: Failed to create D3D9 vertex buffer");
@@ -278,17 +281,38 @@ namespace dxvk {
     return DD_OK;
   }
 
-  void D3D7VertexBuffer::RefreshD3D7Device() {
-    D3DCommonDevice* commonDevice = m_commonIntf->GetCommonD3DDevice();
+  d3d9::IDirect3DDevice9* D3D7VertexBuffer::RefreshD3DDevice() {
+    D3DCommonDevice* commonD3DDevice = m_commonIntf->GetCommonD3DDevice();
 
-    D3D7Device* d3d7Device = commonDevice != nullptr ? commonDevice->GetD3D7Device() : nullptr;
+    D3D7Device* d3d7Device = commonD3DDevice != nullptr ? commonD3DDevice->GetD3D7Device() : nullptr;
     if (unlikely(m_d3d7Device != d3d7Device)) {
       // Check if the device has been recreated and reset all D3D9 resources
       if (unlikely(m_d3d7Device != nullptr)) {
-        Logger::debug("D3D7VertexBuffer::RefreshD3D7Device: Device context has changed, clearing D3D9 buffers");
-        m_d3d9 = nullptr;
+        Logger::debug("D3D7VertexBuffer::RefreshD3DDevice: Device context has changed, clearing D3D9 buffers");
+        m_vb9 = nullptr;
       }
       m_d3d7Device = d3d7Device;
+    }
+
+    return commonD3DDevice != nullptr ? commonD3DDevice->GetD3D9Device() : nullptr;
+  }
+
+  inline void D3D7VertexBuffer::HandlePreProcessVerticesFlags(DWORD pvFlags) {
+    // Disable lighting if the D3DVOP_LIGHT isn't specified
+    if (!(pvFlags & D3DVOP_LIGHT)) {
+      d3d9::IDirect3DDevice9* device9 = m_d3d7Device->GetCommonD3DDevice()->GetD3D9Device();
+
+      device9->GetRenderState(d3d9::D3DRS_LIGHTING, &m_lighting);
+      if (m_lighting)
+        device9->SetRenderState(d3d9::D3DRS_LIGHTING, FALSE);
+    }
+  }
+
+  inline void D3D7VertexBuffer::HandlePostProcessVerticesFlags(DWORD pvFlags) {
+    if (!(pvFlags & D3DVOP_LIGHT) && m_lighting) {
+      d3d9::IDirect3DDevice9* device9 = m_d3d7Device->GetCommonD3DDevice()->GetD3D9Device();
+
+      device9->SetRenderState(d3d9::D3DRS_LIGHTING, TRUE);
     }
   }
 

--- a/src/ddraw/d3d7/d3d7_buffer.h
+++ b/src/ddraw/d3d7/d3d7_buffer.h
@@ -10,7 +10,7 @@
 
 namespace dxvk {
 
-  class D3D7VertexBuffer final : public DDrawWrappedObject<D3D7Interface, IDirect3DVertexBuffer7, d3d9::IDirect3DVertexBuffer9> {
+  class D3D7VertexBuffer final : public DDrawWrappedObject<D3D7Interface, IDirect3DVertexBuffer7> {
 
   public:
 
@@ -34,7 +34,15 @@ namespace dxvk {
 
     HRESULT InitializeD3D9();
 
-    void RefreshD3D7Device();
+    d3d9::IDirect3DDevice9* RefreshD3DDevice();
+
+    bool IsInitialized() const {
+      return m_vb9 != nullptr;
+    }
+
+    d3d9::IDirect3DVertexBuffer9* GetD3D9VertexBuffer() const {
+      return m_vb9.ptr();
+    }
 
     DWORD GetFVF() const {
       return m_desc.dwFVF;
@@ -54,23 +62,12 @@ namespace dxvk {
 
   private:
 
+    inline void HandlePreProcessVerticesFlags(DWORD pvFlags);
+
+    inline void HandlePostProcessVerticesFlags(DWORD pvFlags);
+
     inline bool IsOptimized() const {
       return m_desc.dwCaps & D3DVBCAPS_OPTIMIZED;
-    }
-
-    inline void HandlePreProcessVerticesFlags(DWORD pvFlags) {
-      // Disable lighting if the D3DVOP_LIGHT isn't specified
-      if (!(pvFlags & D3DVOP_LIGHT)) {
-        m_d3d7Device->GetD3D9()->GetRenderState(d3d9::D3DRS_LIGHTING, &m_lighting);
-        if (m_lighting)
-          m_d3d7Device->GetD3D9()->SetRenderState(d3d9::D3DRS_LIGHTING, FALSE);
-      }
-    }
-
-    inline void HandlePostProcessVerticesFlags(DWORD pvFlags) {
-      if (!(pvFlags & D3DVOP_LIGHT) && m_lighting) {
-        m_d3d7Device->GetD3D9()->SetRenderState(d3d9::D3DRS_LIGHTING, TRUE);
-      }
     }
 
     inline void ListBufferDetails() const {
@@ -80,22 +77,24 @@ namespace dxvk {
       Logger::debug(str::format("   Vertices: ", m_size / m_stride));
     }
 
-    bool                  m_locked  = false;
-    bool                  m_legacyDiscard = false;
+    bool                              m_locked  = false;
+    bool                              m_legacyDiscard = false;
 
-    static uint32_t       s_buffCount;
-    uint32_t              m_buffCount  = 0;
+    static uint32_t                   s_buffCount;
+    uint32_t                          m_buffCount  = 0;
 
-    DDrawCommonInterface* m_commonIntf = nullptr;
+    DDrawCommonInterface*             m_commonIntf = nullptr;
 
-    D3D7Device*           m_d3d7Device = nullptr;
+    D3D7Device*                       m_d3d7Device = nullptr;
 
-    DWORD                 m_lighting   = FALSE;
+    Com<d3d9::IDirect3DVertexBuffer9> m_vb9;
 
-    D3DVERTEXBUFFERDESC   m_desc;
+    DWORD                             m_lighting   = FALSE;
 
-    UINT                  m_stride = 0;
-    UINT                  m_size   = 0;
+    D3DVERTEXBUFFERDESC               m_desc;
+
+    UINT                              m_stride = 0;
+    UINT                              m_size   = 0;
 
   };
 

--- a/src/ddraw/d3d7/d3d7_device.cpp
+++ b/src/ddraw/d3d7/d3d7_device.cpp
@@ -21,7 +21,7 @@ namespace dxvk {
         Com<d3d9::IDirect3DDevice9>&& pDevice9,
         DDraw7Surface* pSurface,
         DWORD CreationFlags9)
-    : DDrawWrappedObject<D3D7Interface, IDirect3DDevice7, d3d9::IDirect3DDevice9>(pParent, std::move(d3d7DeviceProxy), std::move(pDevice9))
+    : DDrawWrappedObject<D3D7Interface, IDirect3DDevice7>(pParent, std::move(d3d7DeviceProxy))
     , m_commonD3DDevice ( commonD3DDevice )
     , m_multithread ( CreationFlags9 & D3DCREATE_MULTITHREADED )
     , m_desc ( Desc )
@@ -34,9 +34,22 @@ namespace dxvk {
       throw DxvkError("D3D7Device: ERROR! Failed to retrieve the common interface!");
     }
 
-    // Get the bridge interface to D3D9
-    if (unlikely(FAILED(m_d3d9->QueryInterface(__uuidof(IDxvkD3D8Bridge), reinterpret_cast<void**>(&m_bridge))))) {
-      throw DxvkError("D3D7Device: ERROR! Failed to get D3D9 Bridge. d3d9.dll might not be DXVK!");
+    d3d9::IDirect3DDevice9* device9;
+
+    if (likely(m_commonD3DDevice == nullptr)) {
+      m_commonD3DDevice = new D3DCommonDevice(m_commonIntf, deviceGUID, Params9, CreationFlags9);
+
+      m_commonD3DDevice->SetD3D9Device(std::move(pDevice9));
+      device9 = m_commonD3DDevice->GetD3D9Device();
+
+      const D3DOptions* d3dOptions = m_commonIntf->GetOptions();
+
+      if (unlikely(d3dOptions->emulateFSAA == FSAAEmulation::Forced)) {
+        Logger::warn("D3D7Device: Force enabling AA");
+        device9->SetRenderState(d3d9::D3DRS_MULTISAMPLEANTIALIAS, TRUE);
+      }
+    } else {
+      device9 = m_commonD3DDevice->GetD3D9Device();
     }
 
     // Common D3D9 index buffers
@@ -44,20 +57,16 @@ namespace dxvk {
       throw DxvkError("D3D7Device: ERROR! Failed to initialize D3D9 index buffers.");
     }
 
-    if (likely(m_commonD3DDevice == nullptr)) {
-      m_commonD3DDevice = new D3DCommonDevice(m_commonIntf, deviceGUID, Params9, CreationFlags9,
-                                              m_bridge->DetermineInitialTextureMemory());
-
-      // Update D3D9 legacy light state
-      m_bridge->SetLegacyLightsState(false);
-
-      const D3DOptions* d3dOptions = m_commonIntf->GetOptions();
-
-      if (unlikely(d3dOptions->emulateFSAA == FSAAEmulation::Forced)) {
-        Logger::warn("D3D7Device: Force enabling AA");
-        m_d3d9->SetRenderState(d3d9::D3DRS_MULTISAMPLEANTIALIAS, TRUE);
-      }
+    // Get the bridge interface to D3D9
+    if (unlikely(FAILED(device9->QueryInterface(__uuidof(IDxvkD3D8Bridge), reinterpret_cast<void**>(&m_bridge))))) {
+      throw DxvkError("D3D7Device: ERROR! Failed to get D3D9 Bridge. d3d9.dll might not be DXVK!");
     }
+
+    if (unlikely(!m_commonD3DDevice->GetTotalTextureMemory()))
+      m_commonD3DDevice->SetTotalTextureMemory(m_bridge->DetermineInitialTextureMemory());
+
+    // Update D3D9 legacy light state
+    m_bridge->SetLegacyLightsState(false);
 
     if (m_commonD3DDevice->GetOrigin() == nullptr)
       m_commonD3DDevice->SetOrigin(this);
@@ -215,7 +224,7 @@ namespace dxvk {
     if (unlikely(m_commonD3DDevice->IsInScene()))
       return D3DERR_SCENE_IN_SCENE;
 
-    HRESULT hr = m_d3d9->BeginScene();
+    HRESULT hr = m_commonD3DDevice->GetD3D9Device()->BeginScene();
 
     if (likely(SUCCEEDED(hr)))
       m_commonD3DDevice->SetInScene(true);
@@ -233,7 +242,7 @@ namespace dxvk {
     if (unlikely(!m_commonD3DDevice->IsInScene()))
       return D3DERR_SCENE_NOT_IN_SCENE;
 
-    HRESULT hr = m_d3d9->EndScene();
+    HRESULT hr = m_commonD3DDevice->GetD3D9Device()->EndScene();
 
     if (likely(SUCCEEDED(hr)))
       m_commonD3DDevice->SetInScene(false);
@@ -284,7 +293,9 @@ namespace dxvk {
       return hr;
     }
 
-    hr = m_d3d9->SetRenderTarget(0, rt7->GetD3D9());
+    d3d9::IDirect3DDevice9* device9 = m_commonD3DDevice->GetD3D9Device();
+
+    hr = device9->SetRenderTarget(0, rt7->GetCommonSurface()->GetD3D9Surface());
 
     // TODO: Test suggest that the passed surface is saved as the
     // current RT even if the call fails, or it is an invalid surface...
@@ -307,7 +318,7 @@ namespace dxvk {
           return hrDS;
         }
 
-        hrDS = m_d3d9->SetDepthStencilSurface(m_ds->GetD3D9());
+        hrDS = device9->SetDepthStencilSurface(m_ds->GetCommonSurface()->GetD3D9Surface());
         if (unlikely(FAILED(hrDS))) {
           Logger::err("D3D7Device::SetRenderTarget: Failed to set D3D9 DS");
           return hrDS;
@@ -317,7 +328,7 @@ namespace dxvk {
       } else {
         Logger::debug("D3D7Device::SetRenderTarget: RT has no depth stencil attached");
 
-        hrDS = m_d3d9->SetDepthStencilSurface(nullptr);
+        hrDS = device9->SetDepthStencilSurface(nullptr);
         if (unlikely(FAILED(hrDS))) {
           Logger::err("D3D7Device::SetRenderTarget: Failed to clear the D3D9 DS");
           return hrDS;
@@ -361,7 +372,7 @@ namespace dxvk {
     if (unlikely(FAILED(hr)))
       Logger::debug("D3D7Device::Clear: Failed proxied call");
 
-    hr = m_d3d9->Clear(count, rects, flags, color, static_cast<float>(z), stencil);
+    hr = m_commonD3DDevice->GetD3D9Device()->Clear(count, rects, flags, color, static_cast<float>(z), stencil);
     if (unlikely(FAILED(hr)))
       return hr;
 
@@ -375,17 +386,17 @@ namespace dxvk {
 
   HRESULT STDMETHODCALLTYPE D3D7Device::SetTransform(D3DTRANSFORMSTATETYPE state, D3DMATRIX *matrix) {
     Logger::debug(">>> D3D7Device::SetTransform");
-    return m_d3d9->SetTransform(ConvertTransformState(state), matrix);
+    return m_commonD3DDevice->GetD3D9Device()->SetTransform(ConvertTransformState(state), matrix);
   }
 
   HRESULT STDMETHODCALLTYPE D3D7Device::GetTransform(D3DTRANSFORMSTATETYPE state, D3DMATRIX *matrix) {
     Logger::debug(">>> D3D7Device::GetTransform");
-    return m_d3d9->GetTransform(ConvertTransformState(state), matrix);
+    return m_commonD3DDevice->GetD3D9Device()->GetTransform(ConvertTransformState(state), matrix);
   }
 
   HRESULT STDMETHODCALLTYPE D3D7Device::MultiplyTransform(D3DTRANSFORMSTATETYPE state, D3DMATRIX *matrix) {
     Logger::debug(">>> D3D7Device::MultiplyTransform");
-    return m_d3d9->MultiplyTransform(ConvertTransformState(state), matrix);
+    return m_commonD3DDevice->GetD3D9Device()->MultiplyTransform(ConvertTransformState(state), matrix);
   }
 
   HRESULT STDMETHODCALLTYPE D3D7Device::SetViewport(D3DVIEWPORT7 *data) {
@@ -434,7 +445,7 @@ namespace dxvk {
     if (unlikely(data->dvMinZ == 0.0f && data->dvMaxZ == 0.0f))
       data->dvMaxZ = 1.0f;
 
-    return m_d3d9->SetViewport(reinterpret_cast<d3d9::D3DVIEWPORT9*>(data));
+    return m_commonD3DDevice->GetD3D9Device()->SetViewport(reinterpret_cast<d3d9::D3DVIEWPORT9*>(data));
   }
 
   HRESULT STDMETHODCALLTYPE D3D7Device::GetViewport(D3DVIEWPORT7 *data) {
@@ -445,7 +456,7 @@ namespace dxvk {
     if (unlikely(data == nullptr))
       return DDERR_INVALIDPARAMS;
 
-    return m_d3d9->GetViewport(reinterpret_cast<d3d9::D3DVIEWPORT9*>(data));
+    return m_commonD3DDevice->GetD3D9Device()->GetViewport(reinterpret_cast<d3d9::D3DVIEWPORT9*>(data));
   }
 
   HRESULT STDMETHODCALLTYPE D3D7Device::SetMaterial(D3DMATERIAL7 *data) {
@@ -454,7 +465,7 @@ namespace dxvk {
     if (unlikely(data == nullptr))
       return DDERR_INVALIDPARAMS;
 
-    return m_d3d9->SetMaterial(reinterpret_cast<d3d9::D3DMATERIAL9*>(data));
+    return m_commonD3DDevice->GetD3D9Device()->SetMaterial(reinterpret_cast<d3d9::D3DMATERIAL9*>(data));
   }
 
   HRESULT STDMETHODCALLTYPE D3D7Device::GetMaterial(D3DMATERIAL7 *data) {
@@ -463,7 +474,7 @@ namespace dxvk {
     if (unlikely(data == nullptr))
       return DDERR_INVALIDPARAMS;
 
-    return m_d3d9->GetMaterial(reinterpret_cast<d3d9::D3DMATERIAL9*>(data));
+    return m_commonD3DDevice->GetD3D9Device()->GetMaterial(reinterpret_cast<d3d9::D3DMATERIAL9*>(data));
   }
 
   HRESULT STDMETHODCALLTYPE D3D7Device::SetLight(DWORD idx, D3DLIGHT7 *data) {
@@ -490,7 +501,7 @@ namespace dxvk {
     d3d9::D3DLIGHT9* light9 = reinterpret_cast<d3d9::D3DLIGHT9*>(data);
     m_lights[idx] = *light9;
 
-    HRESULT hr = m_d3d9->SetLight(idx, light9);
+    HRESULT hr = m_commonD3DDevice->GetD3D9Device()->SetLight(idx, light9);
     if (unlikely(FAILED(hr)))
       return DDERR_INVALIDPARAMS;
 
@@ -503,7 +514,7 @@ namespace dxvk {
     if (unlikely(data == nullptr))
       return DDERR_INVALIDPARAMS;
 
-    HRESULT hr = m_d3d9->GetLight(idx, reinterpret_cast<d3d9::D3DLIGHT9*>(data));
+    HRESULT hr = m_commonD3DDevice->GetD3D9Device()->GetLight(idx, reinterpret_cast<d3d9::D3DLIGHT9*>(data));
     if (unlikely(FAILED(hr)))
       return DDERR_INVALIDPARAMS;
 
@@ -616,7 +627,7 @@ namespace dxvk {
     }
 
     // This call will never fail
-    return m_d3d9->SetRenderState(State9, dwRenderState);
+    return m_commonD3DDevice->GetD3D9Device()->SetRenderState(State9, dwRenderState);
   }
 
   HRESULT STDMETHODCALLTYPE D3D7Device::GetRenderState(D3DRENDERSTATETYPE dwRenderStateType, LPDWORD lpdwRenderState) {
@@ -629,7 +640,8 @@ namespace dxvk {
 
     // As opposed to D3D8/9, D3D7 actually validates and
     // errors out in case of unknown/invalid render states
-    if (unlikely(!IsValidD3D7RenderStateType(dwRenderStateType))) {
+    if (unlikely(!IsValidD3D7RenderStateType(dwRenderStateType)
+              && !m_commonIntf->GetOptions()->apitraceMode)) {
       Logger::debug(str::format("D3D7Device::GetRenderState: Invalid render state ", dwRenderStateType));
       return DDERR_INVALIDPARAMS;
     }
@@ -675,7 +687,7 @@ namespace dxvk {
 
       case D3DRENDERSTATE_ZBIAS: {
         DWORD bias = 0;
-        m_d3d9->GetRenderState(d3d9::D3DRS_DEPTHBIAS, &bias);
+        m_commonD3DDevice->GetD3D9Device()->GetRenderState(d3d9::D3DRS_DEPTHBIAS, &bias);
         *lpdwRenderState = static_cast<DWORD>(bit::cast<float>(bias) * ddrawCaps::ZBIAS_SCALE_INV);
         return D3D_OK;
       }
@@ -690,7 +702,7 @@ namespace dxvk {
     }
 
     // This call will never fail
-    return m_d3d9->GetRenderState(State9, lpdwRenderState);
+    return m_commonD3DDevice->GetD3D9Device()->GetRenderState(State9, lpdwRenderState);
   }
 
   HRESULT STDMETHODCALLTYPE D3D7Device::BeginStateBlock() {
@@ -701,7 +713,7 @@ namespace dxvk {
     if (unlikely(m_recorder != nullptr))
       return D3DERR_INBEGINSTATEBLOCK;
 
-    HRESULT hr = m_d3d9->BeginStateBlock();
+    HRESULT hr = m_commonD3DDevice->GetD3D9Device()->BeginStateBlock();
 
     if (likely(SUCCEEDED(hr))) {
       m_handle++;
@@ -727,7 +739,7 @@ namespace dxvk {
       return D3DERR_NOTINBEGINSTATEBLOCK;
 
     Com<d3d9::IDirect3DStateBlock9> pStateBlock;
-    HRESULT hr = m_d3d9->EndStateBlock(&pStateBlock);
+    HRESULT hr = m_commonD3DDevice->GetD3D9Device()->EndStateBlock(&pStateBlock);
 
     if (likely(SUCCEEDED(hr))) {
       m_recorder->SetD3D9(std::move(pStateBlock));
@@ -826,7 +838,7 @@ namespace dxvk {
     }
 
     Com<d3d9::IDirect3DStateBlock9> pStateBlock9;
-    HRESULT res = m_d3d9->CreateStateBlock(d3d9::D3DSTATEBLOCKTYPE(d3dsbType), &pStateBlock9);
+    HRESULT res = m_commonD3DDevice->GetD3D9Device()->CreateStateBlock(d3d9::D3DSTATEBLOCKTYPE(d3dsbType), &pStateBlock9);
 
     if (likely(SUCCEEDED(res))) {
       m_handle++;
@@ -860,7 +872,7 @@ namespace dxvk {
     }
 
     // Does not return an HRESULT
-    surface7->GetD3D9()->PreLoad();
+    surface7->GetCommonSurface()->GetD3D9Surface()->PreLoad();
 
     return D3D_OK;
   }
@@ -878,12 +890,14 @@ namespace dxvk {
     if (unlikely(lpvVertices == nullptr))
       return DDERR_INVALIDPARAMS;
 
+    d3d9::IDirect3DDevice9* device9 = m_commonD3DDevice->GetD3D9Device();
+
     m_rt->InitializeOrUploadD3D9();
     if (likely(m_ds != nullptr))
       m_ds->InitializeOrUploadD3D9();
 
-    m_d3d9->SetFVF(dwVertexTypeDesc);
-    HRESULT hr = m_d3d9->DrawPrimitiveUP(
+    device9->SetFVF(dwVertexTypeDesc);
+    HRESULT hr = device9->DrawPrimitiveUP(
                      d3d9::D3DPRIMITIVETYPE(d3dptPrimitiveType),
                      GetPrimitiveCount(d3dptPrimitiveType, dwVertexCount),
                      lpvVertices,
@@ -912,12 +926,14 @@ namespace dxvk {
     if (unlikely(lpvVertices == nullptr || lpwIndices == nullptr))
       return DDERR_INVALIDPARAMS;
 
+    d3d9::IDirect3DDevice9* device9 = m_commonD3DDevice->GetD3D9Device();
+
     m_rt->InitializeOrUploadD3D9();
     if (likely(m_ds != nullptr))
       m_ds->InitializeOrUploadD3D9();
 
-    m_d3d9->SetFVF(dwVertexTypeDesc);
-    HRESULT hr = m_d3d9->DrawIndexedPrimitiveUP(
+    device9->SetFVF(dwVertexTypeDesc);
+    HRESULT hr = device9->DrawIndexedPrimitiveUP(
                       d3d9::D3DPRIMITIVETYPE(d3dptPrimitiveType),
                       0,
                       dwVertexCount,
@@ -953,7 +969,7 @@ namespace dxvk {
       return DDERR_INVALIDPARAMS;
 
     d3d9::D3DVIEWPORT9 viewport9;
-    if (SUCCEEDED(m_d3d9->GetViewport(&viewport9))) {
+    if (SUCCEEDED(m_commonD3DDevice->GetD3D9Device()->GetViewport(&viewport9))) {
       clip_status->dwFlags = D3DCLIPSTATUS_EXTENTS2;
       clip_status->dwStatus = 0;
       clip_status->minx = viewport9.X;
@@ -980,6 +996,8 @@ namespace dxvk {
     if (unlikely(lpVertexArray == nullptr))
       return DDERR_INVALIDPARAMS;
 
+    d3d9::IDirect3DDevice9* device9 = m_commonD3DDevice->GetD3D9Device();
+
     m_rt->InitializeOrUploadD3D9();
     if (likely(m_ds != nullptr))
       m_ds->InitializeOrUploadD3D9();
@@ -987,8 +1005,8 @@ namespace dxvk {
     // Transform strided vertex data to a standard vertex buffer stream
     PackedVertexBuffer pvb = TransformStridedtoUP(dwVertexTypeDesc, lpVertexArray, dwVertexCount);
 
-    m_d3d9->SetFVF(dwVertexTypeDesc);
-    HRESULT hr = m_d3d9->DrawPrimitiveUP(
+    device9->SetFVF(dwVertexTypeDesc);
+    HRESULT hr = device9->DrawPrimitiveUP(
                      d3d9::D3DPRIMITIVETYPE(d3dptPrimitiveType),
                      GetPrimitiveCount(d3dptPrimitiveType, dwVertexCount),
                      pvb.vertexData.data(),
@@ -1017,6 +1035,8 @@ namespace dxvk {
     if (unlikely(lpVertexArray == nullptr || lpwIndices == nullptr))
       return DDERR_INVALIDPARAMS;
 
+    d3d9::IDirect3DDevice9* device9 = m_commonD3DDevice->GetD3D9Device();
+
     m_rt->InitializeOrUploadD3D9();
     if (likely(m_ds != nullptr))
       m_ds->InitializeOrUploadD3D9();
@@ -1024,8 +1044,8 @@ namespace dxvk {
     // Transform strided vertex data to a standard vertex buffer stream
     PackedVertexBuffer pvb = TransformStridedtoUP(dwVertexTypeDesc, lpVertexArray, dwVertexCount);
 
-    m_d3d9->SetFVF(dwVertexTypeDesc);
-    HRESULT hr = m_d3d9->DrawIndexedPrimitiveUP(
+    device9->SetFVF(dwVertexTypeDesc);
+    HRESULT hr = device9->DrawIndexedPrimitiveUP(
                       d3d9::D3DPRIMITIVETYPE(d3dptPrimitiveType),
                       0,
                       dwVertexCount,
@@ -1065,13 +1085,15 @@ namespace dxvk {
       return D3DERR_VERTEXBUFFERLOCKED;
     }
 
+    d3d9::IDirect3DDevice9* device9 = m_commonD3DDevice->GetD3D9Device();
+
     m_rt->InitializeOrUploadD3D9();
     if (likely(m_ds != nullptr))
       m_ds->InitializeOrUploadD3D9();
 
-    m_d3d9->SetFVF(vb->GetFVF());
-    m_d3d9->SetStreamSource(0, vb->GetD3D9(), 0, vb->GetStride());
-    HRESULT hr = m_d3d9->DrawPrimitive(
+    device9->SetFVF(vb->GetFVF());
+    device9->SetStreamSource(0, vb->GetD3D9VertexBuffer(), 0, vb->GetStride());
+    HRESULT hr = device9->DrawPrimitive(
                            d3d9::D3DPRIMITIVETYPE(d3dptPrimitiveType),
                            dwStartVertex,
                            GetPrimitiveCount(d3dptPrimitiveType, dwNumVertices));
@@ -1116,6 +1138,8 @@ namespace dxvk {
       }
     }
 
+    d3d9::IDirect3DDevice9* device9 = m_commonD3DDevice->GetD3D9Device();
+
     m_rt->InitializeOrUploadD3D9();
     if (likely(m_ds != nullptr))
       m_ds->InitializeOrUploadD3D9();
@@ -1124,10 +1148,10 @@ namespace dxvk {
 
     UploadIndices(ib9, lpwIndices, dwIndexCount);
     m_ib9_uploads[ibIndex]++;
-    m_d3d9->SetIndices(ib9);
-    m_d3d9->SetFVF(vb->GetFVF());
-    m_d3d9->SetStreamSource(0, vb->GetD3D9(), 0, vb->GetStride());
-    HRESULT hr = m_d3d9->DrawIndexedPrimitive(
+    device9->SetIndices(ib9);
+    device9->SetFVF(vb->GetFVF());
+    device9->SetStreamSource(0, vb->GetD3D9VertexBuffer(), 0, vb->GetStride());
+    HRESULT hr = device9->DrawIndexedPrimitive(
                     d3d9::D3DPRIMITIVETYPE(d3dptPrimitiveType),
                     dwStartVertex,
                     0,
@@ -1196,13 +1220,15 @@ namespace dxvk {
     if (unlikely(ShouldRecord()))
       return m_recorder->SetTexture(stage, surface);
 
+    d3d9::IDirect3DDevice9* device9 = m_commonD3DDevice->GetD3D9Device();
+
     HRESULT hr;
 
     // Unbinding texture stages
     if (surface == nullptr) {
       Logger::debug("D3D7Device::SetTexture: Unbiding D3D9 texture");
 
-      hr = m_d3d9->SetTexture(stage, nullptr);
+      hr = device9->SetTexture(stage, nullptr);
 
       if (likely(SUCCEEDED(hr))) {
         if (m_textures[stage] != nullptr) {
@@ -1231,7 +1257,7 @@ namespace dxvk {
 
     // If textures have been used on a different device, they
     // will get their D3D9 object reinitialized at this point
-    if (unlikely(surface7->GetD3D9Device() != m_d3d9.ptr()))
+    if (unlikely(surface7->GetCommonD3DDevice() != m_commonD3DDevice.ptr()))
       surface7->GetCommonSurface()->DirtyDDrawSurface();
 
     hr = surface7->InitializeOrUploadD3D9();
@@ -1244,10 +1270,10 @@ namespace dxvk {
     //if (unlikely(m_textures[stage] == surface7))
       //return D3D_OK;
 
-    d3d9::IDirect3DTexture9* tex9 = surface7->GetD3D9Texture();
+    d3d9::IDirect3DTexture9* tex9 = surface7->GetCommonSurface()->GetD3D9Texture();
 
     if (likely(tex9 != nullptr)) {
-      hr = m_d3d9->SetTexture(stage, tex9);
+      hr = device9->SetTexture(stage, tex9);
       if (unlikely(FAILED(hr))) {
         Logger::warn("D3D7Device::SetTexture: Failed to bind D3D9 texture");
         return hr;
@@ -1264,9 +1290,9 @@ namespace dxvk {
         }
       }
     } else {
-      d3d9::IDirect3DCubeTexture9* cube9 = surface7->GetD3D9CubeTexture();
+      d3d9::IDirect3DCubeTexture9* cube9 = surface7->GetCommonSurface()->GetD3D9CubeTexture();
 
-      hr = m_d3d9->SetTexture(stage, cube9);
+      hr = device9->SetTexture(stage, cube9);
       if (unlikely(FAILED(hr))) {
         Logger::warn("D3D7Device::SetTexture: Failed to bind D3D9 cube texture");
         return hr;
@@ -1284,10 +1310,12 @@ namespace dxvk {
     if (unlikely(lpdwState == nullptr))
       return DDERR_INVALIDPARAMS;
 
+    d3d9::IDirect3DDevice9* device9 = m_commonD3DDevice->GetD3D9Device();
+
     // In the case of D3DTSS_ADDRESS, which is exclusive to D3D7
     // and D3D6, simply return based on D3DTSS_ADDRESSU
     if (d3dTexStageStateType == D3DTSS_ADDRESS) {
-      return m_d3d9->GetSamplerState(dwStage, d3d9::D3DSAMP_ADDRESSU, lpdwState);
+      return device9->GetSamplerState(dwStage, d3d9::D3DSAMP_ADDRESSU, lpdwState);
     }
 
     d3d9::D3DSAMPLERSTATETYPE stateType = ConvertSamplerStateType(d3dTexStageStateType);
@@ -1298,25 +1326,27 @@ namespace dxvk {
       if (stateType == d3d9::D3DSAMP_MAGFILTER ||
           stateType == d3d9::D3DSAMP_MINFILTER || stateType == d3d9::D3DSAMP_MIPFILTER) {
         DWORD dwStateProxy9 = 0;
-        HRESULT hr = m_d3d9->GetSamplerState(dwStage, stateType, &dwStateProxy9);
+        HRESULT hr = device9->GetSamplerState(dwStage, stateType, &dwStateProxy9);
         *lpdwState = DecodeD3D9TexFilterValues(d3dTexStageStateType, dwStateProxy9);
         return hr;
       } else {
-        return m_d3d9->GetSamplerState(dwStage, stateType, lpdwState);
+        return device9->GetSamplerState(dwStage, stateType, lpdwState);
       }
     } else {
-      return m_d3d9->GetTextureStageState(dwStage, d3d9::D3DTEXTURESTAGESTATETYPE(d3dTexStageStateType), lpdwState);
+      return device9->GetTextureStageState(dwStage, d3d9::D3DTEXTURESTAGESTATETYPE(d3dTexStageStateType), lpdwState);
     }
   }
 
   HRESULT STDMETHODCALLTYPE D3D7Device::SetTextureStageState(DWORD dwStage, D3DTEXTURESTAGESTATETYPE d3dTexStageStateType, DWORD dwState) {
     Logger::debug(">>> D3D7Device::SetTextureStageState");
 
+    d3d9::IDirect3DDevice9* device9 = m_commonD3DDevice->GetD3D9Device();
+
     // In the case of D3DTSS_ADDRESS, which is exclusive to D3D7
     // and D3D6, we need to set up both D3DTSS_ADDRESSU and D3DTSS_ADDRESSV
     if (d3dTexStageStateType == D3DTSS_ADDRESS) {
-      m_d3d9->SetSamplerState(dwStage, d3d9::D3DSAMP_ADDRESSU, dwState);
-      return m_d3d9->SetSamplerState(dwStage, d3d9::D3DSAMP_ADDRESSV, dwState);
+      device9->SetSamplerState(dwStage, d3d9::D3DSAMP_ADDRESSU, dwState);
+      return device9->SetSamplerState(dwStage, d3d9::D3DSAMP_ADDRESSV, dwState);
     }
 
     d3d9::D3DSAMPLERSTATETYPE stateType = ConvertSamplerStateType(d3dTexStageStateType);
@@ -1327,19 +1357,19 @@ namespace dxvk {
       if (stateType == d3d9::D3DSAMP_MAGFILTER ||
           stateType == d3d9::D3DSAMP_MINFILTER || stateType == d3d9::D3DSAMP_MIPFILTER) {
         const DWORD dwState9 = DecodeD3D7TexFilterValues(d3dTexStageStateType, dwState);
-        return m_d3d9->SetSamplerState(dwStage, stateType, dwState9);
+        return device9->SetSamplerState(dwStage, stateType, dwState9);
       } else {
-        return m_d3d9->SetSamplerState(dwStage, stateType, dwState);
+        return device9->SetSamplerState(dwStage, stateType, dwState);
       }
     } else {
-      return m_d3d9->SetTextureStageState(dwStage, d3d9::D3DTEXTURESTAGESTATETYPE(d3dTexStageStateType), dwState);
+      return device9->SetTextureStageState(dwStage, d3d9::D3DTEXTURESTAGESTATETYPE(d3dTexStageStateType), dwState);
     }
   }
 
   HRESULT STDMETHODCALLTYPE D3D7Device::ValidateDevice(LPDWORD lpdwPasses) {
     Logger::debug(">>> D3D7Device::ValidateDevice");
 
-    HRESULT hr = m_d3d9->ValidateDevice(lpdwPasses);
+    HRESULT hr = m_commonD3DDevice->GetD3D9Device()->ValidateDevice(lpdwPasses);
     if (unlikely(FAILED(hr)))
       return DDERR_INVALIDPARAMS;
 
@@ -1400,7 +1430,7 @@ namespace dxvk {
 
     m_lightsStates[dwLightIndex] = bEnable;
 
-    return m_d3d9->LightEnable(dwLightIndex, bEnable);
+    return m_commonD3DDevice->GetD3D9Device()->LightEnable(dwLightIndex, bEnable);
   }
 
   HRESULT STDMETHODCALLTYPE D3D7Device::GetLightEnable(DWORD dwLightIndex, BOOL *pbEnable) {
@@ -1409,7 +1439,7 @@ namespace dxvk {
     if (unlikely(pbEnable == nullptr))
       return DDERR_INVALIDPARAMS;
 
-    HRESULT hr = m_d3d9->GetLightEnable(dwLightIndex, pbEnable);
+    HRESULT hr = m_commonD3DDevice->GetD3D9Device()->GetLightEnable(dwLightIndex, pbEnable);
     if (unlikely(FAILED(hr)))
       return DDERR_INVALIDPARAMS;
 
@@ -1418,12 +1448,12 @@ namespace dxvk {
 
   HRESULT STDMETHODCALLTYPE D3D7Device::SetClipPlane(DWORD dwIndex, D3DVALUE *pPlaneEquation) {
     Logger::debug(">>> D3D7Device::SetClipPlane");
-    return m_d3d9->SetClipPlane(dwIndex, pPlaneEquation);
+    return m_commonD3DDevice->GetD3D9Device()->SetClipPlane(dwIndex, pPlaneEquation);
   }
 
   HRESULT STDMETHODCALLTYPE D3D7Device::GetClipPlane(DWORD dwIndex, D3DVALUE *pPlaneEquation) {
     Logger::debug(">>> D3D7Device::GetClipPlane");
-    return m_d3d9->GetClipPlane(dwIndex, pPlaneEquation);
+    return m_commonD3DDevice->GetD3D9Device()->GetClipPlane(dwIndex, pPlaneEquation);
   }
 
   // Docs state: "This method returns S_FALSE on retail builds of DirectX."
@@ -1433,6 +1463,8 @@ namespace dxvk {
   }
 
   void D3D7Device::InitializeDS() {
+    d3d9::IDirect3DDevice9* device9 = m_commonD3DDevice->GetD3D9Device();
+
     m_rt->InitializeD3D9RenderTarget();
 
     m_ds = m_rt->GetAttachedDepthStencil();
@@ -1451,19 +1483,19 @@ namespace dxvk {
         m_ds->GetProxied()->GetSurfaceDesc(&descDS);
         Logger::debug(str::format("D3D7Device::InitializeDS: DepthStencil: ", descDS.dwWidth, "x", descDS.dwHeight));
 
-        HRESULT hrDS9 = m_d3d9->SetDepthStencilSurface(m_ds->GetD3D9());
+        HRESULT hrDS9 = device9->SetDepthStencilSurface(m_ds->GetCommonSurface()->GetD3D9Surface());
         if(unlikely(FAILED(hrDS9))) {
           Logger::err("D3D7Device::InitializeDS: Failed to set D3D9 depth stencil");
         } else {
           // This needs to act like an auto depth stencil of sorts, so manually enable z-buffering
-          m_d3d9->SetRenderState(d3d9::D3DRS_ZENABLE, d3d9::D3DZB_TRUE);
+          device9->SetRenderState(d3d9::D3DRS_ZENABLE, d3d9::D3DZB_TRUE);
         }
       }
     } else {
       Logger::info("D3D7Device::InitializeDS: RT has no depth stencil attached");
-      m_d3d9->SetDepthStencilSurface(nullptr);
+      device9->SetDepthStencilSurface(nullptr);
       // Should be superfluous, but play it safe
-      m_d3d9->SetRenderState(d3d9::D3DRS_ZENABLE, d3d9::D3DZB_FALSE);
+      device9->SetRenderState(d3d9::D3DRS_ZENABLE, d3d9::D3DZB_FALSE);
     }
   }
 
@@ -1491,7 +1523,7 @@ namespace dxvk {
       Logger::err("D3D7Device::ResetD3D9Swapchain: Failed to reset the D3D9 swapchain");
     } else {
       // TODO: Cache and reset all surfaces tied to the D3D9 backbuffers
-      m_rt->SetD3D9(nullptr);
+      m_rt->GetCommonSurface()->SetD3D9Surface(nullptr);
       // Note that the D3D9 depth stencil survives a swapchain reset,
       // so there's no need to worry about it in this case
     }
@@ -1502,13 +1534,15 @@ namespace dxvk {
   inline HRESULT D3D7Device::InitializeIndexBuffers() {
     static constexpr DWORD Usage = D3DUSAGE_DYNAMIC | D3DUSAGE_WRITEONLY;
 
+    d3d9::IDirect3DDevice9* device9 = m_commonD3DDevice->GetD3D9Device();
+
     for (uint8_t ibIndex = 0; ibIndex < ddrawCaps::IndexBufferCount ; ibIndex++) {
       const UINT ibSize = ddrawCaps::IndexCount[ibIndex] * sizeof(WORD);
 
       Logger::debug(str::format("D3D7Device::InitializeIndexBuffer: Creating D3D9 index buffer, size: ", ibSize));
 
-      HRESULT hr = m_d3d9->CreateIndexBuffer(ibSize, Usage, d3d9::D3DFMT_INDEX16,
-                                             d3d9::D3DPOOL_DEFAULT, &m_ib9[ibIndex], nullptr);
+      HRESULT hr = device9->CreateIndexBuffer(ibSize, Usage, d3d9::D3DFMT_INDEX16,
+                                              d3d9::D3DPOOL_DEFAULT, &m_ib9[ibIndex], nullptr);
       if (unlikely(FAILED(hr)))
         return hr;
     }

--- a/src/ddraw/d3d7/d3d7_device.h
+++ b/src/ddraw/d3d7/d3d7_device.h
@@ -28,7 +28,7 @@ namespace dxvk {
   /**
   * \brief D3D7 device implementation
   */
-  class D3D7Device final : public DDrawWrappedObject<D3D7Interface, IDirect3DDevice7, d3d9::IDirect3DDevice9> {
+  class D3D7Device final : public DDrawWrappedObject<D3D7Interface, IDirect3DDevice7> {
 
   friend class D3D7StateBlock;
 

--- a/src/ddraw/d3d7/d3d7_interface.cpp
+++ b/src/ddraw/d3d7/d3d7_interface.cpp
@@ -17,16 +17,22 @@ namespace dxvk {
         D3DCommonInterface* commonD3DIntf,
         Com<IDirect3D7>&& d3d7IntfProxy,
         IUnknown* pParent)
-    : DDrawWrappedObject<IUnknown, IDirect3D7, d3d9::IDirect3D9>(pParent, std::move(d3d7IntfProxy), std::move(d3d9::Direct3DCreate9(D3D_SDK_VERSION)))
+    : DDrawWrappedObject<IUnknown, IDirect3D7>(pParent, std::move(d3d7IntfProxy))
     , m_commonIntf ( commonIntf )
     , m_commonD3DIntf ( commonD3DIntf ) {
-    // Get the bridge interface to D3D9.
-    if (unlikely(FAILED(m_d3d9->QueryInterface(__uuidof(IDxvkD3D8InterfaceBridge), reinterpret_cast<void**>(&m_bridge))))) {
-      throw DxvkError("D3D7Interface: ERROR! Failed to get D3D9 Bridge. d3d9.dll might not be DXVK!");
+    if (m_commonD3DIntf == nullptr) {
+      m_commonD3DIntf = new D3DCommonInterface();
+
+      Com<d3d9::IDirect3D9> d3dIntf9 = d3d9::Direct3DCreate9(D3D_SDK_VERSION);
+      m_commonD3DIntf->SetD3D9Interface(std::move(d3dIntf9));
     }
 
-    if (m_commonD3DIntf == nullptr)
-      m_commonD3DIntf = new D3DCommonInterface();
+    d3d9::IDirect3D9* d3dIntf9 = m_commonD3DIntf->GetD3D9Interface();
+
+    // Get the bridge interface to D3D9.
+    if (unlikely(FAILED(d3dIntf9->QueryInterface(__uuidof(IDxvkD3D8InterfaceBridge), reinterpret_cast<void**>(&m_bridge))))) {
+      throw DxvkError("D3D7Interface: ERROR! Failed to get D3D9 Bridge. d3d9.dll might not be DXVK!");
+    }
 
     m_commonD3DIntf->SetD3D7Interface(this);
 
@@ -148,6 +154,8 @@ namespace dxvk {
   HRESULT STDMETHODCALLTYPE D3D7Interface::CreateDevice(REFCLSID rclsid, IDirectDrawSurface7 *surface, IDirect3DDevice7 **ppd3dDevice) {
     Logger::debug(">>> D3D7Interface::CreateDevice");
 
+    d3d9::IDirect3D9* d3dIntf9 = m_commonD3DIntf->GetD3D9Interface();
+
     if (unlikely(ppd3dDevice == nullptr))
       return DDERR_INVALIDPARAMS;
 
@@ -231,11 +239,11 @@ namespace dxvk {
     // Determine the supported AA sample count by querying the D3D9 interface
     d3d9::D3DMULTISAMPLE_TYPE multiSampleType = d3d9::D3DMULTISAMPLE_NONE;
     if (likely(d3dOptions->emulateFSAA != FSAAEmulation::Disabled)) {
-      HRESULT hr4S = m_d3d9->CheckDeviceMultiSampleType(0, d3d9::D3DDEVTYPE_HAL, backBufferFormat,
-                                                        TRUE, d3d9::D3DMULTISAMPLE_4_SAMPLES, NULL);
+      HRESULT hr4S = d3dIntf9->CheckDeviceMultiSampleType(0, d3d9::D3DDEVTYPE_HAL, backBufferFormat,
+                                                          TRUE, d3d9::D3DMULTISAMPLE_4_SAMPLES, NULL);
       if (unlikely(FAILED(hr4S))) {
-        HRESULT hr2S = m_d3d9->CheckDeviceMultiSampleType(0, d3d9::D3DDEVTYPE_HAL, backBufferFormat,
-                                                          TRUE, d3d9::D3DMULTISAMPLE_2_SAMPLES, NULL);
+        HRESULT hr2S = d3dIntf9->CheckDeviceMultiSampleType(0, d3d9::D3DDEVTYPE_HAL, backBufferFormat,
+                                                            TRUE, d3d9::D3DMULTISAMPLE_2_SAMPLES, NULL);
         if (unlikely(FAILED(hr2S))) {
           Logger::warn("D3D7Interface::CreateDevice: No MSAA support has been detected");
         } else {
@@ -290,7 +298,7 @@ namespace dxvk {
     params.PresentationInterval       = vBlankStatus ? D3DPRESENT_INTERVAL_DEFAULT : D3DPRESENT_INTERVAL_IMMEDIATE;
 
     Com<d3d9::IDirect3DDevice9> device9;
-    hr = m_d3d9->CreateDevice(
+    hr = d3dIntf9->CreateDevice(
       D3DADAPTER_DEFAULT,
       d3d9::D3DDEVTYPE_HAL,
       hWnd,

--- a/src/ddraw/d3d7/d3d7_interface.h
+++ b/src/ddraw/d3d7/d3d7_interface.h
@@ -15,7 +15,7 @@ namespace dxvk {
   /**
   * \brief D3D7 interface implementation
   */
-  class D3D7Interface final : public DDrawWrappedObject<IUnknown, IDirect3D7, d3d9::IDirect3D9> {
+  class D3D7Interface final : public DDrawWrappedObject<IUnknown, IDirect3D7> {
 
   public:
     D3D7Interface(

--- a/src/ddraw/d3d_common_device.cpp
+++ b/src/ddraw/d3d_common_device.cpp
@@ -17,10 +17,8 @@ namespace dxvk {
         DDrawCommonInterface* commonIntf,
         GUID deviceGUID,
         d3d9::D3DPRESENT_PARAMETERS params9,
-        DWORD creationFlags9,
-        uint32_t totalMemory)
+        DWORD creationFlags9)
     : m_commonIntf     ( commonIntf )
-    , m_totalMemory    ( totalMemory )
     , m_deviceGUID     ( deviceGUID )
     , m_params9        ( params9 )
     , m_creationFlags9 ( creationFlags9 ) {
@@ -29,20 +27,6 @@ namespace dxvk {
   D3DCommonDevice::~D3DCommonDevice() {
     if (m_commonIntf->GetCommonD3DDevice() == this)
       m_commonIntf->SetCommonD3DDevice(nullptr);
-  }
-
-  d3d9::IDirect3DDevice9* D3DCommonDevice::GetD3D9Device() {
-    if (m_device7 != nullptr) {
-      return m_device7->GetD3D9();
-    } else if (m_device6 != nullptr) {
-      return m_device6->GetD3D9();
-    } else if (m_device5 != nullptr) {
-      return m_device5->GetD3D9();
-    } else if (m_device3 != nullptr) {
-      return m_device3->GetD3D9();
-    }
-
-    return nullptr;
   }
 
   D3DCommonInterface* D3DCommonDevice::GetCommonD3DInterface() const {
@@ -102,13 +86,13 @@ namespace dxvk {
       return false;
 
     if (m_device7 != nullptr) {
-      return surface == m_device7->GetRenderTarget()->GetD3D9();
+      return surface == m_device7->GetRenderTarget()->GetCommonSurface()->GetD3D9Surface();
     } else if (m_device6 != nullptr) {
-      return surface == m_device6->GetRenderTarget()->GetD3D9();
+      return surface == m_device6->GetRenderTarget()->GetCommonSurface()->GetD3D9Surface();
     } else if (m_device5 != nullptr) {
-      return surface == m_device5->GetRenderTarget()->GetD3D9();
+      return surface == m_device5->GetRenderTarget()->GetCommonSurface()->GetD3D9Surface();
     } else if (m_device3 != nullptr) {
-      return surface == m_device3->GetRenderTarget()->GetD3D9();
+      return surface == m_device3->GetRenderTarget()->GetCommonSurface()->GetD3D9Surface();
     }
 
     return false;
@@ -132,13 +116,13 @@ namespace dxvk {
       return false;
 
     if (m_device7 != nullptr) {
-      return surface == m_device7->GetDepthStencil()->GetD3D9();
+      return surface == m_device7->GetDepthStencil()->GetCommonSurface()->GetD3D9Surface();
     } else if (m_device6 != nullptr) {
-      return surface == m_device6->GetDepthStencil()->GetD3D9();
+      return surface == m_device6->GetDepthStencil()->GetCommonSurface()->GetD3D9Surface();
     } else if (m_device5 != nullptr) {
-      return surface == m_device5->GetDepthStencil()->GetD3D9();
+      return surface == m_device5->GetDepthStencil()->GetCommonSurface()->GetD3D9Surface();
     } else if (m_device3 != nullptr) {
-      return surface == m_device3->GetDepthStencil()->GetD3D9();
+      return surface == m_device3->GetDepthStencil()->GetCommonSurface()->GetD3D9Surface();
     }
 
     return false;

--- a/src/ddraw/d3d_common_device.h
+++ b/src/ddraw/d3d_common_device.h
@@ -26,8 +26,7 @@ namespace dxvk {
           DDrawCommonInterface* commonIntf,
           GUID deviceGUID,
           d3d9::D3DPRESENT_PARAMETERS params9,
-          DWORD creationFlags9,
-          uint32_t totalMemory);
+          DWORD creationFlags9);
 
     ~D3DCommonDevice();
 
@@ -35,8 +34,6 @@ namespace dxvk {
       *ppvObject = this;
       return S_OK;
     }
-
-    d3d9::IDirect3DDevice9* GetD3D9Device();
 
     D3DCommonInterface* GetCommonD3DInterface() const;
 
@@ -74,6 +71,10 @@ namespace dxvk {
 
     DDrawCommonInterface* GetCommonInterface() const {
       return m_commonIntf;
+    }
+
+    void SetTotalTextureMemory(uint32_t totalMemory) {
+      m_totalMemory = totalMemory;
     }
 
     uint32_t GetTotalTextureMemory() const {
@@ -152,6 +153,14 @@ namespace dxvk {
       m_textureMapBlend = textureMapBlend;
     }
 
+    void SetD3D9Device(Com<d3d9::IDirect3DDevice9>&& device9) {
+      m_device9 = device9;
+    }
+
+    d3d9::IDirect3DDevice9* GetD3D9Device() const {
+      return m_device9.ptr();
+    }
+
     void SetD3D7Device(D3D7Device* device7) {
       m_device7 = device7;
     }
@@ -217,6 +226,8 @@ namespace dxvk {
     D3DLINEPATTERN              m_linePattern         = { };
     // Value of D3DRENDERSTATE_TEXTUREMAPBLEND
     DWORD                       m_textureMapBlend     = D3DTBLEND_MODULATE;
+
+    Com<d3d9::IDirect3DDevice9> m_device9;
 
     // Track all possible last used D3D devices
     D3D7Device*                 m_device7        = nullptr;

--- a/src/ddraw/d3d_common_interface.h
+++ b/src/ddraw/d3d_common_interface.h
@@ -38,6 +38,14 @@ namespace dxvk {
       return ++m_materialHandle;
     }
 
+    void SetD3D9Interface(Com<d3d9::IDirect3D9>&& d3d9Intf) {
+      m_d3d9Intf = d3d9Intf;
+    }
+
+    d3d9::IDirect3D9* GetD3D9Interface() const {
+      return m_d3d9Intf.ptr();
+    }
+
     void SetD3D7Interface(D3D7Interface* d3d7Intf) {
       m_d3d7Intf = d3d7Intf;
     }
@@ -72,11 +80,13 @@ namespace dxvk {
 
   private:
 
+    Com<d3d9::IDirect3D9> m_d3d9Intf       = nullptr;
+
     // Track all possible last used D3D interfaces
-    D3D7Interface*    m_d3d7Intf       = nullptr;
-    D3D6Interface*    m_d3d6Intf       = nullptr;
-    D3D5Interface*    m_d3d5Intf       = nullptr;
-    D3D3Interface*    m_d3d3Intf       = nullptr;
+    D3D7Interface*        m_d3d7Intf       = nullptr;
+    D3D6Interface*        m_d3d6Intf       = nullptr;
+    D3D5Interface*        m_d3d5Intf       = nullptr;
+    D3D3Interface*        m_d3d3Intf       = nullptr;
 
     std::atomic<D3DMATERIALHANDLE> m_materialHandle = 0;
     std::unordered_map<D3DMATERIALHANDLE, D3DCommonMaterial*> m_materials;

--- a/src/ddraw/d3d_common_viewport.cpp
+++ b/src/ddraw/d3d_common_viewport.cpp
@@ -38,11 +38,11 @@ namespace dxvk {
 
   d3d9::IDirect3DDevice9* D3DCommonViewport::GetD3D9Device() {
     if (m_device6 != nullptr) {
-      return m_device6->GetD3D9();
+      return m_device6->GetCommonD3DDevice()->GetD3D9Device();
     } else if (m_device5 != nullptr) {
-      return m_device5->GetD3D9();
+      return m_device5->GetCommonD3DDevice()->GetD3D9Device();
     } else if (m_device3 != nullptr) {
-      return m_device3->GetD3D9();
+      return m_device3->GetCommonD3DDevice()->GetD3D9Device();
     }
 
     return nullptr;

--- a/src/ddraw/ddraw/ddraw_interface.cpp
+++ b/src/ddraw/ddraw/ddraw_interface.cpp
@@ -22,7 +22,7 @@ namespace dxvk {
   DDrawInterface::DDrawInterface(
         DDrawCommonInterface* commonIntf,
         Com<IDirectDraw>&& proxyIntf)
-    : DDrawWrappedObject<IUnknown, IDirectDraw, IUnknown>(nullptr, std::move(proxyIntf), nullptr)
+    : DDrawWrappedObject<IUnknown, IDirectDraw>(nullptr, std::move(proxyIntf))
     , m_commonIntf ( commonIntf ) {
 
     if (likely(m_commonIntf == nullptr)) {

--- a/src/ddraw/ddraw/ddraw_interface.h
+++ b/src/ddraw/ddraw/ddraw_interface.h
@@ -17,7 +17,7 @@ namespace dxvk {
   /**
   * \brief DirectDraw interface implementation
   */
-  class DDrawInterface final : public DDrawWrappedObject<IUnknown, IDirectDraw, IUnknown> {
+  class DDrawInterface final : public DDrawWrappedObject<IUnknown, IDirectDraw> {
 
   public:
     DDrawInterface(

--- a/src/ddraw/ddraw/ddraw_surface.cpp
+++ b/src/ddraw/ddraw/ddraw_surface.cpp
@@ -23,7 +23,7 @@ namespace dxvk {
         DDrawInterface* pParent,
         DDrawSurface* pParentSurf,
         bool isChildObject)
-    : DDrawWrappedObject<DDrawInterface, IDirectDrawSurface, d3d9::IDirect3DSurface9>(pParent, std::move(surfProxy), nullptr)
+    : DDrawWrappedObject<DDrawInterface, IDirectDrawSurface>(pParent, std::move(surfProxy))
     , m_isChildObject ( isChildObject )
     , m_commonSurf ( commonSurf )
     , m_parentSurf ( pParentSurf ) {
@@ -324,22 +324,22 @@ namespace dxvk {
     }
     DownloadSurfaceData();
 
-    RefreshD3D9Device();
-    if (likely(m_d3d9Device != nullptr)) {
+    d3d9::IDirect3DDevice9* d3d9Device = RefreshD3D9Device();
+    if (likely(d3d9Device != nullptr)) {
       // Forward DDBLT_DEPTHFILL clears to D3D9 if done on the current depth stencil
       if (unlikely(lpDDSrcSurface == nullptr &&
                   (dwFlags & DDBLT_DEPTHFILL) &&
                   lpDDBltFx != nullptr &&
-                  m_commonIntf->GetCommonD3DDevice()->IsCurrentD3D9DepthStencil(m_d3d9.ptr()))) {
+                  m_commonD3DDevice->IsCurrentD3D9DepthStencil(m_commonSurf->GetD3D9Surface()))) {
         Logger::debug("DDrawSurface::Blt: Clearing d3d9 depth stencil");
 
         HRESULT hrClear;
         const float zClear = m_commonSurf->GetNormalizedFloatDepth(lpDDBltFx->dwFillDepth);
 
         if (lpDestRect == nullptr) {
-          hrClear = m_d3d9Device->Clear(0, NULL, D3DCLEAR_ZBUFFER, 0, zClear, 0);
+          hrClear = d3d9Device->Clear(0, NULL, D3DCLEAR_ZBUFFER, 0, zClear, 0);
         } else {
-          hrClear = m_d3d9Device->Clear(1, reinterpret_cast<D3DRECT*>(lpDestRect), D3DCLEAR_ZBUFFER, 0, zClear, 0);
+          hrClear = d3d9Device->Clear(1, reinterpret_cast<D3DRECT*>(lpDestRect), D3DCLEAR_ZBUFFER, 0, zClear, 0);
         }
         if (unlikely(FAILED(hrClear)))
           Logger::warn("DDrawSurface::Blt: Failed to clear d3d9 depth");
@@ -348,14 +348,14 @@ namespace dxvk {
       if (unlikely(lpDDSrcSurface == nullptr &&
                   (dwFlags & DDBLT_COLORFILL) &&
                   lpDDBltFx != nullptr &&
-                  m_commonIntf->GetCommonD3DDevice()->IsCurrentD3D9RenderTarget(m_d3d9.ptr()))) {
+                  m_commonD3DDevice->IsCurrentD3D9RenderTarget(m_commonSurf->GetD3D9Surface()))) {
         Logger::debug("DDrawSurface::Blt: Clearing d3d9 render target");
 
         HRESULT hrClear;
         if (lpDestRect == nullptr) {
-          hrClear = m_d3d9Device->Clear(0, NULL, D3DCLEAR_TARGET, lpDDBltFx->dwFillColor, 0.0f, 0);
+          hrClear = d3d9Device->Clear(0, NULL, D3DCLEAR_TARGET, lpDDBltFx->dwFillColor, 0.0f, 0);
         } else {
-          hrClear = m_d3d9Device->Clear(1, reinterpret_cast<D3DRECT*>(lpDestRect), D3DCLEAR_TARGET, lpDDBltFx->dwFillColor, 0.0f, 0);
+          hrClear = d3d9Device->Clear(1, reinterpret_cast<D3DRECT*>(lpDestRect), D3DCLEAR_TARGET, lpDDBltFx->dwFillColor, 0.0f, 0);
         }
         if (unlikely(FAILED(hrClear)))
           Logger::warn("DDrawSurface::Blt: Failed to clear d3d9 render target");
@@ -367,14 +367,12 @@ namespace dxvk {
       // Windowed mode presentation path
       if (!exclusiveMode && lpDDSrcSurface != nullptr && m_commonSurf->IsPrimarySurface()) {
         // TODO: Handle this properly, not by uploading the RT again
-        D3DCommonDevice* commonDevice = m_commonIntf->GetCommonD3DDevice();
-
         DDrawSurface* ddrawSurface = static_cast<DDrawSurface*>(lpDDSrcSurface);
-        DDrawSurface* renderTarget = commonDevice->GetCurrentRenderTarget();
+        DDrawSurface* renderTarget = m_commonD3DDevice->GetCurrentRenderTarget();
 
         if (ddrawSurface == renderTarget) {
           renderTarget->InitializeOrUploadD3D9();
-          m_d3d9Device->Present(NULL, NULL, NULL, NULL);
+          d3d9Device->Present(NULL, NULL, NULL, NULL);
           return DD_OK;
         }
       }
@@ -396,14 +394,14 @@ namespace dxvk {
     if (likely(SUCCEEDED(hr))) {
       m_commonSurf->DirtyDDrawSurface();
 
-      if (unlikely(m_shadowSurf != nullptr && m_d3d9Device != nullptr)) {
+      if (unlikely(m_shadowSurf != nullptr && d3d9Device != nullptr)) {
         const bool shouldPresent = m_commonIntf->GetOptions()->legacyPresentGuard == D3DLegacyPresentGuard::Auto ?
                                   !m_commonIntf->GetCommonD3DDevice()->IsInScene() :
                                    m_commonIntf->GetOptions()->legacyPresentGuard == D3DLegacyPresentGuard::Strict ?
                                    false : true;
         if (shouldPresent) {
           InitializeOrUploadD3D9();
-          m_d3d9Device->Present(NULL, NULL, NULL, NULL);
+          d3d9Device->Present(NULL, NULL, NULL, NULL);
         }
       }
     }
@@ -428,26 +426,24 @@ namespace dxvk {
     }
     DownloadSurfaceData();
 
-    RefreshD3D9Device();
-    if (likely(m_d3d9Device != nullptr)) {
+    d3d9::IDirect3DDevice9* d3d9Device = RefreshD3D9Device();
+    if (likely(d3d9Device != nullptr)) {
       const bool exclusiveMode = (m_commonIntf->GetCooperativeLevel() & DDSCL_EXCLUSIVE)
                               && !m_commonIntf->GetOptions()->ignoreExclusiveMode;
 
       // Windowed mode presentation path
       if (!exclusiveMode && lpDDSrcSurface != nullptr && m_commonSurf->IsPrimarySurface()) {
         // TODO: Handle this properly, not by uploading the RT again
-        D3DCommonDevice* commonDevice = m_commonIntf->GetCommonD3DDevice();
-
         DDrawSurface* ddrawSurface = static_cast<DDrawSurface*>(lpDDSrcSurface);
-        DDrawSurface* renderTarget = commonDevice->GetCurrentRenderTarget();
+        DDrawSurface* renderTarget = m_commonD3DDevice->GetCurrentRenderTarget();
 
         if (ddrawSurface == renderTarget) {
           renderTarget->InitializeOrUploadD3D9();
-          m_d3d9Device->Present(NULL, NULL, NULL, NULL);
+          d3d9Device->Present(NULL, NULL, NULL, NULL);
           return DD_OK;
         }
 
-        m_d3d9Device->Present(NULL, NULL, NULL, NULL);
+        d3d9Device->Present(NULL, NULL, NULL, NULL);
         return DD_OK;
       }
     }
@@ -468,14 +464,14 @@ namespace dxvk {
     if (likely(SUCCEEDED(hr))) {
       m_commonSurf->DirtyDDrawSurface();
 
-      if (unlikely(m_shadowSurf != nullptr && m_d3d9Device != nullptr)) {
+      if (unlikely(m_shadowSurf != nullptr && d3d9Device != nullptr)) {
         const bool shouldPresent = m_commonIntf->GetOptions()->legacyPresentGuard == D3DLegacyPresentGuard::Auto ?
                                   !m_commonIntf->GetCommonD3DDevice()->IsInScene() :
                                    m_commonIntf->GetOptions()->legacyPresentGuard == D3DLegacyPresentGuard::Strict ?
                                    false : true;
         if (shouldPresent) {
           InitializeOrUploadD3D9();
-          m_d3d9Device->Present(NULL, NULL, NULL, NULL);
+          d3d9Device->Present(NULL, NULL, NULL, NULL);
         }
       }
     }
@@ -572,8 +568,8 @@ namespace dxvk {
     if (m_commonIntf->IsWrappedSurface(lpDDSurfaceTargetOverride))
       surf = static_cast<DDrawSurface*>(lpDDSurfaceTargetOverride);
 
-    RefreshD3D9Device();
-    if (likely(m_d3d9Device != nullptr)) {
+    d3d9::IDirect3DDevice9* d3d9Device = RefreshD3D9Device();
+    if (likely(d3d9Device != nullptr)) {
       Logger::debug("*** DDrawSurface::Flip: Presenting");
 
       // Lost surfaces are not flippable
@@ -613,7 +609,7 @@ namespace dxvk {
       if (unlikely(rt != nullptr && m_commonSurf->IsPrimarySurface())) {
         Logger::debug("DDrawSurface::Flip: Presenting from DDraw RT");
         rt->InitializeOrUploadD3D9();
-        m_d3d9Device->Present(NULL, NULL, NULL, NULL);
+        d3d9Device->Present(NULL, NULL, NULL, NULL);
         return DD_OK;
       }
 
@@ -623,7 +619,7 @@ namespace dxvk {
         InitializeOrUploadD3D9();
       }
 
-      m_d3d9Device->Present(NULL, NULL, NULL, NULL);
+      d3d9Device->Present(NULL, NULL, NULL, NULL);
     // If we don't have a valid D3D5 device, this means a D3D3 application
     // is trying to flip the surface. Allow that for compatibility reasons.
     } else {
@@ -839,14 +835,15 @@ namespace dxvk {
     if (likely(SUCCEEDED(hr))) {
       m_commonSurf->DirtyDDrawSurface();
 
-      if (unlikely(m_shadowSurf != nullptr && m_d3d9Device != nullptr)) {
+      d3d9::IDirect3DDevice9* d3d9Device = RefreshD3D9Device();
+      if (unlikely(m_shadowSurf != nullptr && d3d9Device != nullptr)) {
         const bool shouldPresent = m_commonIntf->GetOptions()->legacyPresentGuard == D3DLegacyPresentGuard::Auto ?
                                   !m_commonIntf->GetCommonD3DDevice()->IsInScene() :
                                    m_commonIntf->GetOptions()->legacyPresentGuard == D3DLegacyPresentGuard::Strict ?
                                    false : true;
         if (shouldPresent) {
           InitializeOrUploadD3D9();
-          m_d3d9Device->Present(NULL, NULL, NULL, NULL);
+          d3d9Device->Present(NULL, NULL, NULL, NULL);
         }
       }
     }
@@ -962,15 +959,15 @@ namespace dxvk {
     if (likely(SUCCEEDED(hr))) {
       m_commonSurf->DirtyDDrawSurface();
 
-      RefreshD3D9Device();
-      if (unlikely(m_shadowSurf != nullptr && m_d3d9Device != nullptr)) {
+      d3d9::IDirect3DDevice9* d3d9Device = RefreshD3D9Device();
+      if (unlikely(m_shadowSurf != nullptr && d3d9Device != nullptr)) {
         const bool shouldPresent = m_commonIntf->GetOptions()->legacyPresentGuard == D3DLegacyPresentGuard::Auto ?
                                   !m_commonIntf->GetCommonD3DDevice()->IsInScene() :
                                    m_commonIntf->GetOptions()->legacyPresentGuard == D3DLegacyPresentGuard::Strict ?
                                    false : true;
         if (shouldPresent) {
           InitializeOrUploadD3D9();
-          m_d3d9Device->Present(NULL, NULL, NULL, NULL);
+          d3d9Device->Present(NULL, NULL, NULL, NULL);
         }
       }
     }
@@ -1012,9 +1009,9 @@ namespace dxvk {
   }
 
   IDirectDrawSurface* DDrawSurface::GetShadowOrProxied() {
-    RefreshD3D9Device();
+    d3d9::IDirect3DDevice9* d3d9Device = RefreshD3D9Device();
 
-    if (unlikely(m_shadowSurf != nullptr && m_d3d9Device != nullptr))
+    if (unlikely(m_shadowSurf != nullptr && d3d9Device != nullptr))
       return m_shadowSurf->GetProxied();
 
     return m_proxy.ptr();
@@ -1025,8 +1022,18 @@ namespace dxvk {
 
     m_commonSurf->MarkAsD3D9BackBuffer();
 
-    if (unlikely(!IsInitialized()))
-      return InitializeD3D9(true);
+    if (unlikely(!m_commonSurf->IsInitialized())) {
+      if (m_commonSurf->IsTexture())
+        UpdateMipMapCount();
+
+      HRESULT hr = m_commonSurf->InitializeD3D9(true);
+      if (unlikely(FAILED(hr)))
+        return hr;
+
+      Logger::debug(str::format("DDrawSurface::InitializeD3D9RenderTarget: Initialized surface nr. [[1-", m_surfCount, "]]"));
+
+      return UploadSurfaceData();
+    }
 
     return DD_OK;
   }
@@ -1036,19 +1043,45 @@ namespace dxvk {
 
     m_commonSurf->MarkAsD3D9DepthStencil();
 
-    if (unlikely(!IsInitialized()))
-      return InitializeD3D9(false);
+    if (unlikely(!m_commonSurf->IsInitialized())) {
+      HRESULT hr = m_commonSurf->InitializeD3D9(false);
+      if (unlikely(FAILED(hr)))
+        return hr;
+
+      Logger::debug(str::format("DDrawSurface::InitializeD3D9DepthStencil: Initialized surface nr. [[1-", m_surfCount, "]]"));
+
+      return UploadSurfaceData();
+    }
 
     return DD_OK;
   }
 
   HRESULT DDrawSurface::InitializeOrUploadD3D9() {
-    RefreshD3D9Device();
+    d3d9::IDirect3DDevice9* d3d9Device = RefreshD3D9Device();
 
-    if (unlikely(!IsInitialized()))
-      return InitializeD3D9(false);
+    // Fast skip
+    if (unlikely(d3d9Device == nullptr)) {
+      Logger::debug("DDrawSurface::InitializeOrUploadD3D9: Null device, can't initialize right now");
+      return DD_OK;
+    }
 
-    return UploadSurfaceData();
+    if (unlikely(!m_commonSurf->IsInitialized())) {
+      if (m_commonSurf->IsTexture())
+        UpdateMipMapCount();
+
+      const bool initRenderTarget = m_commonIntf->GetCommonD3DDevice()->IsCurrentRenderTarget(this);
+
+      HRESULT hr = m_commonSurf->InitializeD3D9(initRenderTarget);
+      if (unlikely(FAILED(hr)))
+        return hr;
+
+      Logger::debug(str::format("DDrawSurface::InitializeOrUploadD3D9: Initialized surface nr. [[1-", m_surfCount, "]]"));
+    }
+
+    if (likely(m_commonSurf->IsInitialized()))
+      return UploadSurfaceData();
+
+    return DD_OK;
   }
 
   void DDrawSurface::DownloadSurfaceData() {
@@ -1063,339 +1096,64 @@ namespace dxvk {
     if (unlikely(m_commonSurf->IsD3D9BackBuffer())) {
       Logger::debug("DDrawSurface::DownloadSurfaceData: Surface is a bound swapchain surface");
 
-      if (IsInitialized() && m_commonSurf->IsD3D9SurfaceDirty()) {
+      if (m_commonSurf->IsInitialized() && m_commonSurf->IsD3D9SurfaceDirty()) {
         Logger::debug(str::format("DDrawSurface::DownloadSurfaceData: Downloading nr. [[1-", m_surfCount, "]]"));
-        BlitToDDrawSurface<IDirectDrawSurface, DDSURFACEDESC>(GetShadowOrProxied(), m_d3d9.ptr());
+        BlitToDDrawSurface<IDirectDrawSurface, DDSURFACEDESC>(GetShadowOrProxied(), m_commonSurf->GetD3D9Surface());
         m_commonSurf->UnDirtyD3D9Surface();
       }
     } else if (unlikely(m_commonSurf->IsD3D9DepthStencil())) {
       Logger::debug("DDrawSurface::DownloadSurfaceData: Surface is a bound depth stencil");
 
-      if (IsInitialized() && m_commonSurf->IsD3D9SurfaceDirty()) {
+      if (m_commonSurf->IsInitialized() && m_commonSurf->IsD3D9SurfaceDirty()) {
         Logger::debug(str::format("DDrawSurface::DownloadSurfaceData: Downloading nr. [[1-", m_surfCount, "]]"));
-        BlitToDDrawSurface<IDirectDrawSurface, DDSURFACEDESC>(m_proxy.ptr(), m_d3d9.ptr());
+        BlitToDDrawSurface<IDirectDrawSurface, DDSURFACEDESC>(m_proxy.ptr(), m_commonSurf->GetD3D9Surface());
         m_commonSurf->UnDirtyD3D9Surface();
       }
     }
   }
 
-  inline HRESULT DDrawSurface::InitializeD3D9(const bool initRT) {
-    if (unlikely(m_d3d9Device == nullptr)) {
-      Logger::debug("DDrawSurface::InitializeD3D9: Null device, can't initialize right now");
-      return DD_OK;
-    }
-
-    Logger::debug(str::format("DDrawSurface::InitializeD3D9: Initializing nr. [[1-", m_surfCount, "]]"));
-
-    const DDSURFACEDESC* desc    = m_commonSurf->GetDesc();
-    const d3d9::D3DFORMAT format = m_commonSurf->GetD3D9Format();
-
-    if (unlikely(desc->dwHeight == 0 || desc->dwWidth == 0)) {
-      Logger::err("DDrawSurface::InitializeD3D9: Surface has 0 height or width");
-      return DDERR_GENERIC;
-    }
-
-    if (unlikely(format == d3d9::D3DFMT_UNKNOWN)) {
-      Logger::err("DDrawSurface::InitializeD3D9: Surface has an unknown format");
-      return DDERR_GENERIC;
-    }
-
-    // Don't initialize P8 textures/surfaces since we don't support them.
-    // Some applications do require them to be created by ddraw, otherwise
-    // they will simply fail to start, so just ignore them for now.
-    if (unlikely(format == d3d9::D3DFMT_P8)) {
-      static bool s_formatP8ErrorShown;
-
-      if (!std::exchange(s_formatP8ErrorShown, true))
-        Logger::warn("DDrawSurface::InitializeD3D9: Unsupported format D3DFMT_P8");
-
-      return DD_OK;
-
-    // Similarly, D3DFMT_R3G3B2 isn't supported by D3D9 dxvk, however some
-    // applications require it to be supported by ddraw, even if they do not
-    // use it. Simply ignore any D3DFMT_R3G3B2 textures/surfaces for now.
-    } else if (unlikely(format == d3d9::D3DFMT_R3G3B2)) {
-      static bool s_formatR3G3B2ErrorShown;
-
-      if (!std::exchange(s_formatR3G3B2ErrorShown, true))
-        Logger::warn("DDrawSurface::InitializeD3D9: Unsupported format D3DFMT_R3G3B2");
-
-      return DD_OK;
-    }
-
+  inline void DDrawSurface::UpdateMipMapCount() {
     // We need to count the number of actual mips on initialization by going through
     // the mip chain, since the dwMipMapCount number may or may not be accurate. I am
     // guessing it was intended more as a hint, not neceesarily a set number.
-    if (m_commonSurf->IsTexture()) {
-      IDirectDrawSurface* mipMap = m_proxy.ptr();
-      DDSURFACEDESC mipDesc;
-      uint16_t mipCount = 1;
+    const DDSURFACEDESC* desc  = m_commonSurf->GetDesc();
 
-      while (mipMap != nullptr) {
-        IDirectDrawSurface* parentSurface = mipMap;
-        mipMap = nullptr;
-        parentSurface->EnumAttachedSurfaces(&mipMap, ListMipChainSurfacesCallback);
-        if (mipMap != nullptr) {
-          mipCount++;
+    IDirectDrawSurface* mipMap = m_proxy.ptr();
+    DDSURFACEDESC mipDesc;
+    uint16_t mipCount = 1;
 
-          mipDesc = { };
-          mipDesc.dwSize = sizeof(DDSURFACEDESC2);
-          mipMap->GetSurfaceDesc(&mipDesc);
-          // Ignore multiple 1x1 mips, which apparently can get generated if the
-          // application gets the dwMipMapCount wrong vs surface dimensions.
-          if (unlikely(mipDesc.dwWidth == 1 && mipDesc.dwHeight == 1))
-            break;
-        }
-      }
+    while (mipMap != nullptr) {
+      IDirectDrawSurface* parentSurface = mipMap;
+      mipMap = nullptr;
+      parentSurface->EnumAttachedSurfaces(&mipMap, ListMipChainSurfacesCallback);
+      if (mipMap != nullptr) {
+        mipCount++;
 
-      // Do not worry about maximum supported mip map levels validation,
-      // because D3D9 will handle this for us and cap them appropriately
-      if (mipCount > 1) {
-        Logger::debug(str::format("DDrawSurface::InitializeD3D9: Found ", mipCount, " mip levels"));
-
-        if (unlikely(mipCount != desc->dwMipMapCount))
-          Logger::debug(str::format("DDrawSurface::InitializeD3D9: Mismatch with declared ", desc->dwMipMapCount, " mip levels"));
-      }
-
-      if (unlikely(m_commonIntf->GetOptions()->autoGenMipMaps)) {
-        Logger::debug("DDrawSurface::InitializeD3D9: Using auto mip map generation");
-        mipCount = 0;
-      }
-
-      m_commonSurf->SetMipCount(mipCount);
-    }
-
-    d3d9::D3DPOOL pool  = d3d9::D3DPOOL_DEFAULT;
-    DWORD         usage = 0;
-
-    // General surface/texture pool placement
-    if (desc->ddsCaps.dwCaps & DDSCAPS_LOCALVIDMEM)
-      pool = d3d9::D3DPOOL_DEFAULT;
-    // There's no explicit non-local video memory placement
-    // per se, but D3DPOOL_MANAGED is close enough
-    else if (desc->ddsCaps.dwCaps & DDSCAPS_NONLOCALVIDMEM)
-      pool = d3d9::D3DPOOL_MANAGED;
-    else if (desc->ddsCaps.dwCaps & DDSCAPS_SYSTEMMEMORY)
-      // We can't know beforehand if a texture is or isn't going to be
-      // used in SetTexture() calls, and textures placed in D3DPOOL_SYSTEMMEM
-      // will not work in that context in dxvk, so revert to D3DPOOL_MANAGED.
-      pool = m_commonSurf->IsTexture() ? d3d9::D3DPOOL_MANAGED : d3d9::D3DPOOL_SYSTEMMEM;
-
-    // Place all possible render targets in DEFAULT
-    //
-    // Note: This is somewhat problematic for textures and cube maps
-    // which will have D3DUSAGE_RENDERTARGET, but also need to have
-    // D3DUSAGE_DYNAMIC for locking/uploads to work. The flag combination
-    // isn't supported in D3D9, but we have a D3D7 exception in place.
-    //
-    if (m_commonSurf->IsRenderTarget() || initRT) {
-      Logger::debug("DDrawSurface::InitializeD3D9: Usage: D3DUSAGE_RENDERTARGET");
-      pool  = d3d9::D3DPOOL_DEFAULT;
-      usage |= D3DUSAGE_RENDERTARGET;
-    }
-    // All depth stencils will be created in DEFAULT
-    if (m_commonSurf->IsDepthStencil()) {
-      Logger::debug("DDrawSurface::InitializeD3D9: Usage: D3DUSAGE_DEPTHSTENCIL");
-      pool  = d3d9::D3DPOOL_DEFAULT;
-      usage |= D3DUSAGE_DEPTHSTENCIL;
-    }
-
-    // General usage flags
-    if (m_commonSurf->IsTexture()) {
-      if (pool == d3d9::D3DPOOL_DEFAULT) {
-        Logger::debug("DDrawSurface::InitializeD3D9: Usage: D3DUSAGE_DYNAMIC");
-        usage |= D3DUSAGE_DYNAMIC;
-      }
-      if (unlikely(m_commonIntf->GetOptions()->autoGenMipMaps)) {
-        Logger::debug("DDrawSurface::InitializeD3D9: Usage: D3DUSAGE_AUTOGENMIPMAP");
-        usage |= D3DUSAGE_AUTOGENMIPMAP;
+        mipDesc = { };
+        mipDesc.dwSize = sizeof(DDSURFACEDESC2);
+        mipMap->GetSurfaceDesc(&mipDesc);
+        // Ignore multiple 1x1 mips, which apparently can get generated if the
+        // application gets the dwMipMapCount wrong vs surface dimensions.
+        if (unlikely(mipDesc.dwWidth == 1 && mipDesc.dwHeight == 1))
+          break;
       }
     }
 
-    const char* poolPlacement = pool == d3d9::D3DPOOL_DEFAULT ? "D3DPOOL_DEFAULT" :
-                                pool == d3d9::D3DPOOL_SYSTEMMEM ? "D3DPOOL_SYSTEMMEM" : "D3DPOOL_MANAGED";
+    // Do not worry about maximum supported mip map levels validation,
+    // because D3D9 will handle this for us and cap them appropriately
+    if (mipCount > 1) {
+      Logger::debug(str::format("DDrawSurface::InitializeD3D9: Found ", mipCount, " mip levels"));
 
-    Logger::debug(str::format("DDrawSurface::InitializeD3D9: Placing in: ", poolPlacement));
-
-    // Use the MSAA type that was determined to be supported during device creation
-    const d3d9::D3DMULTISAMPLE_TYPE multiSampleType = m_commonIntf->GetCommonD3DDevice()->GetMultiSampleType();
-    const uint32_t index = m_commonSurf->GetBackBufferIndex();
-
-    Com<d3d9::IDirect3DSurface9> surf;
-
-    HRESULT hr = DDERR_GENERIC;
-
-    // Front Buffer
-    if (m_commonSurf->IsFrontBuffer()) {
-      Logger::debug("DDrawSurface::InitializeD3D9: Initializing front buffer...");
-
-      m_d3d9Device->GetBackBuffer(0, index, d3d9::D3DBACKBUFFER_TYPE_MONO, &surf);
-
-      if (unlikely(surf == nullptr)) {
-        Logger::err("DDrawSurface::InitializeD3D9: Failed to retrieve front buffer");
-        m_d3d9 = nullptr;
-        return hr;
-      }
-
-      m_d3d9 = std::move(surf);
-
-      m_commonSurf->MarkAsD3D9BackBuffer();
-
-    // Back Buffer
-    } else if (m_commonSurf->IsBackBufferOrFlippable()) {
-      Logger::debug("DDrawSurface::InitializeD3D9: Initializing back buffer...");
-
-      m_d3d9Device->GetBackBuffer(0, index, d3d9::D3DBACKBUFFER_TYPE_MONO, &surf);
-
-      if (unlikely(surf == nullptr)) {
-        Logger::err("DDrawSurface::InitializeD3D9: Failed to retrieve back buffer");
-        m_d3d9 = nullptr;
-        return hr;
-      }
-
-      m_d3d9 = std::move(surf);
-
-      m_commonSurf->MarkAsD3D9BackBuffer();
-
-    // Textures
-    } else if (m_commonSurf->IsTexture()) {
-      Logger::debug("DDrawSurface::InitializeD3D9: Initializing texture...");
-
-      Com<d3d9::IDirect3DTexture9> tex;
-
-      hr = m_d3d9Device->CreateTexture(
-        desc->dwWidth, desc->dwHeight, m_commonSurf->GetMipCount(), usage,
-        format, pool, &tex, nullptr);
-
-      if (unlikely(FAILED(hr))) {
-        Logger::err("DDrawSurface::InitializeD3D9: Failed to create texture");
-        m_texture9 = nullptr;
-        return hr;
-      }
-
-      if (unlikely(m_commonIntf->GetOptions()->autoGenMipMaps))
-        tex->SetAutoGenFilterType(d3d9::D3DTEXF_ANISOTROPIC);
-
-      // Attach level 0 to this surface
-      tex->GetSurfaceLevel(0, &surf);
-      m_d3d9 = (std::move(surf));
-
-      Logger::debug("DDrawSurface::InitializeD3D9: Created texture");
-      m_texture9 = std::move(tex);
-
-    // Depth Stencil
-    } else if (m_commonSurf->IsDepthStencil()) {
-      Logger::debug("DDrawSurface::InitializeD3D9: Initializing depth stencil...");
-
-      hr = m_d3d9Device->CreateDepthStencilSurface(
-        desc->dwWidth, desc->dwHeight, format,
-        multiSampleType, 0, FALSE, &surf, nullptr);
-
-      if (unlikely(FAILED(hr))) {
-        Logger::err("DDrawSurface::InitializeD3D9: Failed to create DS");
-        m_d3d9 = nullptr;
-        return hr;
-      }
-
-      Logger::debug("DDrawSurface::InitializeD3D9: Created depth stencil surface");
-
-      m_d3d9 = std::move(surf);
-
-    // Offscreen Plain Surfaces
-    } else if (m_commonSurf->IsOffScreenPlainSurface()) {
-      Logger::debug("DDrawSurface::InitializeD3D9: Initializing offscreen plain surface...");
-
-      // Sometimes we get passed offscreen plain surfaces which should be tied to the back buffer,
-      // either as existing RTs or during SetRenderTarget() calls, which are tracked with initRT
-      if (unlikely(m_commonIntf->GetCommonD3DDevice()->IsCurrentRenderTarget(this) || initRT)) {
-        Logger::debug("DDrawSurface::InitializeD3D9: Offscreen plain surface is the RT");
-
-        m_d3d9Device->GetBackBuffer(0, index, d3d9::D3DBACKBUFFER_TYPE_MONO, &surf);
-
-        if (unlikely(surf == nullptr)) {
-          Logger::err("DDrawSurface::InitializeD3D9: Failed to retrieve offscreen plain surface");
-          m_d3d9 = nullptr;
-          return hr;
-        }
-      } else {
-        hr = m_d3d9Device->CreateOffscreenPlainSurface(
-          desc->dwWidth, desc->dwHeight, format,
-          pool, &surf, nullptr);
-
-        if (unlikely(FAILED(hr))) {
-          Logger::err("DDrawSurface::InitializeD3D9: Failed to create offscreen plain surface");
-          m_d3d9 = nullptr;
-          return hr;
-        }
-      }
-
-      m_d3d9 = std::move(surf);
-
-      m_commonSurf->MarkAsD3D9BackBuffer();
-
-    // Overlays (haven't seen any actual use of overlays in the wild)
-    } else if (m_commonSurf->IsOverlay()) {
-      Logger::debug("DDrawSurface::InitializeD3D9: Initializing overlay...");
-
-      // Always link overlays to the back buffer
-      m_d3d9Device->GetBackBuffer(0, index, d3d9::D3DBACKBUFFER_TYPE_MONO, &surf);
-
-      if (unlikely(surf == nullptr)) {
-        Logger::err("DDrawSurface::InitializeD3D9: Failed to retrieve overlay surface");
-        m_d3d9 = nullptr;
-        return hr;
-      }
-
-      m_d3d9 = std::move(surf);
-
-      m_commonSurf->MarkAsD3D9BackBuffer();
-
-    // Generic render target
-    } else if (m_commonSurf->IsRenderTarget()) {
-      Logger::debug("DDrawSurface::InitializeD3D9: Initializing render target...");
-
-      // Must be lockable for blitting to work. Note that
-      // D3D9 does not allow the creation of lockable RTs when
-      // using MSAA, but we have a D3D7 exception in place.
-      hr = m_d3d9Device->CreateRenderTarget(
-        desc->dwWidth, desc->dwHeight, format,
-        multiSampleType, usage, TRUE, &surf, nullptr);
-
-      if (unlikely(FAILED(hr))) {
-        Logger::err("DDrawSurface::InitializeD3D9: Failed to create render target");
-        m_d3d9 = nullptr;
-        return hr;
-      }
-
-      m_d3d9 = std::move(surf);
-
-    // We sometimes get generic surfaces, with only dimensions, format and placement info
-    } else if (!m_commonSurf->IsNotKnown()) {
-      Logger::debug("DDrawSurface::InitializeD3D9: Initializing generic surface...");
-
-      hr = m_d3d9Device->CreateOffscreenPlainSurface(
-          desc->dwWidth, desc->dwHeight, format,
-          pool, &surf, nullptr);
-
-      if (unlikely(FAILED(hr))) {
-        Logger::err("DDrawSurface::InitializeD3D9: Failed to create offscreen plain surface");
-        m_d3d9 = nullptr;
-        return hr;
-      }
-
-      Logger::debug("DDrawSurface::InitializeD3D9: Created offscreen plain surface");
-
-      m_d3d9 = std::move(surf);
-    } else {
-      Logger::warn("DDrawSurface::InitializeD3D9: Skipping initialization of unknown surface");
+      if (unlikely(mipCount != desc->dwMipMapCount))
+        Logger::debug(str::format("DDrawSurface::InitializeD3D9: Mismatch with declared ", desc->dwMipMapCount, " mip levels"));
     }
 
-    if (m_shadowSurf != nullptr)
-      m_shadowSurf->SetD3D9(m_d3d9.ptr());
+    if (unlikely(m_commonIntf->GetOptions()->autoGenMipMaps)) {
+      Logger::debug("DDrawSurface::InitializeD3D9: Using auto mip map generation");
+      mipCount = 0;
+    }
 
-    UploadSurfaceData();
-
-    return DD_OK;
+    m_commonSurf->SetMipCount(mipCount);
   }
 
   inline HRESULT DDrawSurface::UploadSurfaceData() {
@@ -1408,19 +1166,36 @@ namespace dxvk {
     const d3d9::D3DFORMAT format = m_commonSurf->GetD3D9Format();
 
     if (m_commonSurf->IsTexture()) {
-      BlitToD3D9Texture<IDirectDrawSurface, DDSURFACEDESC>(m_texture9.ptr(), format,
+      BlitToD3D9Texture<IDirectDrawSurface, DDSURFACEDESC>(m_commonSurf->GetD3D9Texture(), format,
                                                            m_proxy.ptr(), m_commonSurf->GetMipCount());
     // Blit surfaces directly
     } else {
       if (unlikely(m_commonSurf->IsDepthStencil()))
         Logger::debug("DDrawSurface::UploadSurfaceData: Uploading depth stencil");
 
-      BlitToD3D9Surface<IDirectDrawSurface, DDSURFACEDESC>(m_d3d9.ptr(), format, GetShadowOrProxied());
+      BlitToD3D9Surface<IDirectDrawSurface, DDSURFACEDESC>(m_commonSurf->GetD3D9Surface(), format, GetShadowOrProxied());
     }
 
     m_commonSurf->UnDirtyDDrawSurface();
 
     return DD_OK;
+  }
+
+  inline d3d9::IDirect3DDevice9* DDrawSurface::RefreshD3D9Device() {
+    D3DCommonDevice* commonD3DDevice = m_commonIntf->GetCommonD3DDevice();
+
+    if (unlikely(m_commonD3DDevice != commonD3DDevice)) {
+      // Check if the device has been recreated and reset all D3D9 resources
+      if (m_commonD3DDevice != nullptr) {
+        Logger::debug("DDrawSurface: Device context has changed, clearing all D3D9 resources");
+        m_commonSurf->SetD3D9Texture(nullptr);
+        m_commonSurf->SetD3D9Surface(nullptr);
+      }
+
+      m_commonD3DDevice = commonD3DDevice;
+    }
+
+    return m_commonD3DDevice != nullptr ? m_commonD3DDevice->GetD3D9Device() : nullptr;
   }
 
   inline HRESULT DDrawSurface::CreateDeviceInternal(REFIID riid, void** ppvObject) {
@@ -1498,7 +1273,7 @@ namespace dxvk {
 
       d3d9Bridge->EnableD3D3CompatibilityMode();
     } else {
-      d3d9Intf = d3d3Intf->GetD3D9();
+      d3d9Intf = d3d3Intf->GetCommonD3DInterface()->GetD3D9Interface();
     }
 
     // Determine the supported AA sample count by querying the D3D9 interface
@@ -1585,23 +1360,6 @@ namespace dxvk {
     *ppvObject = device3.ref();
 
     return DD_OK;
-  }
-
-  inline void DDrawSurface::RefreshD3D9Device() {
-    D3DCommonDevice* commonDevice = m_commonIntf->GetCommonD3DDevice();
-
-    d3d9::IDirect3DDevice9* d3d9Device = commonDevice != nullptr ? commonDevice->GetD3D9Device() : nullptr;
-    if (unlikely(m_d3d9Device != d3d9Device)) {
-      // Check if the device has been recreated and reset all D3D9 resources
-      if (m_d3d9Device != nullptr) {
-        Logger::debug("DDrawSurface: Device context has changed, clearing all D3D9 resources");
-        m_d3d9 = nullptr;
-        if (m_shadowSurf != nullptr)
-          m_shadowSurf->SetD3D9(nullptr);
-      }
-
-      m_d3d9Device = d3d9Device;
-    }
   }
 
   inline DWORD DDrawSurface::DetermineBackBufferCount(IDirectDrawSurface* renderTarget) {

--- a/src/ddraw/ddraw/ddraw_surface.h
+++ b/src/ddraw/ddraw/ddraw_surface.h
@@ -21,7 +21,7 @@ namespace dxvk {
   /**
   * \brief IDirectDrawSurface interface implementation
   */
-  class DDrawSurface final : public DDrawWrappedObject<DDrawInterface, IDirectDrawSurface, d3d9::IDirect3DSurface9> {
+  class DDrawSurface final : public DDrawWrappedObject<DDrawInterface, IDirectDrawSurface> {
 
   public:
 
@@ -128,12 +128,8 @@ namespace dxvk {
       return m_commonIntf;
     }
 
-    d3d9::IDirect3DDevice9* GetD3D9Device() const {
-      return m_d3d9Device;
-    }
-
-    d3d9::IDirect3DTexture9* GetD3D9Texture() const {
-      return m_texture9.ptr();
+    D3DCommonDevice* GetCommonD3DDevice() const {
+      return m_commonD3DDevice;
     }
 
     DDrawSurface* GetNextFlippable() const {
@@ -189,13 +185,13 @@ namespace dxvk {
 
   private:
 
-    inline HRESULT InitializeD3D9(const bool initRT);
+    inline void UpdateMipMapCount();
 
     inline HRESULT UploadSurfaceData();
 
-    inline HRESULT CreateDeviceInternal(REFIID riid, void** ppvObject);
+    inline d3d9::IDirect3DDevice9* RefreshD3D9Device();
 
-    inline void RefreshD3D9Device();
+    inline HRESULT CreateDeviceInternal(REFIID riid, void** ppvObject);
 
     inline DWORD DetermineBackBufferCount(IDirectDrawSurface* renderTarget);
 
@@ -204,27 +200,25 @@ namespace dxvk {
     static uint32_t  s_surfCount;
     uint32_t         m_surfCount       = 0;
 
-    Com<DDrawCommonSurface>      m_commonSurf;
-    DDrawCommonInterface*        m_commonIntf = nullptr;
+    Com<DDrawCommonSurface> m_commonSurf;
+    DDrawCommonInterface*   m_commonIntf = nullptr;
 
-    DDrawSurface*                m_parentSurf = nullptr;
+    DDrawSurface*           m_parentSurf = nullptr;
 
-    d3d9::IDirect3DDevice9*      m_d3d9Device = nullptr;
+    D3DCommonDevice*        m_commonD3DDevice = nullptr;
 
-    Com<D3D3Texture, false>      m_texture3;
-    Com<D3D5Texture, false>      m_texture5;
+    Com<D3D3Texture, false> m_texture3;
+    Com<D3D5Texture, false> m_texture5;
 
-    Com<d3d9::IDirect3DTexture9> m_texture9;
-
-    DDrawSurface*                m_nextFlippable = nullptr;
+    DDrawSurface*           m_nextFlippable = nullptr;
 
     // Offscreen plain surface we use to mask unwanted DDraw interactions, such
     // as forced swapchain presents caused by blits/locks on primary surfaces
-    Com<DDrawSurface>            m_shadowSurf;
+    Com<DDrawSurface>       m_shadowSurf;
 
     // Back buffers will have depth stencil surfaces as attachments (in practice
     // I have never seen more than one depth stencil being attached at a time)
-    Com<DDrawSurface>            m_depthStencil;
+    Com<DDrawSurface>       m_depthStencil;
 
     // These are attached surfaces, which are typically mips or other types of generated
     // surfaces, which need to exist for the entire lifecycle of their parent surface.

--- a/src/ddraw/ddraw2/ddraw2_interface.cpp
+++ b/src/ddraw/ddraw2/ddraw2_interface.cpp
@@ -20,7 +20,7 @@ namespace dxvk {
   DDraw2Interface::DDraw2Interface(
         DDrawCommonInterface* commonIntf,
         Com<IDirectDraw2>&& proxyIntf)
-    : DDrawWrappedObject<IUnknown, IDirectDraw2, IUnknown>(nullptr, std::move(proxyIntf), nullptr)
+    : DDrawWrappedObject<IUnknown, IDirectDraw2>(nullptr, std::move(proxyIntf))
     , m_commonIntf ( commonIntf ) {
     // Hold a reference to the parent IDirectDraw object, since
     // it is needed to be able to create surfaces from this interface

--- a/src/ddraw/ddraw2/ddraw2_interface.h
+++ b/src/ddraw/ddraw2/ddraw2_interface.h
@@ -18,7 +18,7 @@ namespace dxvk {
   /**
   * \brief DirectDraw2 interface implementation
   */
-  class DDraw2Interface final : public DDrawWrappedObject<IUnknown, IDirectDraw2, IUnknown> {
+  class DDraw2Interface final : public DDrawWrappedObject<IUnknown, IDirectDraw2> {
 
   public:
     DDraw2Interface(

--- a/src/ddraw/ddraw2/ddraw2_surface.cpp
+++ b/src/ddraw/ddraw2/ddraw2_surface.cpp
@@ -5,7 +5,6 @@
 #include "../ddraw_gamma.h"
 
 #include "../ddraw/ddraw_interface.h"
-#include "../ddraw/ddraw_surface.h"
 #include "../ddraw2/ddraw3_surface.h"
 #include "../ddraw4/ddraw4_surface.h"
 #include "../ddraw7/ddraw7_surface.h"
@@ -23,7 +22,7 @@ namespace dxvk {
         Com<IDirectDrawSurface2>&& surfProxy,
         DDrawSurface* pParent,
         DDraw2Surface* pParentSurf)
-    : DDrawWrappedObject<DDrawSurface, IDirectDrawSurface2, d3d9::IDirect3DSurface9>(pParent, std::move(surfProxy), nullptr)
+    : DDrawWrappedObject<DDrawSurface, IDirectDrawSurface2>(pParent, std::move(surfProxy))
     , m_commonSurf ( commonSurf )
     , m_parentSurf ( pParentSurf ) {
     if (m_parent != nullptr) {
@@ -298,22 +297,22 @@ namespace dxvk {
     }
     DownloadSurfaceData();
 
-    RefreshD3D9Device();
-    if (likely(m_d3d9Device != nullptr)) {
+    d3d9::IDirect3DDevice9* d3d9Device = RefreshD3D9Device();
+    if (likely(d3d9Device != nullptr)) {
       // Forward DDBLT_DEPTHFILL clears to D3D9 if done on the current depth stencil
       if (unlikely(lpDDSrcSurface == nullptr &&
                   (dwFlags & DDBLT_DEPTHFILL) &&
                   lpDDBltFx != nullptr &&
-                  m_commonIntf->GetCommonD3DDevice()->IsCurrentD3D9DepthStencil(m_d3d9.ptr()))) {
+                  m_commonIntf->GetCommonD3DDevice()->IsCurrentD3D9DepthStencil(m_commonSurf->GetD3D9Surface()))) {
         Logger::debug("DDraw2Surface::Blt: Clearing d3d9 depth stencil");
 
         HRESULT hrClear;
         const float zClear = m_commonSurf->GetNormalizedFloatDepth(lpDDBltFx->dwFillDepth);
 
         if (lpDestRect == nullptr) {
-          hrClear = m_d3d9Device->Clear(0, NULL, D3DCLEAR_ZBUFFER, 0, zClear, 256);
+          hrClear = d3d9Device->Clear(0, NULL, D3DCLEAR_ZBUFFER, 0, zClear, 256);
         } else {
-          hrClear = m_d3d9Device->Clear(1, reinterpret_cast<D3DRECT*>(lpDestRect), D3DCLEAR_ZBUFFER, 0, zClear, 0);
+          hrClear = d3d9Device->Clear(1, reinterpret_cast<D3DRECT*>(lpDestRect), D3DCLEAR_ZBUFFER, 0, zClear, 0);
         }
         if (unlikely(FAILED(hrClear)))
           Logger::warn("DDraw2Surface::Blt: Failed to clear d3d9 depth");
@@ -322,14 +321,14 @@ namespace dxvk {
       if (unlikely(lpDDSrcSurface == nullptr &&
                   (dwFlags & DDBLT_COLORFILL) &&
                   lpDDBltFx != nullptr &&
-                  m_commonIntf->GetCommonD3DDevice()->IsCurrentD3D9RenderTarget(m_d3d9.ptr()))) {
+                  m_commonIntf->GetCommonD3DDevice()->IsCurrentD3D9RenderTarget(m_commonSurf->GetD3D9Surface()))) {
         Logger::debug("DDraw2Surface::Blt: Clearing d3d9 render target");
 
         HRESULT hrClear;
         if (lpDestRect == nullptr) {
-          hrClear = m_d3d9Device->Clear(0, NULL, D3DCLEAR_TARGET, lpDDBltFx->dwFillColor, 0.0f, 0);
+          hrClear = d3d9Device->Clear(0, NULL, D3DCLEAR_TARGET, lpDDBltFx->dwFillColor, 0.0f, 0);
         } else {
-          hrClear = m_d3d9Device->Clear(1, reinterpret_cast<D3DRECT*>(lpDestRect), D3DCLEAR_TARGET, lpDDBltFx->dwFillColor, 0.0f, 0);
+          hrClear = d3d9Device->Clear(1, reinterpret_cast<D3DRECT*>(lpDestRect), D3DCLEAR_TARGET, lpDDBltFx->dwFillColor, 0.0f, 0);
         }
         if (unlikely(FAILED(hrClear)))
           Logger::warn("DDraw2Surface::Blt: Failed to clear d3d9 render target");
@@ -349,7 +348,7 @@ namespace dxvk {
 
         if (ddrawSurface == renderTarget) {
           renderTarget->InitializeOrUploadD3D9();
-          m_d3d9Device->Present(NULL, NULL, NULL, NULL);
+          d3d9Device->Present(NULL, NULL, NULL, NULL);
           return DD_OK;
         }
       }
@@ -371,14 +370,14 @@ namespace dxvk {
     if (likely(SUCCEEDED(hr))) {
       m_commonSurf->DirtyDDrawSurface();
 
-      if (unlikely(m_shadowSurf != nullptr && m_d3d9Device != nullptr)) {
+      if (unlikely(m_shadowSurf != nullptr && d3d9Device != nullptr)) {
         const bool shouldPresent = m_commonIntf->GetOptions()->legacyPresentGuard == D3DLegacyPresentGuard::Auto ?
                                   !m_commonIntf->GetCommonD3DDevice()->IsInScene() :
                                    m_commonIntf->GetOptions()->legacyPresentGuard == D3DLegacyPresentGuard::Strict ?
                                    false : true;
         if (shouldPresent) {
           InitializeOrUploadD3D9();
-          m_d3d9Device->Present(NULL, NULL, NULL, NULL);
+          d3d9Device->Present(NULL, NULL, NULL, NULL);
         }
       }
     }
@@ -403,8 +402,8 @@ namespace dxvk {
     }
     DownloadSurfaceData();
 
-    RefreshD3D9Device();
-    if (likely(m_d3d9Device != nullptr)) {
+    d3d9::IDirect3DDevice9* d3d9Device = RefreshD3D9Device();
+    if (likely(d3d9Device != nullptr)) {
       const bool exclusiveMode = (m_commonIntf->GetCooperativeLevel() & DDSCL_EXCLUSIVE)
                               && !m_commonIntf->GetOptions()->ignoreExclusiveMode;
 
@@ -419,7 +418,7 @@ namespace dxvk {
 
         if (ddrawSurface == renderTarget) {
           renderTarget->InitializeOrUploadD3D9();
-          m_d3d9Device->Present(NULL, NULL, NULL, NULL);
+          d3d9Device->Present(NULL, NULL, NULL, NULL);
           return DD_OK;
         }
       }
@@ -441,14 +440,14 @@ namespace dxvk {
     if (likely(SUCCEEDED(hr))) {
       m_commonSurf->DirtyDDrawSurface();
 
-      if (unlikely(m_shadowSurf != nullptr && m_d3d9Device != nullptr)) {
+      if (unlikely(m_shadowSurf != nullptr && d3d9Device != nullptr)) {
         const bool shouldPresent = m_commonIntf->GetOptions()->legacyPresentGuard == D3DLegacyPresentGuard::Auto ?
                                   !m_commonIntf->GetCommonD3DDevice()->IsInScene() :
                                    m_commonIntf->GetOptions()->legacyPresentGuard == D3DLegacyPresentGuard::Strict ?
                                    false : true;
         if (shouldPresent) {
           InitializeOrUploadD3D9();
-          m_d3d9Device->Present(NULL, NULL, NULL, NULL);
+          d3d9Device->Present(NULL, NULL, NULL, NULL);
         }
       }
     }
@@ -509,8 +508,8 @@ namespace dxvk {
 
     Com<DDraw2Surface> surf2 = static_cast<DDraw2Surface*>(lpDDSurfaceTargetOverride);
 
-    RefreshD3D9Device();
-    if (likely(m_d3d9Device != nullptr)) {
+    d3d9::IDirect3DDevice9* d3d9Device = RefreshD3D9Device();
+    if (likely(d3d9Device != nullptr)) {
       Logger::debug("*** DDraw2Surface::Flip: Presenting");
 
       // Lost surfaces are not flippable
@@ -550,7 +549,7 @@ namespace dxvk {
       if (unlikely(rt != nullptr && m_commonSurf->IsPrimarySurface())) {
         Logger::debug("DDraw2Surface::Flip: Presenting from DDraw RT");
         rt->InitializeOrUploadD3D9();
-        m_d3d9Device->Present(NULL, NULL, NULL, NULL);
+        d3d9Device->Present(NULL, NULL, NULL, NULL);
         return DD_OK;
       }
 
@@ -560,7 +559,7 @@ namespace dxvk {
         InitializeOrUploadD3D9();
       }
 
-      m_d3d9Device->Present(NULL, NULL, NULL, NULL);
+      d3d9Device->Present(NULL, NULL, NULL, NULL);
     // If we don't have a valid D3D5 device, this means a D3D3 application
     // is trying to flip the surface. Allow that for compatibility reasons.
     } else {
@@ -776,14 +775,15 @@ namespace dxvk {
     if (likely(SUCCEEDED(hr))) {
       m_commonSurf->DirtyDDrawSurface();
 
-      if (unlikely(m_shadowSurf != nullptr && m_d3d9Device != nullptr)) {
+      d3d9::IDirect3DDevice9* d3d9Device = RefreshD3D9Device();
+      if (unlikely(m_shadowSurf != nullptr && d3d9Device != nullptr)) {
         const bool shouldPresent = m_commonIntf->GetOptions()->legacyPresentGuard == D3DLegacyPresentGuard::Auto ?
                                   !m_commonIntf->GetCommonD3DDevice()->IsInScene() :
                                    m_commonIntf->GetOptions()->legacyPresentGuard == D3DLegacyPresentGuard::Strict ?
                                    false : true;
         if (shouldPresent) {
           InitializeOrUploadD3D9();
-          m_d3d9Device->Present(NULL, NULL, NULL, NULL);
+          d3d9Device->Present(NULL, NULL, NULL, NULL);
         }
       }
     }
@@ -899,15 +899,15 @@ namespace dxvk {
     if (likely(SUCCEEDED(hr))) {
       m_commonSurf->DirtyDDrawSurface();
 
-      RefreshD3D9Device();
-      if (unlikely(m_shadowSurf != nullptr && m_d3d9Device != nullptr)) {
+      d3d9::IDirect3DDevice9* d3d9Device = RefreshD3D9Device();
+      if (unlikely(m_shadowSurf != nullptr && d3d9Device != nullptr)) {
         const bool shouldPresent = m_commonIntf->GetOptions()->legacyPresentGuard == D3DLegacyPresentGuard::Auto ?
                                   !m_commonIntf->GetCommonD3DDevice()->IsInScene() :
                                    m_commonIntf->GetOptions()->legacyPresentGuard == D3DLegacyPresentGuard::Strict ?
                                    false : true;
         if (shouldPresent) {
           InitializeOrUploadD3D9();
-          m_d3d9Device->Present(NULL, NULL, NULL, NULL);
+          d3d9Device->Present(NULL, NULL, NULL, NULL);
         }
       }
     }
@@ -976,9 +976,9 @@ namespace dxvk {
   }
 
   IDirectDrawSurface2* DDraw2Surface::GetShadowOrProxied() {
-    RefreshD3D9Device();
+    d3d9::IDirect3DDevice9* d3d9Device = RefreshD3D9Device();
 
-    if (unlikely(m_shadowSurf != nullptr && m_d3d9Device != nullptr))
+    if (unlikely(m_shadowSurf != nullptr && d3d9Device != nullptr))
       return m_shadowSurf->GetProxied();
 
     return m_proxy.ptr();
@@ -996,37 +996,37 @@ namespace dxvk {
     if (unlikely(m_commonSurf->IsD3D9BackBuffer())) {
       Logger::debug("DDraw2Surface::DownloadSurfaceData: Surface is a bound swapchain surface");
 
-      if (IsInitialized() && m_commonSurf->IsD3D9SurfaceDirty()) {
+      if (m_commonSurf->IsInitialized() && m_commonSurf->IsD3D9SurfaceDirty()) {
         Logger::debug(str::format("DDraw2Surface::DownloadSurfaceData: Downloading nr. [[2-", m_surfCount, "]]"));
-        BlitToDDrawSurface<IDirectDrawSurface2, DDSURFACEDESC>(GetShadowOrProxied(), m_d3d9.ptr());
+        BlitToDDrawSurface<IDirectDrawSurface2, DDSURFACEDESC>(GetShadowOrProxied(), m_commonSurf->GetD3D9Surface());
         m_commonSurf->UnDirtyD3D9Surface();
       }
     } else if (unlikely(m_commonSurf->IsD3D9DepthStencil())) {
       Logger::debug("DDraw2Surface::DownloadSurfaceData: Surface is a bound depth stencil");
 
-      if (IsInitialized() && m_commonSurf->IsD3D9SurfaceDirty()) {
+      if (m_commonSurf->IsInitialized() && m_commonSurf->IsD3D9SurfaceDirty()) {
         Logger::debug(str::format("DDraw2Surface::DownloadSurfaceData: Downloading nr. [[2-", m_surfCount, "]]"));
-        BlitToDDrawSurface<IDirectDrawSurface2, DDSURFACEDESC>(m_proxy.ptr(), m_d3d9.ptr());
+        BlitToDDrawSurface<IDirectDrawSurface2, DDSURFACEDESC>(m_proxy.ptr(), m_commonSurf->GetD3D9Surface());
         m_commonSurf->UnDirtyD3D9Surface();
       }
     }
   }
 
-  inline void DDraw2Surface::RefreshD3D9Device() {
-    D3DCommonDevice* commonDevice = m_commonIntf->GetCommonD3DDevice();
+  inline d3d9::IDirect3DDevice9* DDraw2Surface::RefreshD3D9Device() {
+    D3DCommonDevice* commonD3DDevice = m_commonIntf->GetCommonD3DDevice();
 
-    d3d9::IDirect3DDevice9* d3d9Device = commonDevice != nullptr ? commonDevice->GetD3D9Device() : nullptr;
-    if (unlikely(m_d3d9Device != d3d9Device)) {
+    if (unlikely(m_commonD3DDevice != commonD3DDevice)) {
       // Check if the device has been recreated and reset all D3D9 resources
-      if (m_d3d9Device != nullptr) {
+      if (m_commonD3DDevice != nullptr) {
         Logger::debug("DDraw2Surface: Device context has changed, clearing all D3D9 resources");
-        m_d3d9 = nullptr;
-        if (m_shadowSurf != nullptr)
-          m_shadowSurf->SetD3D9(nullptr);
+        m_commonSurf->SetD3D9Texture(nullptr);
+        m_commonSurf->SetD3D9Surface(nullptr);
       }
 
-      m_d3d9Device = d3d9Device;
+      m_commonD3DDevice = commonD3DDevice;
     }
+
+    return m_commonD3DDevice != nullptr ? m_commonD3DDevice->GetD3D9Device() : nullptr;
   }
 
 }

--- a/src/ddraw/ddraw2/ddraw2_surface.h
+++ b/src/ddraw/ddraw2/ddraw2_surface.h
@@ -11,12 +11,12 @@
 
 namespace dxvk {
 
-  class DDraw7Surface;
+  class D3DCommonDevice;
 
   /**
   * \brief IDirectDrawSurface2 interface implementation
   */
-  class DDraw2Surface final : public DDrawWrappedObject<DDrawSurface, IDirectDrawSurface2, d3d9::IDirect3DSurface9> {
+  class DDraw2Surface final : public DDrawWrappedObject<DDrawSurface, IDirectDrawSurface2> {
 
   public:
 
@@ -122,8 +122,8 @@ namespace dxvk {
       return m_commonIntf;
     }
 
-    d3d9::IDirect3DDevice9* GetD3D9Device() const {
-      return m_d3d9Device;
+    D3DCommonDevice* GetCommonD3DDevice() const {
+      return m_commonD3DDevice;
     }
 
     DDraw2Surface* GetAttachedDepthStencil() {
@@ -158,27 +158,24 @@ namespace dxvk {
     }
 
     HRESULT InitializeOrUploadD3D9() {
-      HRESULT hr = m_parent->InitializeOrUploadD3D9();
-      if (unlikely(m_d3d9 == nullptr && SUCCEEDED(hr)))
-        m_d3d9 = m_parent->GetD3D9();
-      return hr;
+      return m_parent->InitializeOrUploadD3D9();
     }
 
   private:
 
-    inline void RefreshD3D9Device();
+    inline d3d9::IDirect3DDevice9* RefreshD3D9Device();
 
     static uint32_t  s_surfCount;
     uint32_t         m_surfCount = 0;
 
     Com<DDrawCommonSurface>  m_commonSurf;
-    DDrawCommonInterface*    m_commonIntf = nullptr;
+    DDrawCommonInterface*    m_commonIntf      = nullptr;
 
     Com<DDrawSurface, false> m_originSurf;
 
-    DDraw2Surface*           m_parentSurf = nullptr;
+    DDraw2Surface*           m_parentSurf      = nullptr;
 
-    d3d9::IDirect3DDevice9*  m_d3d9Device = nullptr;
+    D3DCommonDevice*         m_commonD3DDevice = nullptr;
 
     // Offscreen plain surface we use to mask unwanted DDraw interactions, such
     // as forced swapchain presents caused by blits/locks on primary surfaces

--- a/src/ddraw/ddraw2/ddraw3_surface.cpp
+++ b/src/ddraw/ddraw2/ddraw3_surface.cpp
@@ -5,7 +5,6 @@
 #include "../ddraw_gamma.h"
 
 #include "../ddraw/ddraw_interface.h"
-#include "../ddraw/ddraw_surface.h"
 #include "../ddraw2/ddraw2_surface.h"
 #include "../ddraw4/ddraw4_surface.h"
 #include "../ddraw7/ddraw7_surface.h"
@@ -23,7 +22,7 @@ namespace dxvk {
         Com<IDirectDrawSurface3>&& surfProxy,
         DDrawSurface* pParent,
         DDraw3Surface* pParentSurf)
-    : DDrawWrappedObject<DDrawSurface, IDirectDrawSurface3, d3d9::IDirect3DSurface9>(pParent, std::move(surfProxy), nullptr)
+    : DDrawWrappedObject<DDrawSurface, IDirectDrawSurface3>(pParent, std::move(surfProxy))
     , m_commonSurf ( commonSurf )
     , m_parentSurf ( pParentSurf ) {
     if (m_parent != nullptr) {
@@ -307,22 +306,22 @@ namespace dxvk {
     }
     DownloadSurfaceData();
 
-    RefreshD3D9Device();
-    if (likely(m_d3d9Device != nullptr)) {
+    d3d9::IDirect3DDevice9* d3d9Device = RefreshD3D9Device();
+    if (likely(d3d9Device != nullptr)) {
       // Forward DDBLT_DEPTHFILL clears to D3D9 if done on the current depth stencil
       if (unlikely(lpDDSrcSurface == nullptr &&
                   (dwFlags & DDBLT_DEPTHFILL) &&
                   lpDDBltFx != nullptr &&
-                  m_commonIntf->GetCommonD3DDevice()->IsCurrentD3D9DepthStencil(m_d3d9.ptr()))) {
+                  m_commonIntf->GetCommonD3DDevice()->IsCurrentD3D9DepthStencil(m_commonSurf->GetD3D9Surface()))) {
         Logger::debug("DDraw3Surface::Blt: Clearing d3d9 depth stencil");
 
         HRESULT hrClear;
         const float zClear = m_commonSurf->GetNormalizedFloatDepth(lpDDBltFx->dwFillDepth);
 
         if (lpDestRect == nullptr) {
-          hrClear = m_d3d9Device->Clear(0, NULL, D3DCLEAR_ZBUFFER, 0, zClear, 0);
+          hrClear = d3d9Device->Clear(0, NULL, D3DCLEAR_ZBUFFER, 0, zClear, 0);
         } else {
-          hrClear = m_d3d9Device->Clear(1, reinterpret_cast<D3DRECT*>(lpDestRect), D3DCLEAR_ZBUFFER, 0, zClear, 0);
+          hrClear = d3d9Device->Clear(1, reinterpret_cast<D3DRECT*>(lpDestRect), D3DCLEAR_ZBUFFER, 0, zClear, 0);
         }
         if (unlikely(FAILED(hrClear)))
           Logger::warn("DDraw3Surface::Blt: Failed to clear d3d9 depth");
@@ -331,14 +330,14 @@ namespace dxvk {
       if (unlikely(lpDDSrcSurface == nullptr &&
                   (dwFlags & DDBLT_COLORFILL) &&
                   lpDDBltFx != nullptr &&
-                  m_commonIntf->GetCommonD3DDevice()->IsCurrentD3D9RenderTarget(m_d3d9.ptr()))) {
+                  m_commonIntf->GetCommonD3DDevice()->IsCurrentD3D9RenderTarget(m_commonSurf->GetD3D9Surface()))) {
         Logger::debug("DDraw3Surface::Blt: Clearing d3d9 render target");
 
         HRESULT hrClear;
         if (lpDestRect == nullptr) {
-          hrClear = m_d3d9Device->Clear(0, NULL, D3DCLEAR_TARGET, lpDDBltFx->dwFillColor, 0.0f, 0);
+          hrClear = d3d9Device->Clear(0, NULL, D3DCLEAR_TARGET, lpDDBltFx->dwFillColor, 0.0f, 0);
         } else {
-          hrClear = m_d3d9Device->Clear(1, reinterpret_cast<D3DRECT*>(lpDestRect), D3DCLEAR_TARGET, lpDDBltFx->dwFillColor, 0.0f, 0);
+          hrClear = d3d9Device->Clear(1, reinterpret_cast<D3DRECT*>(lpDestRect), D3DCLEAR_TARGET, lpDDBltFx->dwFillColor, 0.0f, 0);
         }
         if (unlikely(FAILED(hrClear)))
           Logger::warn("DDraw3Surface::Blt: Failed to clear d3d9 render target");
@@ -358,7 +357,7 @@ namespace dxvk {
 
         if (ddrawSurface == renderTarget) {
           renderTarget->InitializeOrUploadD3D9();
-          m_d3d9Device->Present(NULL, NULL, NULL, NULL);
+          d3d9Device->Present(NULL, NULL, NULL, NULL);
           return DD_OK;
         }
       }
@@ -387,14 +386,14 @@ namespace dxvk {
     if (likely(SUCCEEDED(hr))) {
       m_commonSurf->DirtyDDrawSurface();
 
-      if (unlikely(m_shadowSurf != nullptr && m_d3d9Device != nullptr)) {
+      if (unlikely(m_shadowSurf != nullptr && d3d9Device != nullptr)) {
         const bool shouldPresent = m_commonIntf->GetOptions()->legacyPresentGuard == D3DLegacyPresentGuard::Auto ?
                                   !m_commonIntf->GetCommonD3DDevice()->IsInScene() :
                                    m_commonIntf->GetOptions()->legacyPresentGuard == D3DLegacyPresentGuard::Strict ?
                                    false : true;
         if (shouldPresent) {
           InitializeOrUploadD3D9();
-          m_d3d9Device->Present(NULL, NULL, NULL, NULL);
+          d3d9Device->Present(NULL, NULL, NULL, NULL);
         }
       }
     }
@@ -419,8 +418,8 @@ namespace dxvk {
     }
     DownloadSurfaceData();
 
-    RefreshD3D9Device();
-    if (likely(m_d3d9Device != nullptr)) {
+    d3d9::IDirect3DDevice9* d3d9Device = RefreshD3D9Device();
+    if (likely(d3d9Device != nullptr)) {
       const bool exclusiveMode = (m_commonIntf->GetCooperativeLevel() & DDSCL_EXCLUSIVE)
                               && !m_commonIntf->GetOptions()->ignoreExclusiveMode;
 
@@ -435,7 +434,7 @@ namespace dxvk {
 
         if (ddrawSurface == renderTarget) {
           renderTarget->InitializeOrUploadD3D9();
-          m_d3d9Device->Present(NULL, NULL, NULL, NULL);
+          d3d9Device->Present(NULL, NULL, NULL, NULL);
           return DD_OK;
         }
       }
@@ -457,14 +456,14 @@ namespace dxvk {
     if (likely(SUCCEEDED(hr))) {
       m_commonSurf->DirtyDDrawSurface();
 
-      if (unlikely(m_shadowSurf != nullptr && m_d3d9Device != nullptr)) {
+      if (unlikely(m_shadowSurf != nullptr && d3d9Device != nullptr)) {
         const bool shouldPresent = m_commonIntf->GetOptions()->legacyPresentGuard == D3DLegacyPresentGuard::Auto ?
                                   !m_commonIntf->GetCommonD3DDevice()->IsInScene() :
                                    m_commonIntf->GetOptions()->legacyPresentGuard == D3DLegacyPresentGuard::Strict ?
                                    false : true;
         if (shouldPresent) {
           InitializeOrUploadD3D9();
-          m_d3d9Device->Present(NULL, NULL, NULL, NULL);
+          d3d9Device->Present(NULL, NULL, NULL, NULL);
         }
       }
     }
@@ -525,8 +524,8 @@ namespace dxvk {
 
     Com<DDraw3Surface> surf3 = static_cast<DDraw3Surface*>(lpDDSurfaceTargetOverride);
 
-    RefreshD3D9Device();
-    if (likely(m_d3d9Device != nullptr)) {
+    d3d9::IDirect3DDevice9* d3d9Device = RefreshD3D9Device();
+    if (likely(d3d9Device != nullptr)) {
       Logger::debug("*** DDraw3Surface::Flip: Presenting");
 
       // Lost surfaces are not flippable
@@ -566,7 +565,7 @@ namespace dxvk {
       if (unlikely(rt != nullptr && m_commonSurf->IsPrimarySurface())) {
         Logger::debug("DDraw3Surface::Flip: Presenting from DDraw RT");
         rt->InitializeOrUploadD3D9();
-        m_d3d9Device->Present(NULL, NULL, NULL, NULL);
+        d3d9Device->Present(NULL, NULL, NULL, NULL);
         return DD_OK;
       }
 
@@ -576,7 +575,7 @@ namespace dxvk {
         InitializeOrUploadD3D9();
       }
 
-      m_d3d9Device->Present(NULL, NULL, NULL, NULL);
+      d3d9Device->Present(NULL, NULL, NULL, NULL);
     // If we don't have a valid D3D5 device, this means a D3D3 application
     // is trying to flip the surface. Allow that for compatibility reasons.
     } else {
@@ -792,14 +791,15 @@ namespace dxvk {
     if (likely(SUCCEEDED(hr))) {
       m_commonSurf->DirtyDDrawSurface();
 
-      if (unlikely(m_shadowSurf != nullptr && m_d3d9Device != nullptr)) {
+      d3d9::IDirect3DDevice9* d3d9Device = RefreshD3D9Device();
+      if (unlikely(m_shadowSurf != nullptr && d3d9Device != nullptr)) {
         const bool shouldPresent = m_commonIntf->GetOptions()->legacyPresentGuard == D3DLegacyPresentGuard::Auto ?
                                   !m_commonIntf->GetCommonD3DDevice()->IsInScene() :
                                    m_commonIntf->GetOptions()->legacyPresentGuard == D3DLegacyPresentGuard::Strict ?
                                    false : true;
         if (shouldPresent) {
           InitializeOrUploadD3D9();
-          m_d3d9Device->Present(NULL, NULL, NULL, NULL);
+          d3d9Device->Present(NULL, NULL, NULL, NULL);
         }
       }
     }
@@ -915,15 +915,15 @@ namespace dxvk {
     if (likely(SUCCEEDED(hr))) {
       m_commonSurf->DirtyDDrawSurface();
 
-      RefreshD3D9Device();
-      if (unlikely(m_shadowSurf != nullptr && m_d3d9Device != nullptr)) {
+      d3d9::IDirect3DDevice9* d3d9Device = RefreshD3D9Device();
+      if (unlikely(m_shadowSurf != nullptr && d3d9Device != nullptr)) {
         const bool shouldPresent = m_commonIntf->GetOptions()->legacyPresentGuard == D3DLegacyPresentGuard::Auto ?
                                   !m_commonIntf->GetCommonD3DDevice()->IsInScene() :
                                    m_commonIntf->GetOptions()->legacyPresentGuard == D3DLegacyPresentGuard::Strict ?
                                    false : true;
         if (shouldPresent) {
           InitializeOrUploadD3D9();
-          m_d3d9Device->Present(NULL, NULL, NULL, NULL);
+          d3d9Device->Present(NULL, NULL, NULL, NULL);
         }
       }
     }
@@ -1005,15 +1005,15 @@ namespace dxvk {
       Logger::err("DDraw3Surface::SetSurfaceDesc: Failed to retrieve updated surface desc");
 
     // We may need to recreate the d3d9 object based on the new desc
-    m_d3d9 = nullptr;
+    m_commonSurf->SetD3D9Surface(nullptr);
 
     return hr;
   }
 
   IDirectDrawSurface3* DDraw3Surface::GetShadowOrProxied() {
-    RefreshD3D9Device();
+    d3d9::IDirect3DDevice9* d3d9Device = RefreshD3D9Device();
 
-    if (unlikely(m_shadowSurf != nullptr && m_d3d9Device != nullptr))
+    if (unlikely(m_shadowSurf != nullptr && d3d9Device != nullptr))
       return m_shadowSurf->GetProxied();
 
     return m_proxy.ptr();
@@ -1031,37 +1031,37 @@ namespace dxvk {
     if (unlikely(m_commonSurf->IsD3D9BackBuffer())) {
       Logger::debug("DDraw3Surface::DownloadSurfaceData: Surface is a bound swapchain surface");
 
-      if (IsInitialized() && m_commonSurf->IsD3D9SurfaceDirty()) {
+      if (m_commonSurf->IsInitialized() && m_commonSurf->IsD3D9SurfaceDirty()) {
         Logger::debug(str::format("DDraw3Surface::DownloadSurfaceData: Downloading nr. [[3-", m_surfCount, "]]"));
-        BlitToDDrawSurface<IDirectDrawSurface3, DDSURFACEDESC>(GetShadowOrProxied(), m_d3d9.ptr());
+        BlitToDDrawSurface<IDirectDrawSurface3, DDSURFACEDESC>(GetShadowOrProxied(), m_commonSurf->GetD3D9Surface());
         m_commonSurf->UnDirtyD3D9Surface();
       }
     } else if (unlikely(m_commonSurf->IsD3D9DepthStencil())) {
       Logger::debug("DDraw3Surface::DownloadSurfaceData: Surface is a bound depth stencil");
 
-      if (IsInitialized() && m_commonSurf->IsD3D9SurfaceDirty()) {
+      if (m_commonSurf->IsInitialized() && m_commonSurf->IsD3D9SurfaceDirty()) {
         Logger::debug(str::format("DDraw3Surface::DownloadSurfaceData: Downloading nr. [[3-", m_surfCount, "]]"));
-        BlitToDDrawSurface<IDirectDrawSurface3, DDSURFACEDESC>(m_proxy.ptr(), m_d3d9.ptr());
+        BlitToDDrawSurface<IDirectDrawSurface3, DDSURFACEDESC>(m_proxy.ptr(), m_commonSurf->GetD3D9Surface());
         m_commonSurf->UnDirtyD3D9Surface();
       }
     }
   }
 
-  inline void DDraw3Surface::RefreshD3D9Device() {
-    D3DCommonDevice* commonDevice = m_commonIntf->GetCommonD3DDevice();
+  inline d3d9::IDirect3DDevice9* DDraw3Surface::RefreshD3D9Device() {
+    D3DCommonDevice* commonD3DDevice = m_commonIntf->GetCommonD3DDevice();
 
-    d3d9::IDirect3DDevice9* d3d9Device = commonDevice != nullptr ? commonDevice->GetD3D9Device() : nullptr;
-    if (unlikely(m_d3d9Device != d3d9Device)) {
+    if (unlikely(m_commonD3DDevice != commonD3DDevice)) {
       // Check if the device has been recreated and reset all D3D9 resources
-      if (m_d3d9Device != nullptr) {
+      if (m_commonD3DDevice != nullptr) {
         Logger::debug("DDraw3Surface: Device context has changed, clearing all D3D9 resources");
-        m_d3d9 = nullptr;
-        if (m_shadowSurf != nullptr)
-          m_shadowSurf->SetD3D9(nullptr);
+        m_commonSurf->SetD3D9Texture(nullptr);
+        m_commonSurf->SetD3D9Surface(nullptr);
       }
 
-      m_d3d9Device = d3d9Device;
+      m_commonD3DDevice = commonD3DDevice;
     }
+
+    return m_commonD3DDevice != nullptr ? m_commonD3DDevice->GetD3D9Device() : nullptr;
   }
 
 }

--- a/src/ddraw/ddraw2/ddraw3_surface.h
+++ b/src/ddraw/ddraw2/ddraw3_surface.h
@@ -11,13 +11,12 @@
 
 namespace dxvk {
 
-  class DDrawSurface;
-  class DDraw7Surface;
+  class D3DCommonDevice;
 
   /**
   * \brief IDirectDrawSurface3 interface implementation
   */
-  class DDraw3Surface final : public DDrawWrappedObject<DDrawSurface, IDirectDrawSurface3, d3d9::IDirect3DSurface9> {
+  class DDraw3Surface final : public DDrawWrappedObject<DDrawSurface, IDirectDrawSurface3> {
 
   public:
 
@@ -125,8 +124,8 @@ namespace dxvk {
       return m_commonIntf;
     }
 
-    d3d9::IDirect3DDevice9* GetD3D9Device() const {
-      return m_d3d9Device;
+    D3DCommonDevice* GetCommonD3DDevice() const {
+      return m_commonD3DDevice;
     }
 
     DDraw3Surface* GetAttachedDepthStencil() {
@@ -161,27 +160,24 @@ namespace dxvk {
     }
 
     HRESULT InitializeOrUploadD3D9() {
-      HRESULT hr = m_parent->InitializeOrUploadD3D9();
-      if (unlikely(m_d3d9 == nullptr && SUCCEEDED(hr)))
-        m_d3d9 = m_parent->GetD3D9();
-      return hr;
+      return m_parent->InitializeOrUploadD3D9();
     }
 
   private:
 
-    inline void RefreshD3D9Device();
+    inline d3d9::IDirect3DDevice9* RefreshD3D9Device();
 
     static uint32_t  s_surfCount;
     uint32_t         m_surfCount = 0;
 
     Com<DDrawCommonSurface>  m_commonSurf;
-    DDrawCommonInterface*    m_commonIntf = nullptr;
+    DDrawCommonInterface*    m_commonIntf      = nullptr;
 
     Com<DDrawSurface, false> m_originSurf;
 
-    DDraw3Surface*           m_parentSurf = nullptr;
+    DDraw3Surface*           m_parentSurf      = nullptr;
 
-    d3d9::IDirect3DDevice9*  m_d3d9Device = nullptr;
+    D3DCommonDevice*         m_commonD3DDevice = nullptr;
 
     // Offscreen plain surface we use to mask unwanted DDraw interactions, such
     // as forced swapchain presents caused by blits/locks on primary surfaces

--- a/src/ddraw/ddraw4/ddraw4_interface.cpp
+++ b/src/ddraw/ddraw4/ddraw4_interface.cpp
@@ -22,7 +22,7 @@ namespace dxvk {
   DDraw4Interface::DDraw4Interface(
         DDrawCommonInterface* commonIntf,
         Com<IDirectDraw4>&& proxyIntf)
-    : DDrawWrappedObject<IUnknown, IDirectDraw4, IUnknown>(nullptr, std::move(proxyIntf), nullptr)
+    : DDrawWrappedObject<IUnknown, IDirectDraw4>(nullptr, std::move(proxyIntf))
     , m_commonIntf ( commonIntf ) {
     // We need a temporary D3D9 interface at this point to retrieve the adapter identifier
     Com<d3d9::IDirect3D9> d3d9Intf = d3d9::Direct3DCreate9(D3D_SDK_VERSION);

--- a/src/ddraw/ddraw4/ddraw4_interface.h
+++ b/src/ddraw/ddraw4/ddraw4_interface.h
@@ -17,7 +17,7 @@ namespace dxvk {
   /**
   * \brief DirectDraw4 interface implementation
   */
-  class DDraw4Interface final : public DDrawWrappedObject<IUnknown, IDirectDraw4, IUnknown> {
+  class DDraw4Interface final : public DDrawWrappedObject<IUnknown, IDirectDraw4> {
 
   public:
     DDraw4Interface(

--- a/src/ddraw/ddraw4/ddraw4_surface.cpp
+++ b/src/ddraw/ddraw4/ddraw4_surface.cpp
@@ -23,7 +23,7 @@ namespace dxvk {
         DDraw4Interface* pParent,
         DDraw4Surface* pParentSurf,
         bool isChildObject)
-    : DDrawWrappedObject<DDraw4Interface, IDirectDrawSurface4, d3d9::IDirect3DSurface9>(pParent, std::move(surfProxy), nullptr)
+    : DDrawWrappedObject<DDraw4Interface, IDirectDrawSurface4>(pParent, std::move(surfProxy))
     , m_isChildObject ( isChildObject )
     , m_commonSurf ( commonSurf )
     , m_parentSurf ( pParentSurf ) {
@@ -290,22 +290,22 @@ namespace dxvk {
     }
     DownloadSurfaceData();
 
-    RefreshD3D9Device();
-    if (likely(m_d3d9Device != nullptr)) {
+    d3d9::IDirect3DDevice9* d3d9Device = RefreshD3D9Device();
+    if (likely(d3d9Device != nullptr)) {
       // Forward DDBLT_DEPTHFILL clears to D3D9 if done on the current depth stencil
       if (unlikely(lpDDSrcSurface == nullptr &&
                   (dwFlags & DDBLT_DEPTHFILL) &&
                   lpDDBltFx != nullptr &&
-                  m_commonIntf->GetCommonD3DDevice()->IsCurrentD3D9DepthStencil(m_d3d9.ptr()))) {
+                  m_commonIntf->GetCommonD3DDevice()->IsCurrentD3D9DepthStencil(m_commonSurf->GetD3D9Surface()))) {
         Logger::debug("DDraw4Surface::Blt: Clearing d3d9 depth stencil");
 
         HRESULT hrClear;
         const float zClear = m_commonSurf->GetNormalizedFloatDepth(lpDDBltFx->dwFillDepth);
 
         if (lpDestRect == nullptr) {
-          hrClear = m_d3d9Device->Clear(0, NULL, D3DCLEAR_ZBUFFER, 0, zClear, 0);
+          hrClear = d3d9Device->Clear(0, NULL, D3DCLEAR_ZBUFFER, 0, zClear, 0);
         } else {
-          hrClear = m_d3d9Device->Clear(1, reinterpret_cast<D3DRECT*>(lpDestRect), D3DCLEAR_ZBUFFER, 0, zClear, 0);
+          hrClear = d3d9Device->Clear(1, reinterpret_cast<D3DRECT*>(lpDestRect), D3DCLEAR_ZBUFFER, 0, zClear, 0);
         }
         if (unlikely(FAILED(hrClear)))
           Logger::warn("DDraw4Surface::Blt: Failed to clear d3d9 depth");
@@ -314,14 +314,14 @@ namespace dxvk {
       if (unlikely(lpDDSrcSurface == nullptr &&
                   (dwFlags & DDBLT_COLORFILL) &&
                   lpDDBltFx != nullptr &&
-                  m_commonIntf->GetCommonD3DDevice()->IsCurrentD3D9RenderTarget(m_d3d9.ptr()))) {
+                  m_commonIntf->GetCommonD3DDevice()->IsCurrentD3D9RenderTarget(m_commonSurf->GetD3D9Surface()))) {
         Logger::debug("DDraw4Surface::Blt: Clearing d3d9 render target");
 
         HRESULT hrClear;
         if (lpDestRect == nullptr) {
-          hrClear = m_d3d9Device->Clear(0, NULL, D3DCLEAR_TARGET, lpDDBltFx->dwFillColor, 0.0f, 0);
+          hrClear = d3d9Device->Clear(0, NULL, D3DCLEAR_TARGET, lpDDBltFx->dwFillColor, 0.0f, 0);
         } else {
-          hrClear = m_d3d9Device->Clear(1, reinterpret_cast<D3DRECT*>(lpDestRect), D3DCLEAR_TARGET, lpDDBltFx->dwFillColor, 0.0f, 0);
+          hrClear = d3d9Device->Clear(1, reinterpret_cast<D3DRECT*>(lpDestRect), D3DCLEAR_TARGET, lpDDBltFx->dwFillColor, 0.0f, 0);
         }
         if (unlikely(FAILED(hrClear)))
           Logger::warn("DDraw4Surface::Blt: Failed to clear d3d9 render target");
@@ -340,7 +340,7 @@ namespace dxvk {
 
         if (ddraw4Surface == renderTarget) {
           renderTarget->InitializeOrUploadD3D9();
-          m_d3d9Device->Present(NULL, NULL, NULL, NULL);
+          d3d9Device->Present(NULL, NULL, NULL, NULL);
           return DD_OK;
         }
       }
@@ -362,14 +362,14 @@ namespace dxvk {
     if (likely(SUCCEEDED(hr))) {
       m_commonSurf->DirtyDDrawSurface();
 
-      if (unlikely(m_shadowSurf != nullptr && m_d3d9Device != nullptr)) {
+      if (unlikely(m_shadowSurf != nullptr && d3d9Device != nullptr)) {
         const bool shouldPresent = m_commonIntf->GetOptions()->legacyPresentGuard == D3DLegacyPresentGuard::Auto ?
                                   !m_commonIntf->GetCommonD3DDevice()->IsInScene() :
                                    m_commonIntf->GetOptions()->legacyPresentGuard == D3DLegacyPresentGuard::Strict ?
                                    false : true;
         if (shouldPresent) {
           InitializeOrUploadD3D9();
-          m_d3d9Device->Present(NULL, NULL, NULL, NULL);
+          d3d9Device->Present(NULL, NULL, NULL, NULL);
         }
       }
     }
@@ -394,8 +394,8 @@ namespace dxvk {
     }
     DownloadSurfaceData();
 
-    RefreshD3D9Device();
-    if (likely(m_d3d9Device != nullptr)) {
+    d3d9::IDirect3DDevice9* d3d9Device = RefreshD3D9Device();
+    if (likely(d3d9Device != nullptr)) {
       const bool exclusiveMode = (m_commonIntf->GetCooperativeLevel() & DDSCL_EXCLUSIVE)
                               && !m_commonIntf->GetOptions()->ignoreExclusiveMode;
 
@@ -409,7 +409,7 @@ namespace dxvk {
 
         if (ddraw4Surface == renderTarget) {
           renderTarget->InitializeOrUploadD3D9();
-          m_d3d9Device->Present(NULL, NULL, NULL, NULL);
+          d3d9Device->Present(NULL, NULL, NULL, NULL);
           return DD_OK;
         }
       }
@@ -431,14 +431,14 @@ namespace dxvk {
     if (likely(SUCCEEDED(hr))) {
       m_commonSurf->DirtyDDrawSurface();
 
-      if (unlikely(m_shadowSurf != nullptr && m_d3d9Device != nullptr)) {
+      if (unlikely(m_shadowSurf != nullptr && d3d9Device != nullptr)) {
         const bool shouldPresent = m_commonIntf->GetOptions()->legacyPresentGuard == D3DLegacyPresentGuard::Auto ?
                                   !m_commonIntf->GetCommonD3DDevice()->IsInScene() :
                                    m_commonIntf->GetOptions()->legacyPresentGuard == D3DLegacyPresentGuard::Strict ?
                                    false : true;
         if (shouldPresent) {
           InitializeOrUploadD3D9();
-          m_d3d9Device->Present(NULL, NULL, NULL, NULL);
+          d3d9Device->Present(NULL, NULL, NULL, NULL);
         }
       }
     }
@@ -536,8 +536,8 @@ namespace dxvk {
     if (m_commonIntf->IsWrappedSurface(lpDDSurfaceTargetOverride))
       surf4 = static_cast<DDraw4Surface*>(lpDDSurfaceTargetOverride);
 
-    RefreshD3D9Device();
-    if (likely(m_d3d9Device != nullptr)) {
+    d3d9::IDirect3DDevice9* d3d9Device = RefreshD3D9Device();
+    if (likely(d3d9Device != nullptr)) {
       Logger::debug("*** DDraw4Surface::Flip: Presenting");
 
       // Lost surfaces are not flippable
@@ -609,7 +609,7 @@ namespace dxvk {
       if (unlikely(rt != nullptr && m_commonSurf->IsPrimarySurface())) {
         Logger::debug("DDraw4Surface::Flip: Presenting from DDraw RT");
         rt->InitializeOrUploadD3D9();
-        m_d3d9Device->Present(NULL, NULL, NULL, NULL);
+        d3d9Device->Present(NULL, NULL, NULL, NULL);
         return DD_OK;
       }
 
@@ -619,7 +619,7 @@ namespace dxvk {
         InitializeOrUploadD3D9();
       }
 
-      m_d3d9Device->Present(NULL, NULL, NULL, NULL);
+      d3d9Device->Present(NULL, NULL, NULL, NULL);
     // If we don't have a valid D3D6 device, this means a D3D7 application
     // is trying to flip the surface. Allow that for compatibility reasons.
     } else {
@@ -840,13 +840,14 @@ namespace dxvk {
     if (likely(SUCCEEDED(hr))) {
       m_commonSurf->DirtyDDrawSurface();
 
-      if (unlikely(m_shadowSurf != nullptr && m_d3d9Device != nullptr)) {
+      d3d9::IDirect3DDevice9* d3d9Device = RefreshD3D9Device();
+      if (unlikely(m_shadowSurf != nullptr && d3d9Device != nullptr)) {
         const bool shouldPresent = m_commonIntf->GetOptions()->legacyPresentGuard == D3DLegacyPresentGuard::Auto ?
                                   !m_commonIntf->GetCommonD3DDevice()->IsInScene() :
                                    m_commonIntf->GetOptions()->legacyPresentGuard == D3DLegacyPresentGuard::Strict ?
                                    false : true;
         if (shouldPresent)
-          m_d3d9Device->Present(NULL, NULL, NULL, NULL);
+          d3d9Device->Present(NULL, NULL, NULL, NULL);
       }
     }
 
@@ -961,15 +962,15 @@ namespace dxvk {
     if (likely(SUCCEEDED(hr))) {
       m_commonSurf->DirtyDDrawSurface();
 
-      RefreshD3D9Device();
-      if (unlikely(m_shadowSurf != nullptr && m_d3d9Device != nullptr)) {
+      d3d9::IDirect3DDevice9* d3d9Device = RefreshD3D9Device();
+      if (unlikely(m_shadowSurf != nullptr && d3d9Device != nullptr)) {
         const bool shouldPresent = m_commonIntf->GetOptions()->legacyPresentGuard == D3DLegacyPresentGuard::Auto ?
                                   !m_commonIntf->GetCommonD3DDevice()->IsInScene() :
                                    m_commonIntf->GetOptions()->legacyPresentGuard == D3DLegacyPresentGuard::Strict ?
                                    false : true;
         if (shouldPresent) {
           InitializeOrUploadD3D9();
-          m_d3d9Device->Present(NULL, NULL, NULL, NULL);
+          d3d9Device->Present(NULL, NULL, NULL, NULL);
         }
       }
     }
@@ -1051,7 +1052,7 @@ namespace dxvk {
       Logger::err("DDraw4Surface::SetSurfaceDesc: Failed to retrieve updated surface desc");
 
     // We may need to recreate the d3d9 object based on the new desc
-    m_d3d9 = nullptr;
+    m_commonSurf->SetD3D9Surface(nullptr);
 
     return hr;
   }
@@ -1090,9 +1091,9 @@ namespace dxvk {
   }
 
   IDirectDrawSurface4* DDraw4Surface::GetShadowOrProxied() {
-    RefreshD3D9Device();
+    d3d9::IDirect3DDevice9* d3d9Device = RefreshD3D9Device();
 
-    if (unlikely(m_shadowSurf != nullptr && m_d3d9Device != nullptr))
+    if (unlikely(m_shadowSurf != nullptr && d3d9Device != nullptr))
       return m_shadowSurf->GetProxied();
 
     return m_proxy.ptr();
@@ -1103,10 +1104,20 @@ namespace dxvk {
 
     m_commonSurf->MarkAsD3D9BackBuffer();
 
-    if (unlikely(!IsInitialized()))
-      return InitializeD3D9(true);
+    if (unlikely(!m_commonSurf->IsInitialized())) {
+      if (m_commonSurf->IsTexture())
+        UpdateMipMapCount();
 
-    return DD_OK;
+      HRESULT hr = m_commonSurf->InitializeD3D9(true);
+      if (unlikely(FAILED(hr)))
+        return hr;
+
+      Logger::debug(str::format("DDraw4Surface::InitializeD3D9RenderTarget: Initialized surface nr. [[4-", m_surfCount, "]]"));
+
+      return UploadSurfaceData();
+    }
+
+    return D3D_OK;
   }
 
   HRESULT DDraw4Surface::InitializeD3D9DepthStencil() {
@@ -1114,19 +1125,45 @@ namespace dxvk {
 
     m_commonSurf->MarkAsD3D9DepthStencil();
 
-    if (unlikely(!IsInitialized()))
-      return InitializeD3D9(false);
+    if (unlikely(!m_commonSurf->IsInitialized())) {
+      HRESULT hr = m_commonSurf->InitializeD3D9(false);
+      if (unlikely(FAILED(hr)))
+        return hr;
+
+      Logger::debug(str::format("DDraw4Surface::InitializeD3D9DepthStencil: Initialized surface nr. [[4-", m_surfCount, "]]"));
+
+      return UploadSurfaceData();
+    }
 
     return DD_OK;
   }
 
   HRESULT DDraw4Surface::InitializeOrUploadD3D9() {
-    RefreshD3D9Device();
+    d3d9::IDirect3DDevice9* d3d9Device = RefreshD3D9Device();
 
-    if (unlikely(!IsInitialized()))
-      return InitializeD3D9(false);
+    // Fast skip
+    if (unlikely(d3d9Device == nullptr)) {
+      Logger::debug("DDraw4Surface::InitializeOrUploadD3D9: Null device, can't initialize right now");
+      return D3D_OK;
+    }
 
-    return UploadSurfaceData();
+    if (unlikely(!m_commonSurf->IsInitialized())) {
+      if (m_commonSurf->IsTexture())
+        UpdateMipMapCount();
+
+      const bool initRenderTarget = m_commonIntf->GetCommonD3DDevice()->IsCurrentRenderTarget(this);
+
+      HRESULT hr = m_commonSurf->InitializeD3D9(initRenderTarget);
+      if (unlikely(FAILED(hr)))
+        return hr;
+
+      Logger::debug(str::format("DDraw4Surface::InitializeOrUploadD3D9: Initialized surface nr. [[4-", m_surfCount, "]]"));
+    }
+
+    if (likely(m_commonSurf->IsInitialized()))
+      return UploadSurfaceData();
+
+    return DD_OK;
   }
 
   void DDraw4Surface::DownloadSurfaceData() {
@@ -1141,339 +1178,64 @@ namespace dxvk {
     if (unlikely(m_commonSurf->IsD3D9BackBuffer())) {
       Logger::debug("DDraw4Surface::DownloadSurfaceData: Surface is a bound swapchain surface");
 
-      if (IsInitialized() && m_commonSurf->IsD3D9SurfaceDirty()) {
+      if (m_commonSurf->IsInitialized() && m_commonSurf->IsD3D9SurfaceDirty()) {
         Logger::debug(str::format("DDraw4Surface::DownloadSurfaceData: Downloading nr. [[4-", m_surfCount, "]]"));
-        BlitToDDrawSurface<IDirectDrawSurface4, DDSURFACEDESC2>(GetShadowOrProxied(), m_d3d9.ptr());
+        BlitToDDrawSurface<IDirectDrawSurface4, DDSURFACEDESC2>(GetShadowOrProxied(), m_commonSurf->GetD3D9Surface());
         m_commonSurf->UnDirtyD3D9Surface();
       }
     } else if (unlikely(m_commonSurf->IsD3D9DepthStencil())) {
       Logger::debug("DDraw4Surface::DownloadSurfaceData: Surface is a bound depth stencil");
 
-      if (IsInitialized() && m_commonSurf->IsD3D9SurfaceDirty()) {
+      if (m_commonSurf->IsInitialized() && m_commonSurf->IsD3D9SurfaceDirty()) {
         Logger::debug(str::format("DDraw4Surface::DownloadSurfaceData: Downloading nr. [[4-", m_surfCount, "]]"));
-        BlitToDDrawSurface<IDirectDrawSurface4, DDSURFACEDESC2>(m_proxy.ptr(), m_d3d9.ptr());
+        BlitToDDrawSurface<IDirectDrawSurface4, DDSURFACEDESC2>(m_proxy.ptr(), m_commonSurf->GetD3D9Surface());
         m_commonSurf->UnDirtyD3D9Surface();
       }
     }
   }
 
-  inline HRESULT DDraw4Surface::InitializeD3D9(const bool initRT) {
-    if (unlikely(m_d3d9Device == nullptr)) {
-      Logger::debug("DDraw4Surface::InitializeD3D9: Null device, can't initialize right now");
-      return DD_OK;
-    }
-
-    Logger::debug(str::format("DDraw4Surface::InitializeD3D9: Initializing nr. [[4-", m_surfCount, "]]"));
-
-    const DDSURFACEDESC2* desc2  = m_commonSurf->GetDesc2();
-    const d3d9::D3DFORMAT format = m_commonSurf->GetD3D9Format();
-
-    if (unlikely(desc2->dwHeight == 0 || desc2->dwWidth == 0)) {
-      Logger::err("DDraw4Surface::InitializeD3D9: Surface has 0 height or width");
-      return DDERR_GENERIC;
-    }
-
-    if (unlikely(format == d3d9::D3DFMT_UNKNOWN)) {
-      Logger::err("DDraw4Surface::InitializeD3D9: Surface has an unknown format");
-      return DDERR_GENERIC;
-    }
-
-    // Don't initialize P8 textures/surfaces since we don't support them.
-    // Some applications do require them to be created by ddraw, otherwise
-    // they will simply fail to start, so just ignore them for now.
-    if (unlikely(format == d3d9::D3DFMT_P8)) {
-      static bool s_formatP8ErrorShown;
-
-      if (!std::exchange(s_formatP8ErrorShown, true))
-        Logger::warn("DDraw4Surface::InitializeD3D9: Unsupported format D3DFMT_P8");
-
-      return DD_OK;
-
-    // Similarly, D3DFMT_R3G3B2 isn't supported by D3D9 dxvk, however some
-    // applications require it to be supported by ddraw, even if they do not
-    // use it. Simply ignore any D3DFMT_R3G3B2 textures/surfaces for now.
-    } else if (unlikely(format == d3d9::D3DFMT_R3G3B2)) {
-      static bool s_formatR3G3B2ErrorShown;
-
-      if (!std::exchange(s_formatR3G3B2ErrorShown, true))
-        Logger::warn("DDraw4Surface::InitializeD3D9: Unsupported format D3DFMT_R3G3B2");
-
-      return DD_OK;
-    }
-
+  inline void DDraw4Surface::UpdateMipMapCount() {
     // We need to count the number of actual mips on initialization by going through
     // the mip chain, since the dwMipMapCount number may or may not be accurate. I am
     // guessing it was intended more as a hint, not neceesarily a set number.
-    if (m_commonSurf->IsTexture()) {
-      IDirectDrawSurface4* mipMap = m_proxy.ptr();
-      DDSURFACEDESC2 mipDesc2;
-      uint16_t mipCount = 1;
+    const DDSURFACEDESC2* desc2  = m_commonSurf->GetDesc2();
 
-      while (mipMap != nullptr) {
-        IDirectDrawSurface4* parentSurface = mipMap;
-        mipMap = nullptr;
-        parentSurface->EnumAttachedSurfaces(&mipMap, ListMipChainSurfaces4Callback);
-        if (mipMap != nullptr) {
-          mipCount++;
+    IDirectDrawSurface4* mipMap = m_proxy.ptr();
+    DDSURFACEDESC2 mipDesc2;
+    uint16_t mipCount = 1;
 
-          mipDesc2 = { };
-          mipDesc2.dwSize = sizeof(DDSURFACEDESC2);
-          mipMap->GetSurfaceDesc(&mipDesc2);
-          // Ignore multiple 1x1 mips, which apparently can get generated if the
-          // application gets the dwMipMapCount wrong vs surface dimensions.
-          if (unlikely(mipDesc2.dwWidth == 1 && mipDesc2.dwHeight == 1))
-            break;
-        }
-      }
+    while (mipMap != nullptr) {
+      IDirectDrawSurface4* parentSurface = mipMap;
+      mipMap = nullptr;
+      parentSurface->EnumAttachedSurfaces(&mipMap, ListMipChainSurfaces4Callback);
+      if (mipMap != nullptr) {
+        mipCount++;
 
-      // Do not worry about maximum supported mip map levels validation,
-      // because D3D9 will handle this for us and cap them appropriately
-      if (mipCount > 1) {
-        Logger::debug(str::format("DDraw4Surface::InitializeD3D9: Found ", mipCount, " mip levels"));
-
-        if (unlikely(mipCount != desc2->dwMipMapCount))
-          Logger::debug(str::format("DDraw4Surface::InitializeD3D9: Mismatch with declared ", desc2->dwMipMapCount, " mip levels"));
-      }
-
-      if (unlikely(m_commonIntf->GetOptions()->autoGenMipMaps)) {
-        Logger::debug("DDraw4Surface::InitializeD3D9: Using auto mip map generation");
-        mipCount = 0;
-      }
-
-      m_commonSurf->SetMipCount(mipCount);
-    }
-
-    d3d9::D3DPOOL pool  = d3d9::D3DPOOL_DEFAULT;
-    DWORD         usage = 0;
-
-    // General surface/texture pool placement
-    if (desc2->ddsCaps.dwCaps & DDSCAPS_LOCALVIDMEM)
-      pool = d3d9::D3DPOOL_DEFAULT;
-    // There's no explicit non-local video memory placement
-    // per se, but D3DPOOL_MANAGED is close enough
-    else if ((desc2->ddsCaps.dwCaps & DDSCAPS_NONLOCALVIDMEM) || (desc2->ddsCaps.dwCaps2 & DDSCAPS2_TEXTUREMANAGE))
-      pool = d3d9::D3DPOOL_MANAGED;
-    else if (desc2->ddsCaps.dwCaps & DDSCAPS_SYSTEMMEMORY)
-      // We can't know beforehand if a texture is or isn't going to be
-      // used in SetTexture() calls, and textures placed in D3DPOOL_SYSTEMMEM
-      // will not work in that context in dxvk, so revert to D3DPOOL_MANAGED.
-      pool = m_commonSurf->IsTexture() ? d3d9::D3DPOOL_MANAGED : d3d9::D3DPOOL_SYSTEMMEM;
-
-    // Place all possible render targets in DEFAULT
-    //
-    // Note: This is somewhat problematic for textures and cube maps
-    // which will have D3DUSAGE_RENDERTARGET, but also need to have
-    // D3DUSAGE_DYNAMIC for locking/uploads to work. The flag combination
-    // isn't supported in D3D9, but we have a D3D7 exception in place.
-    //
-    if (m_commonSurf->IsRenderTarget() || initRT) {
-      Logger::debug("DDraw4Surface::InitializeD3D9: Usage: D3DUSAGE_RENDERTARGET");
-      pool  = d3d9::D3DPOOL_DEFAULT;
-      usage |= D3DUSAGE_RENDERTARGET;
-    }
-    // All depth stencils will be created in DEFAULT
-    if (m_commonSurf->IsDepthStencil()) {
-      Logger::debug("DDraw4Surface::InitializeD3D9: Usage: D3DUSAGE_DEPTHSTENCIL");
-      pool  = d3d9::D3DPOOL_DEFAULT;
-      usage |= D3DUSAGE_DEPTHSTENCIL;
-    }
-
-    // General usage flags
-    if (m_commonSurf->IsTexture()) {
-      if (pool == d3d9::D3DPOOL_DEFAULT) {
-        Logger::debug("DDraw4Surface::InitializeD3D9: Usage: D3DUSAGE_DYNAMIC");
-        usage |= D3DUSAGE_DYNAMIC;
-      }
-      if (unlikely(m_commonIntf->GetOptions()->autoGenMipMaps)) {
-        Logger::debug("DDraw4Surface::InitializeD3D9: Usage: D3DUSAGE_AUTOGENMIPMAP");
-        usage |= D3DUSAGE_AUTOGENMIPMAP;
+        mipDesc2 = { };
+        mipDesc2.dwSize = sizeof(DDSURFACEDESC2);
+        mipMap->GetSurfaceDesc(&mipDesc2);
+        // Ignore multiple 1x1 mips, which apparently can get generated if the
+        // application gets the dwMipMapCount wrong vs surface dimensions.
+        if (unlikely(mipDesc2.dwWidth == 1 && mipDesc2.dwHeight == 1))
+          break;
       }
     }
 
-    const char* poolPlacement = pool == d3d9::D3DPOOL_DEFAULT ? "D3DPOOL_DEFAULT" :
-                                pool == d3d9::D3DPOOL_SYSTEMMEM ? "D3DPOOL_SYSTEMMEM" : "D3DPOOL_MANAGED";
+    // Do not worry about maximum supported mip map levels validation,
+    // because D3D9 will handle this for us and cap them appropriately
+    if (mipCount > 1) {
+      Logger::debug(str::format("DDraw4Surface::UpdateMipMapCount: Found ", mipCount, " mip levels"));
 
-    Logger::debug(str::format("DDraw4Surface::InitializeD3D9: Placing in: ", poolPlacement));
-
-    // Use the MSAA type that was determined to be supported during device creation
-    const d3d9::D3DMULTISAMPLE_TYPE multiSampleType = m_commonIntf->GetCommonD3DDevice()->GetMultiSampleType();
-    const uint32_t index = m_commonSurf->GetBackBufferIndex();
-
-    Com<d3d9::IDirect3DSurface9> surf;
-
-    HRESULT hr = DDERR_GENERIC;
-
-    // Front Buffer
-    if (m_commonSurf->IsFrontBuffer()) {
-      Logger::debug("DDraw4Surface::InitializeD3D9: Initializing front buffer...");
-
-      m_d3d9Device->GetBackBuffer(0, index, d3d9::D3DBACKBUFFER_TYPE_MONO, &surf);
-
-      if (unlikely(surf == nullptr)) {
-        Logger::err("DDraw4Surface::InitializeD3D9: Failed to retrieve front buffer");
-        m_d3d9 = nullptr;
-        return hr;
-      }
-
-      m_d3d9 = std::move(surf);
-
-      m_commonSurf->MarkAsD3D9BackBuffer();
-
-    // Back Buffer
-    } else if (m_commonSurf->IsBackBufferOrFlippable()) {
-      Logger::debug("DDraw4Surface::InitializeD3D9: Initializing back buffer...");
-
-      m_d3d9Device->GetBackBuffer(0, index, d3d9::D3DBACKBUFFER_TYPE_MONO, &surf);
-
-      if (unlikely(surf == nullptr)) {
-        Logger::err("DDraw4Surface::InitializeD3D9: Failed to retrieve back buffer");
-        m_d3d9 = nullptr;
-        return hr;
-      }
-
-      m_d3d9 = std::move(surf);
-
-      m_commonSurf->MarkAsD3D9BackBuffer();
-
-    // Textures
-    } else if (m_commonSurf->IsTexture()) {
-      Logger::debug("DDraw4Surface::InitializeD3D9: Initializing texture...");
-
-      Com<d3d9::IDirect3DTexture9> tex;
-
-      hr = m_d3d9Device->CreateTexture(
-        desc2->dwWidth, desc2->dwHeight, m_commonSurf->GetMipCount(), usage,
-        format, pool, &tex, nullptr);
-
-      if (unlikely(FAILED(hr))) {
-        Logger::err("DDraw4Surface::InitializeD3D9: Failed to create texture");
-        m_texture9 = nullptr;
-        return hr;
-      }
-
-      if (unlikely(m_commonIntf->GetOptions()->autoGenMipMaps))
-        tex->SetAutoGenFilterType(d3d9::D3DTEXF_ANISOTROPIC);
-
-      // Attach level 0 to this surface
-      tex->GetSurfaceLevel(0, &surf);
-      m_d3d9 = (std::move(surf));
-
-      Logger::debug("DDraw4Surface::InitializeD3D9: Created texture");
-      m_texture9 = std::move(tex);
-
-    // Depth Stencil
-    } else if (m_commonSurf->IsDepthStencil()) {
-      Logger::debug("DDraw4Surface::InitializeD3D9: Initializing depth stencil...");
-
-      hr = m_d3d9Device->CreateDepthStencilSurface(
-        desc2->dwWidth, desc2->dwHeight, format,
-        multiSampleType, 0, FALSE, &surf, nullptr);
-
-      if (unlikely(FAILED(hr))) {
-        Logger::err("DDraw4Surface::InitializeD3D9: Failed to create DS");
-        m_d3d9 = nullptr;
-        return hr;
-      }
-
-      Logger::debug("DDraw4Surface::InitializeD3D9: Created depth stencil surface");
-
-      m_d3d9 = std::move(surf);
-
-    // Offscreen Plain Surfaces
-    } else if (m_commonSurf->IsOffScreenPlainSurface()) {
-      Logger::debug("DDraw4Surface::InitializeD3D9: Initializing offscreen plain surface...");
-
-      // Sometimes we get passed offscreen plain surfaces which should be tied to the back buffer,
-      // either as existing RTs or during SetRenderTarget() calls, which are tracked with initRT
-      if (unlikely(m_commonIntf->GetCommonD3DDevice()->IsCurrentRenderTarget(this) || initRT)) {
-        Logger::debug("DDraw4Surface::InitializeD3D9: Offscreen plain surface is the RT");
-
-        m_d3d9Device->GetBackBuffer(0, index, d3d9::D3DBACKBUFFER_TYPE_MONO, &surf);
-
-        if (unlikely(surf == nullptr)) {
-          Logger::err("DDraw4Surface::InitializeD3D9: Failed to retrieve offscreen plain surface");
-          m_d3d9 = nullptr;
-          return hr;
-        }
-      } else {
-        hr = m_d3d9Device->CreateOffscreenPlainSurface(
-          desc2->dwWidth, desc2->dwHeight, format,
-          pool, &surf, nullptr);
-
-        if (unlikely(FAILED(hr))) {
-          Logger::err("DDraw4Surface::InitializeD3D9: Failed to create offscreen plain surface");
-          m_d3d9 = nullptr;
-          return hr;
-        }
-      }
-
-      m_d3d9 = std::move(surf);
-
-      m_commonSurf->MarkAsD3D9BackBuffer();
-
-    // Overlays (haven't seen any actual use of overlays in the wild)
-    } else if (m_commonSurf->IsOverlay()) {
-      Logger::debug("DDraw4Surface::InitializeD3D9: Initializing overlay...");
-
-      // Always link overlays to the back buffer
-      m_d3d9Device->GetBackBuffer(0, index, d3d9::D3DBACKBUFFER_TYPE_MONO, &surf);
-
-      if (unlikely(surf == nullptr)) {
-        Logger::err("DDraw4Surface::InitializeD3D9: Failed to retrieve overlay surface");
-        m_d3d9 = nullptr;
-        return hr;
-      }
-
-      m_d3d9 = std::move(surf);
-
-      m_commonSurf->MarkAsD3D9BackBuffer();
-
-    // Generic render target
-    } else if (m_commonSurf->IsRenderTarget()) {
-      Logger::debug("DDraw4Surface::InitializeD3D9: Initializing render target...");
-
-      // Must be lockable for blitting to work. Note that
-      // D3D9 does not allow the creation of lockable RTs when
-      // using MSAA, but we have a D3D7 exception in place.
-      hr = m_d3d9Device->CreateRenderTarget(
-        desc2->dwWidth, desc2->dwHeight, format,
-        multiSampleType, usage, TRUE, &surf, nullptr);
-
-      if (unlikely(FAILED(hr))) {
-        Logger::err("DDraw4Surface::InitializeD3D9: Failed to create render target");
-        m_d3d9 = nullptr;
-        return hr;
-      }
-
-      m_d3d9 = std::move(surf);
-
-    // We sometimes get generic surfaces, with only dimensions, format and placement info
-    } else if (!m_commonSurf->IsNotKnown()) {
-      Logger::debug("DDraw4Surface::InitializeD3D9: Initializing generic surface...");
-
-      hr = m_d3d9Device->CreateOffscreenPlainSurface(
-          desc2->dwWidth, desc2->dwHeight, format,
-          pool, &surf, nullptr);
-
-      if (unlikely(FAILED(hr))) {
-        Logger::err("DDraw4Surface::InitializeD3D9: Failed to create offscreen plain surface");
-        m_d3d9 = nullptr;
-        return hr;
-      }
-
-      Logger::debug("DDraw4Surface::InitializeD3D9: Created offscreen plain surface");
-
-      m_d3d9 = std::move(surf);
-    } else {
-      Logger::warn("DDraw4Surface::InitializeD3D9: Skipping initialization of unknown surface");
+      if (unlikely(mipCount != desc2->dwMipMapCount))
+        Logger::debug(str::format("DDraw4Surface::UpdateMipMapCount: Mismatch with declared ", desc2->dwMipMapCount, " mip levels"));
     }
 
-    if (m_shadowSurf != nullptr)
-      m_shadowSurf->SetD3D9(m_d3d9.ptr());
+    if (unlikely(m_commonIntf->GetOptions()->autoGenMipMaps)) {
+      Logger::debug("DDraw4Surface::UpdateMipMapCount: Using auto mip map generation");
+      mipCount = 0;
+    }
 
-    UploadSurfaceData();
-
-    return DD_OK;
+    m_commonSurf->SetMipCount(mipCount);
   }
 
   inline HRESULT DDraw4Surface::UploadSurfaceData() {
@@ -1486,14 +1248,14 @@ namespace dxvk {
     const d3d9::D3DFORMAT format = m_commonSurf->GetD3D9Format();
 
     if (m_commonSurf->IsTexture()) {
-      BlitToD3D9Texture<IDirectDrawSurface4, DDSURFACEDESC2>(m_texture9.ptr(), format,
+      BlitToD3D9Texture<IDirectDrawSurface4, DDSURFACEDESC2>(m_commonSurf->GetD3D9Texture(), format,
                                                              m_proxy.ptr(), m_commonSurf->GetMipCount());
     // Blit surfaces directly
     } else {
       if (unlikely(m_commonSurf->IsDepthStencil()))
         Logger::debug("DDrawSurface::UploadSurfaceData: Uploading depth stencil");
 
-      BlitToD3D9Surface<IDirectDrawSurface4, DDSURFACEDESC2>(m_d3d9.ptr(), format, GetShadowOrProxied());
+      BlitToD3D9Surface<IDirectDrawSurface4, DDSURFACEDESC2>(m_commonSurf->GetD3D9Surface(), format, GetShadowOrProxied());
     }
 
     m_commonSurf->UnDirtyDDrawSurface();
@@ -1501,22 +1263,21 @@ namespace dxvk {
     return DD_OK;
   }
 
-  inline void DDraw4Surface::RefreshD3D9Device() {
-    D3DCommonDevice* commonDevice = m_commonIntf->GetCommonD3DDevice();
+  inline d3d9::IDirect3DDevice9* DDraw4Surface::RefreshD3D9Device() {
+    D3DCommonDevice* commonD3DDevice = m_commonIntf->GetCommonD3DDevice();
 
-    d3d9::IDirect3DDevice9* d3d9Device = commonDevice != nullptr ? commonDevice->GetD3D9Device() : nullptr;
-    if (unlikely(m_d3d9Device != d3d9Device)) {
+    if (unlikely(m_commonD3DDevice != commonD3DDevice)) {
       // Check if the device has been recreated and reset all D3D9 resources
-      if (m_d3d9Device != nullptr) {
+      if (m_commonD3DDevice != nullptr) {
         Logger::debug("DDraw4Surface: Device context has changed, clearing all D3D9 resources");
-        m_texture9 = nullptr;
-        m_d3d9 = nullptr;
-        if (m_shadowSurf != nullptr)
-          m_shadowSurf->SetD3D9(nullptr);
+        m_commonSurf->SetD3D9Texture(nullptr);
+        m_commonSurf->SetD3D9Surface(nullptr);
       }
 
-      m_d3d9Device = d3d9Device;
+      m_commonD3DDevice = commonD3DDevice;
     }
+
+    return m_commonD3DDevice != nullptr ? m_commonD3DDevice->GetD3D9Device() : nullptr;
   }
 
 }

--- a/src/ddraw/ddraw4/ddraw4_surface.h
+++ b/src/ddraw/ddraw4/ddraw4_surface.h
@@ -15,12 +15,12 @@
 
 namespace dxvk {
 
-  class DDraw7Surface;
+  class D3DCommonDevice;
 
   /**
   * \brief IDirectDrawSurface4 interface implementation
   */
-  class DDraw4Surface final : public DDrawWrappedObject<DDraw4Interface, IDirectDrawSurface4, d3d9::IDirect3DSurface9> {
+  class DDraw4Surface final : public DDrawWrappedObject<DDraw4Interface, IDirectDrawSurface4> {
 
   public:
 
@@ -145,12 +145,8 @@ namespace dxvk {
       return m_commonIntf;
     }
 
-    d3d9::IDirect3DDevice9* GetD3D9Device() const {
-      return m_d3d9Device;
-    }
-
-    d3d9::IDirect3DTexture9* GetD3D9Texture() const {
-      return m_texture9.ptr();
+    D3DCommonDevice* GetCommonD3DDevice() const {
+      return m_commonD3DDevice;
     }
 
     DDraw4Surface* GetAttachedDepthStencil() {
@@ -186,37 +182,35 @@ namespace dxvk {
 
   private:
 
-    inline HRESULT InitializeD3D9(const bool initRT);
+    inline void UpdateMipMapCount();
 
     inline HRESULT UploadSurfaceData();
 
-    inline void RefreshD3D9Device();
+    inline d3d9::IDirect3DDevice9* RefreshD3D9Device();
 
     bool             m_isChildObject = true;
 
     static uint32_t  s_surfCount;
     uint32_t         m_surfCount = 0;
 
-    Com<DDrawCommonSurface>      m_commonSurf;
-    DDrawCommonInterface*        m_commonIntf = nullptr;
+    Com<DDrawCommonSurface> m_commonSurf;
+    DDrawCommonInterface*   m_commonIntf = nullptr;
 
-    DDraw4Surface*               m_parentSurf = nullptr;
+    DDraw4Surface*          m_parentSurf = nullptr;
 
-    d3d9::IDirect3DDevice9*      m_d3d9Device = nullptr;
+    D3DCommonDevice*        m_commonD3DDevice = nullptr;
 
-    Com<D3D6Texture, false>      m_texture6;
+    Com<D3D6Texture, false> m_texture6;
 
-    Com<d3d9::IDirect3DTexture9> m_texture9;
-
-    DDraw4Surface*               m_nextFlippable = nullptr;
+    DDraw4Surface*          m_nextFlippable = nullptr;
 
     // Offscreen plain surface we use to mask unwanted DDraw interactions, such
     // as forced swapchain presents caused by blits/locks on primary surfaces
-    Com<DDraw4Surface>           m_shadowSurf;
+    Com<DDraw4Surface>      m_shadowSurf;
 
     // Back buffers will have depth stencil surfaces as attachments (in practice
     // I have never seen more than one depth stencil being attached at a time)
-    Com<DDraw4Surface>           m_depthStencil;
+    Com<DDraw4Surface>      m_depthStencil;
 
     // These are attached surfaces, which are typically mips or other types of generated
     // surfaces, which need to exist for the entire lifecycle of their parent surface.

--- a/src/ddraw/ddraw7/ddraw7_interface.cpp
+++ b/src/ddraw/ddraw7/ddraw7_interface.cpp
@@ -21,7 +21,7 @@ namespace dxvk {
   DDraw7Interface::DDraw7Interface(
         DDrawCommonInterface* commonIntf,
         Com<IDirectDraw7>&& proxyIntf)
-    : DDrawWrappedObject<IUnknown, IDirectDraw7, IUnknown>(nullptr, std::move(proxyIntf), nullptr)
+    : DDrawWrappedObject<IUnknown, IDirectDraw7>(nullptr, std::move(proxyIntf))
     , m_commonIntf ( commonIntf ) {
     // We need a temporary D3D9 interface at this point to retrieve the
     // adapter identifier, as well as (potentially) the options through a bridge

--- a/src/ddraw/ddraw7/ddraw7_interface.h
+++ b/src/ddraw/ddraw7/ddraw7_interface.h
@@ -17,7 +17,7 @@ namespace dxvk {
   /**
   * \brief DirectDraw7 interface implementation
   */
-  class DDraw7Interface final : public DDrawWrappedObject<IUnknown, IDirectDraw7, IUnknown> {
+  class DDraw7Interface final : public DDrawWrappedObject<IUnknown, IDirectDraw7> {
 
   public:
     DDraw7Interface(

--- a/src/ddraw/ddraw7/ddraw7_surface.cpp
+++ b/src/ddraw/ddraw7/ddraw7_surface.cpp
@@ -21,7 +21,7 @@ namespace dxvk {
         DDraw7Interface* pParent,
         DDraw7Surface* pParentSurf,
         bool isChildObject)
-    : DDrawWrappedObject<DDraw7Interface, IDirectDrawSurface7, d3d9::IDirect3DSurface9>(pParent, std::move(surfProxy), nullptr)
+    : DDrawWrappedObject<DDraw7Interface, IDirectDrawSurface7>(pParent, std::move(surfProxy))
     , m_isChildObject ( isChildObject )
     , m_commonSurf ( commonSurf )
     , m_parentSurf ( pParentSurf ) {
@@ -271,22 +271,22 @@ namespace dxvk {
     }
     DownloadSurfaceData();
 
-    RefreshD3D9Device();
-    if (likely(m_d3d9Device != nullptr)) {
+    d3d9::IDirect3DDevice9* d3d9Device = RefreshD3D9Device();
+    if (likely(d3d9Device != nullptr)) {
       // Forward DDBLT_DEPTHFILL clears to D3D9 if done on the current depth stencil
       if (unlikely(lpDDSrcSurface == nullptr &&
                     (dwFlags & DDBLT_DEPTHFILL) &&
                     lpDDBltFx != nullptr &&
-                    m_commonIntf->GetCommonD3DDevice()->IsCurrentD3D9DepthStencil(m_d3d9.ptr()))) {
+                    m_commonIntf->GetCommonD3DDevice()->IsCurrentD3D9DepthStencil(m_commonSurf->GetD3D9Surface()))) {
         Logger::debug("DDraw7Surface::Blt: Clearing d3d9 depth stencil");
 
         HRESULT hrClear;
         const float zClear = m_commonSurf->GetNormalizedFloatDepth(lpDDBltFx->dwFillDepth);
 
         if (lpDestRect == nullptr) {
-          hrClear = m_d3d9Device->Clear(0, NULL, D3DCLEAR_ZBUFFER, 0, zClear, 0);
+          hrClear = d3d9Device->Clear(0, NULL, D3DCLEAR_ZBUFFER, 0, zClear, 0);
         } else {
-          hrClear = m_d3d9Device->Clear(1, reinterpret_cast<D3DRECT*>(lpDestRect), D3DCLEAR_ZBUFFER, 0, zClear, 0);
+          hrClear = d3d9Device->Clear(1, reinterpret_cast<D3DRECT*>(lpDestRect), D3DCLEAR_ZBUFFER, 0, zClear, 0);
         }
         if (unlikely(FAILED(hrClear)))
           Logger::warn("DDraw7Surface::Blt: Failed to clear d3d9 depth");
@@ -295,14 +295,14 @@ namespace dxvk {
       if (unlikely(lpDDSrcSurface == nullptr &&
                     (dwFlags & DDBLT_COLORFILL) &&
                     lpDDBltFx != nullptr &&
-                    m_commonIntf->GetCommonD3DDevice()->IsCurrentD3D9RenderTarget(m_d3d9.ptr()))) {
+                    m_commonIntf->GetCommonD3DDevice()->IsCurrentD3D9RenderTarget(m_commonSurf->GetD3D9Surface()))) {
         Logger::debug("DDraw7Surface::Blt: Clearing d3d9 render target");
 
         HRESULT hrClear;
         if (lpDestRect == nullptr) {
-          hrClear = m_d3d9Device->Clear(0, NULL, D3DCLEAR_TARGET, lpDDBltFx->dwFillColor, 0.0f, 0);
+          hrClear = d3d9Device->Clear(0, NULL, D3DCLEAR_TARGET, lpDDBltFx->dwFillColor, 0.0f, 0);
         } else {
-          hrClear = m_d3d9Device->Clear(1, reinterpret_cast<D3DRECT*>(lpDestRect), D3DCLEAR_TARGET, lpDDBltFx->dwFillColor, 0.0f, 0);
+          hrClear = d3d9Device->Clear(1, reinterpret_cast<D3DRECT*>(lpDestRect), D3DCLEAR_TARGET, lpDDBltFx->dwFillColor, 0.0f, 0);
         }
         if (unlikely(FAILED(hrClear)))
           Logger::warn("DDraw7Surface::Blt: Failed to clear d3d9 render target");
@@ -321,7 +321,7 @@ namespace dxvk {
 
         if (ddraw7Surface == renderTarget) {
           renderTarget->InitializeOrUploadD3D9();
-          m_d3d9Device->Present(NULL, NULL, NULL, NULL);
+          d3d9Device->Present(NULL, NULL, NULL, NULL);
           return DD_OK;
         }
       }
@@ -343,14 +343,14 @@ namespace dxvk {
     if (likely(SUCCEEDED(hr))) {
       m_commonSurf->DirtyDDrawSurface();
 
-      if (unlikely(m_shadowSurf != nullptr && m_d3d9Device != nullptr)) {
+      if (unlikely(m_shadowSurf != nullptr && d3d9Device != nullptr)) {
         const bool shouldPresent = m_commonIntf->GetOptions()->legacyPresentGuard == D3DLegacyPresentGuard::Auto ?
                                   !m_commonIntf->GetCommonD3DDevice()->IsInScene() :
                                    m_commonIntf->GetOptions()->legacyPresentGuard == D3DLegacyPresentGuard::Strict ?
                                    false : true;
         if (shouldPresent) {
           InitializeOrUploadD3D9();
-          m_d3d9Device->Present(NULL, NULL, NULL, NULL);
+          d3d9Device->Present(NULL, NULL, NULL, NULL);
         }
       }
     }
@@ -377,8 +377,8 @@ namespace dxvk {
     }
     DownloadSurfaceData();
 
-    RefreshD3D9Device();
-    if (likely(m_d3d9Device != nullptr)) {
+    d3d9::IDirect3DDevice9* d3d9Device = RefreshD3D9Device();
+    if (likely(d3d9Device != nullptr)) {
       const bool exclusiveMode = (m_commonIntf->GetCooperativeLevel() & DDSCL_EXCLUSIVE)
                               && !m_commonIntf->GetOptions()->ignoreExclusiveMode;
 
@@ -392,7 +392,7 @@ namespace dxvk {
 
         if (ddraw7Surface == renderTarget) {
           renderTarget->InitializeOrUploadD3D9();
-          m_d3d9Device->Present(NULL, NULL, NULL, NULL);
+          d3d9Device->Present(NULL, NULL, NULL, NULL);
           return DD_OK;
         }
       }
@@ -414,14 +414,14 @@ namespace dxvk {
     if (likely(SUCCEEDED(hr))) {
       m_commonSurf->DirtyDDrawSurface();
 
-      if (unlikely(m_shadowSurf != nullptr && m_d3d9Device != nullptr)) {
+      if (unlikely(m_shadowSurf != nullptr && d3d9Device != nullptr)) {
         const bool shouldPresent = m_commonIntf->GetOptions()->legacyPresentGuard == D3DLegacyPresentGuard::Auto ?
                                   !m_commonIntf->GetCommonD3DDevice()->IsInScene() :
                                    m_commonIntf->GetOptions()->legacyPresentGuard == D3DLegacyPresentGuard::Strict ?
                                    false : true;
         if (shouldPresent) {
           InitializeOrUploadD3D9();
-          m_d3d9Device->Present(NULL, NULL, NULL, NULL);
+          d3d9Device->Present(NULL, NULL, NULL, NULL);
         }
       }
     }
@@ -512,8 +512,8 @@ namespace dxvk {
     if (m_commonIntf->IsWrappedSurface(lpDDSurfaceTargetOverride))
       surf7 = static_cast<DDraw7Surface*>(lpDDSurfaceTargetOverride);
 
-    RefreshD3D9Device();
-    if (likely(m_d3d9Device != nullptr)) {
+    d3d9::IDirect3DDevice9* d3d9Device = RefreshD3D9Device();
+    if (likely(d3d9Device != nullptr)) {
       Logger::debug("*** DDraw7Surface::Flip: Presenting");
 
       // Lost surfaces are not flippable
@@ -585,7 +585,7 @@ namespace dxvk {
         InitializeOrUploadD3D9();
       }
 
-      m_d3d9Device->Present(NULL, NULL, NULL, NULL);
+      d3d9Device->Present(NULL, NULL, NULL, NULL);
     // If we don't yet have a device, perhaps a D3D7 application is trying to
     // present exclusively on DDraw (such as a main menu), so allow the flip
     } else {
@@ -808,14 +808,15 @@ namespace dxvk {
     if (likely(SUCCEEDED(hr))) {
       m_commonSurf->DirtyDDrawSurface();
 
-      if (unlikely(m_shadowSurf != nullptr && m_d3d9Device != nullptr)) {
+      d3d9::IDirect3DDevice9* d3d9Device = RefreshD3D9Device();
+      if (unlikely(m_shadowSurf != nullptr && d3d9Device != nullptr)) {
         const bool shouldPresent = m_commonIntf->GetOptions()->legacyPresentGuard == D3DLegacyPresentGuard::Auto ?
                                   !m_commonIntf->GetCommonD3DDevice()->IsInScene() :
                                    m_commonIntf->GetOptions()->legacyPresentGuard == D3DLegacyPresentGuard::Strict ?
                                    false : true;
         if (shouldPresent) {
           InitializeOrUploadD3D9();
-          m_d3d9Device->Present(NULL, NULL, NULL, NULL);
+          d3d9Device->Present(NULL, NULL, NULL, NULL);
         }
       }
     }
@@ -931,15 +932,15 @@ namespace dxvk {
     if (likely(SUCCEEDED(hr))) {
       m_commonSurf->DirtyDDrawSurface();
 
-      RefreshD3D9Device();
-      if (unlikely(m_shadowSurf != nullptr && m_d3d9Device != nullptr)) {
+      d3d9::IDirect3DDevice9* d3d9Device = RefreshD3D9Device();
+      if (unlikely(m_shadowSurf != nullptr && d3d9Device != nullptr)) {
         const bool shouldPresent = m_commonIntf->GetOptions()->legacyPresentGuard == D3DLegacyPresentGuard::Auto ?
                                   !m_commonIntf->GetCommonD3DDevice()->IsInScene() :
                                    m_commonIntf->GetOptions()->legacyPresentGuard == D3DLegacyPresentGuard::Strict ?
                                    false : true;
         if (shouldPresent) {
           InitializeOrUploadD3D9();
-          m_d3d9Device->Present(NULL, NULL, NULL, NULL);
+          d3d9Device->Present(NULL, NULL, NULL, NULL);
         }
       }
     }
@@ -1016,7 +1017,7 @@ namespace dxvk {
       Logger::err("DDraw4Surface::SetSurfaceDesc: Failed to retrieve updated surface desc");
 
     // We may need to recreate the d3d9 object based on the new desc
-    m_d3d9 = nullptr;
+    m_commonSurf->SetD3D9Surface(nullptr);
 
     return hr;
   }
@@ -1060,7 +1061,7 @@ namespace dxvk {
     Logger::debug(">>> DDraw7Surface::SetPriority");
 
     RefreshD3D9Device();
-    if (unlikely(!IsInitialized())) {
+    if (unlikely(!m_commonSurf->IsInitialized())) {
       Logger::debug("DDraw7Surface::SetPriority: Not yet initialized");
       return m_proxy->SetPriority(prio);
     }
@@ -1072,7 +1073,7 @@ namespace dxvk {
     if (unlikely(FAILED(hr)))
       return hr;
 
-    m_d3d9->SetPriority(prio);
+    m_commonSurf->GetD3D9Surface()->SetPriority(prio);
 
     return DD_OK;
   }
@@ -1081,7 +1082,7 @@ namespace dxvk {
     Logger::debug(">>> DDraw7Surface::GetPriority");
 
     RefreshD3D9Device();
-    if (unlikely(!IsInitialized())) {
+    if (unlikely(!m_commonSurf->IsInitialized())) {
       Logger::debug("DDraw7Surface::GetPriority: Not yet initialized");
       return m_proxy->GetPriority(prio);
     }
@@ -1092,7 +1093,7 @@ namespace dxvk {
     if (unlikely(!m_commonSurf->IsManaged()))
       return DDERR_INVALIDOBJECT;
 
-    *prio = m_d3d9->GetPriority();
+    *prio = m_commonSurf->GetD3D9Surface()->GetPriority();
 
     return DD_OK;
   }
@@ -1101,7 +1102,7 @@ namespace dxvk {
     Logger::debug("<<< DDraw7Surface::SetLOD: Proxy");
 
     RefreshD3D9Device();
-    if (unlikely(!IsInitialized())) {
+    if (unlikely(!m_commonSurf->IsInitialized())) {
       Logger::debug("DDraw7Surface::SetLOD: Not yet initialized");
       return m_proxy->SetLOD(lod);
     }
@@ -1113,10 +1114,10 @@ namespace dxvk {
     if (unlikely(FAILED(hr)))
       return hr;
 
-    if (m_texture9 != nullptr) {
-      m_texture9->SetLOD(lod);
-    } else if (m_cubeMap9 != nullptr) {
-      m_cubeMap9->SetLOD(lod);
+    if (m_commonSurf->GetD3D9Texture() != nullptr) {
+      m_commonSurf->GetD3D9Texture()->SetLOD(lod);
+    } else if (m_commonSurf->GetD3D9CubeTexture() != nullptr) {
+      m_commonSurf->GetD3D9CubeTexture()->SetLOD(lod);
     } else {
       Logger::warn("DDraw7Surface::SetLOD: Failed to set D3D9 LOD");
       return DDERR_INVALIDOBJECT;
@@ -1129,7 +1130,7 @@ namespace dxvk {
     Logger::debug(">>> DDraw7Surface::GetLOD");
 
     RefreshD3D9Device();
-    if (unlikely(!IsInitialized())) {
+    if (unlikely(!m_commonSurf->IsInitialized())) {
       Logger::debug("DDraw7Surface::GetLOD: Not yet initialized");
       return m_proxy->GetLOD(lod);
     }
@@ -1140,10 +1141,10 @@ namespace dxvk {
     if (unlikely(!m_commonSurf->IsManaged()))
       return DDERR_INVALIDOBJECT;
 
-    if (likely(m_texture9 != nullptr)) {
-      *lod = m_texture9->GetLOD();
-    } else if (m_cubeMap9 != nullptr) {
-      *lod = m_cubeMap9->GetLOD();
+    if (likely(m_commonSurf->GetD3D9Texture() != nullptr)) {
+      *lod = m_commonSurf->GetD3D9Texture()->GetLOD();
+    } else if (m_commonSurf->GetD3D9CubeTexture() != nullptr) {
+      *lod = m_commonSurf->GetD3D9CubeTexture()->GetLOD();
     } else {
       Logger::warn("DDraw7Surface::GetLOD: Failed to get D3D9 LOD");
       return DDERR_INVALIDOBJECT;
@@ -1153,9 +1154,9 @@ namespace dxvk {
   }
 
   IDirectDrawSurface7* DDraw7Surface::GetShadowOrProxied() {
-    RefreshD3D9Device();
+    d3d9::IDirect3DDevice9* d3d9Device = RefreshD3D9Device();
 
-    if (unlikely(m_shadowSurf != nullptr && m_d3d9Device != nullptr))
+    if (unlikely(m_shadowSurf != nullptr && d3d9Device != nullptr))
       return m_shadowSurf->GetProxied();
 
     return m_proxy.ptr();
@@ -1166,10 +1167,23 @@ namespace dxvk {
 
     m_commonSurf->MarkAsD3D9BackBuffer();
 
-    if (unlikely(!IsInitialized()))
-      return InitializeD3D9(true);
+    if (unlikely(!m_commonSurf->IsInitialized())) {
+      if (m_commonSurf->IsTextureOrCubeMap())
+        UpdateMipMapCount();
 
-    return DD_OK;
+      HRESULT hr = m_commonSurf->InitializeD3D9(true);
+      if (unlikely(FAILED(hr)))
+        return hr;
+
+      if (unlikely(m_commonSurf->IsCubeMap()))
+        InitializeAllCubeMapSurfaces();
+
+      Logger::debug(str::format("DDraw7Surface::InitializeD3D9RenderTarget: Initialized surface nr. [[7-", m_surfCount, "]]"));
+
+      return UploadSurfaceData();
+    }
+
+    return D3D_OK;
   }
 
   HRESULT DDraw7Surface::InitializeD3D9DepthStencil() {
@@ -1177,19 +1191,48 @@ namespace dxvk {
 
     m_commonSurf->MarkAsD3D9DepthStencil();
 
-    if (unlikely(!IsInitialized()))
-      return InitializeD3D9(false);
+    if (unlikely(!m_commonSurf->IsInitialized())) {
+      HRESULT hr = m_commonSurf->InitializeD3D9(false);
+      if (unlikely(FAILED(hr)))
+        return hr;
+
+      Logger::debug(str::format("DDraw7Surface::InitializeD3D9DepthStencil: Initialized surface nr. [[7-", m_surfCount, "]]"));
+
+      return UploadSurfaceData();
+    }
 
     return DD_OK;
   }
 
   HRESULT DDraw7Surface::InitializeOrUploadD3D9() {
-    RefreshD3D9Device();
+    d3d9::IDirect3DDevice9* d3d9Device = RefreshD3D9Device();
 
-    if (unlikely(!IsInitialized()))
-      return InitializeD3D9(false);
+    // Fast skip
+    if (unlikely(d3d9Device == nullptr)) {
+      Logger::debug("DDraw7Surface::InitializeOrUploadD3D9: Null device, can't initialize right now");
+      return D3D_OK;
+    }
 
-    return UploadSurfaceData();
+    if (unlikely(!m_commonSurf->IsInitialized())) {
+      if (m_commonSurf->IsTextureOrCubeMap())
+        UpdateMipMapCount();
+
+      const bool initRenderTarget = m_commonIntf->GetCommonD3DDevice()->IsCurrentRenderTarget(this);
+
+      HRESULT hr = m_commonSurf->InitializeD3D9(initRenderTarget);
+      if (unlikely(FAILED(hr)))
+        return hr;
+
+      if (unlikely(m_commonSurf->IsCubeMap()))
+        InitializeAllCubeMapSurfaces();
+
+      Logger::debug(str::format("DDraw7Surface::InitializeOrUploadD3D9: Initialized surface nr. [[7-", m_surfCount, "]]"));
+    }
+
+    if (likely(m_commonSurf->IsInitialized()))
+      return UploadSurfaceData();
+
+    return DD_OK;
   }
 
   void DDraw7Surface::DownloadSurfaceData() {
@@ -1204,20 +1247,64 @@ namespace dxvk {
     if (unlikely(m_commonSurf->IsD3D9BackBuffer())) {
       Logger::debug("DDraw7Surface::DownloadSurfaceData: Surface is a bound swapchain surface");
 
-      if (IsInitialized() && m_commonSurf->IsD3D9SurfaceDirty()) {
+      if (m_commonSurf->IsInitialized() && m_commonSurf->IsD3D9SurfaceDirty()) {
         Logger::debug(str::format("DDraw7Surface::DownloadSurfaceData: Downloading nr. [[7-", m_surfCount, "]]"));
-        BlitToDDrawSurface<IDirectDrawSurface7, DDSURFACEDESC2>(GetShadowOrProxied(), m_d3d9.ptr());
+        BlitToDDrawSurface<IDirectDrawSurface7, DDSURFACEDESC2>(GetShadowOrProxied(), m_commonSurf->GetD3D9Surface());
         m_commonSurf->UnDirtyD3D9Surface();
       }
     } else if (unlikely(m_commonSurf->IsD3D9DepthStencil())) {
       Logger::debug("DDraw7Surface::DownloadSurfaceData: Surface is a bound depth stencil");
 
-      if (IsInitialized() && m_commonSurf->IsD3D9SurfaceDirty()) {
+      if (m_commonSurf->IsInitialized() && m_commonSurf->IsD3D9SurfaceDirty()) {
         Logger::debug(str::format("DDraw7Surface::DownloadSurfaceData: Downloading nr. [[7-", m_surfCount, "]]"));
-        BlitToDDrawSurface<IDirectDrawSurface7, DDSURFACEDESC2>(m_proxy.ptr(), m_d3d9.ptr());
+        BlitToDDrawSurface<IDirectDrawSurface7, DDSURFACEDESC2>(m_proxy.ptr(), m_commonSurf->GetD3D9Surface());
         m_commonSurf->UnDirtyD3D9Surface();
       }
     }
+  }
+
+  inline void DDraw7Surface::UpdateMipMapCount() {
+    // We need to count the number of actual mips on initialization by going through
+    // the mip chain, since the dwMipMapCount number may or may not be accurate. I am
+    // guessing it was intended more as a hint, not neceesarily a set number.
+    const DDSURFACEDESC2* desc2  = m_commonSurf->GetDesc2();
+
+    IDirectDrawSurface7* mipMap = m_proxy.ptr();
+    DDSURFACEDESC2 mipDesc2;
+    uint16_t mipCount = 1;
+
+    while (mipMap != nullptr) {
+      IDirectDrawSurface7* parentSurface = mipMap;
+      mipMap = nullptr;
+      parentSurface->EnumAttachedSurfaces(&mipMap, ListMipChainSurfaces7Callback);
+      if (mipMap != nullptr) {
+        mipCount++;
+
+        mipDesc2 = { };
+        mipDesc2.dwSize = sizeof(DDSURFACEDESC2);
+        mipMap->GetSurfaceDesc(&mipDesc2);
+        // Ignore multiple 1x1 mips, which apparently can get generated if the
+        // application gets the dwMipMapCount wrong vs surface dimensions.
+        if (unlikely(mipDesc2.dwWidth == 1 && mipDesc2.dwHeight == 1))
+          break;
+      }
+    }
+
+    // Do not worry about maximum supported mip map levels validation,
+    // because D3D9 will handle this for us and cap them appropriately
+    if (mipCount > 1) {
+      Logger::debug(str::format("DDraw7Surface::UpdateMipMapCount: Found ", mipCount, " mip levels"));
+
+      if (unlikely(mipCount != desc2->dwMipMapCount))
+        Logger::debug(str::format("DDraw7Surface::UpdateMipMapCount: Mismatch with declared ", desc2->dwMipMapCount, " mip levels"));
+    }
+
+    if (unlikely(m_commonIntf->GetOptions()->autoGenMipMaps)) {
+      Logger::debug("DDraw7Surface::UpdateMipMapCount: Using auto mip map generation");
+      mipCount = 0;
+    }
+
+    m_commonSurf->SetMipCount(mipCount);
   }
 
   inline void DDraw7Surface::InitializeAndAttachCubeFace(
@@ -1240,400 +1327,57 @@ namespace dxvk {
     if (likely(face7 != nullptr)) {
       Com<d3d9::IDirect3DSurface9> face9;
       cubeTex9->GetCubeMapSurface(face, 0, &face9);
-      face7->SetD3D9(std::move(face9));
+      face7->GetCommonSurface()->SetD3D9Surface(std::move(face9));
       m_attachedSurfaces.emplace(std::piecewise_construct,
                                 std::forward_as_tuple(face7->GetProxied()),
                                 std::forward_as_tuple(face7.ref()));
     }
   }
 
-  inline HRESULT DDraw7Surface::InitializeD3D9(const bool initRT) {
-    if (unlikely(m_d3d9Device == nullptr)) {
-      Logger::debug("DDraw7Surface::InitializeD3D9: Null device, can't initialize right now");
-      return DD_OK;
+  inline void DDraw7Surface::InitializeAllCubeMapSurfaces() {
+    Logger::debug("DDraw7Surface::InitializeAllCubeMapSurfaces: Retrieving cube map faces");
+
+    CubeMapAttachedSurfaces cubeMapAttachedSurfaces;
+    m_proxy->EnumAttachedSurfaces(&cubeMapAttachedSurfaces, EnumAndAttachCubeMapFacesCallback);
+
+    // The positive X surfaces is this surface, so nothing should be retrieved
+    if (unlikely(cubeMapAttachedSurfaces.positiveX != nullptr))
+      Logger::warn("DDraw7Surface::InitializeAllCubeMapSurfaces: Non-null positive X cube map face");
+
+    m_cubeMapSurfaces[0] = m_proxy.ptr();
+
+    // We can't know in advance which faces have been generated,
+    // so check them one by one, initialize and bind as needed
+    if (cubeMapAttachedSurfaces.negativeX != nullptr) {
+      Logger::debug("DDraw7Surface::InitializeAllCubeMapSurfaces: Detected negative X cube map face");
+      m_cubeMapSurfaces[1] = cubeMapAttachedSurfaces.negativeX;
+      InitializeAndAttachCubeFace(cubeMapAttachedSurfaces.negativeX, m_commonSurf->GetD3D9CubeTexture(),
+                                  d3d9::D3DCUBEMAP_FACE_NEGATIVE_X);
     }
-
-    Logger::debug(str::format("DDraw7Surface::InitializeD3D9: Initializing nr. [[7-", m_surfCount, "]]"));
-
-    const DDSURFACEDESC2* desc2  = m_commonSurf->GetDesc2();
-    const d3d9::D3DFORMAT format = m_commonSurf->GetD3D9Format();
-
-    if (unlikely(desc2->dwHeight == 0 || desc2->dwWidth == 0)) {
-      Logger::err("DDraw7Surface::InitializeD3D9: Surface has 0 height or width");
-      return DDERR_GENERIC;
+    if (cubeMapAttachedSurfaces.positiveY != nullptr) {
+      Logger::debug("DDraw7Surface::InitializeAllCubeMapSurfaces: Detected positive Y cube map face");
+      m_cubeMapSurfaces[2] = cubeMapAttachedSurfaces.positiveY;
+      InitializeAndAttachCubeFace(cubeMapAttachedSurfaces.positiveY, m_commonSurf->GetD3D9CubeTexture(),
+                                  d3d9::D3DCUBEMAP_FACE_POSITIVE_Y);
     }
-
-    if (unlikely(format == d3d9::D3DFMT_UNKNOWN)) {
-      Logger::err("DDraw7Surface::InitializeD3D9: Surface has an unknown format");
-      return DDERR_GENERIC;
+    if (cubeMapAttachedSurfaces.negativeY != nullptr) {
+      Logger::debug("DDraw7Surface::InitializeAllCubeMapSurfaces: Detected negative Y cube map face");
+      m_cubeMapSurfaces[3] = cubeMapAttachedSurfaces.negativeY;
+      InitializeAndAttachCubeFace(cubeMapAttachedSurfaces.negativeY, m_commonSurf->GetD3D9CubeTexture(),
+                                  d3d9::D3DCUBEMAP_FACE_NEGATIVE_Y);
     }
-
-    // Don't initialize P8 textures/surfaces since we don't support them.
-    // Some applications do require them to be created by ddraw, otherwise
-    // they will simply fail to start, so just ignore them for now.
-    if (unlikely(format == d3d9::D3DFMT_P8)) {
-      static bool s_formatP8ErrorShown;
-
-      if (!std::exchange(s_formatP8ErrorShown, true))
-        Logger::warn("DDraw7Surface::InitializeD3D9: Unsupported format D3DFMT_P8");
-
-      return DD_OK;
-
-    // Similarly, D3DFMT_R3G3B2 isn't supported by D3D9 dxvk, however some
-    // applications require it to be supported by ddraw, even if they do not
-    // use it. Simply ignore any D3DFMT_R3G3B2 textures/surfaces for now.
-    } else if (unlikely(format == d3d9::D3DFMT_R3G3B2)) {
-      static bool s_formatR3G3B2ErrorShown;
-
-      if (!std::exchange(s_formatR3G3B2ErrorShown, true))
-        Logger::warn("DDraw7Surface::InitializeD3D9: Unsupported format D3DFMT_R3G3B2");
-
-      return DD_OK;
+    if (cubeMapAttachedSurfaces.positiveZ != nullptr) {
+      Logger::debug("DDraw7Surface::InitializeAllCubeMapSurfaces: Detected positive Z cube map face");
+      m_cubeMapSurfaces[4] = cubeMapAttachedSurfaces.positiveZ;
+      InitializeAndAttachCubeFace(cubeMapAttachedSurfaces.positiveZ, m_commonSurf->GetD3D9CubeTexture(),
+                                  d3d9::D3DCUBEMAP_FACE_POSITIVE_Z);
     }
-
-    // We need to count the number of actual mips on initialization by going through
-    // the mip chain, since the dwMipMapCount number may or may not be accurate. I am
-    // guessing it was intended more as a hint, not neceesarily a set number.
-    if (m_commonSurf->IsTextureOrCubeMap()) {
-      IDirectDrawSurface7* mipMap = m_proxy.ptr();
-      DDSURFACEDESC2 mipDesc2;
-      uint16_t mipCount = 1;
-
-      while (mipMap != nullptr) {
-        IDirectDrawSurface7* parentSurface = mipMap;
-        mipMap = nullptr;
-        parentSurface->EnumAttachedSurfaces(&mipMap, ListMipChainSurfaces7Callback);
-        if (mipMap != nullptr) {
-          mipCount++;
-
-          mipDesc2 = { };
-          mipDesc2.dwSize = sizeof(DDSURFACEDESC2);
-          mipMap->GetSurfaceDesc(&mipDesc2);
-          // Ignore multiple 1x1 mips, which apparently can get generated if the
-          // application gets the dwMipMapCount wrong vs surface dimensions.
-          if (unlikely(mipDesc2.dwWidth == 1 && mipDesc2.dwHeight == 1))
-            break;
-        }
-      }
-
-      // Do not worry about maximum supported mip map levels validation,
-      // because D3D9 will handle this for us and cap them appropriately
-      if (mipCount > 1) {
-        Logger::debug(str::format("DDraw7Surface::InitializeD3D9: Found ", mipCount, " mip levels"));
-
-        if (unlikely(mipCount != desc2->dwMipMapCount))
-          Logger::debug(str::format("DDraw7Surface::InitializeD3D9: Mismatch with declared ", desc2->dwMipMapCount, " mip levels"));
-      }
-
-      if (unlikely(m_commonIntf->GetOptions()->autoGenMipMaps)) {
-        Logger::debug("DDraw7Surface::InitializeD3D9: Using auto mip map generation");
-        mipCount = 0;
-      }
-
-      m_commonSurf->SetMipCount(mipCount);
+    if (cubeMapAttachedSurfaces.negativeZ != nullptr) {
+      Logger::debug("DDraw7Surface::InitializeAllCubeMapSurfaces: Detected negative Z cube map face");
+      m_cubeMapSurfaces[5] = cubeMapAttachedSurfaces.negativeZ;
+      InitializeAndAttachCubeFace(cubeMapAttachedSurfaces.negativeZ, m_commonSurf->GetD3D9CubeTexture(),
+                                  d3d9::D3DCUBEMAP_FACE_NEGATIVE_Z);
     }
-
-    d3d9::D3DPOOL pool  = d3d9::D3DPOOL_DEFAULT;
-    DWORD         usage = 0;
-
-    // General surface/texture pool placement
-    if (desc2->ddsCaps.dwCaps & DDSCAPS_LOCALVIDMEM)
-      pool = d3d9::D3DPOOL_DEFAULT;
-    // There's no explicit non-local video memory placement
-    // per se, but D3DPOOL_MANAGED is close enough
-    else if ((desc2->ddsCaps.dwCaps & DDSCAPS_NONLOCALVIDMEM) || (desc2->ddsCaps.dwCaps2 & DDSCAPS2_TEXTUREMANAGE))
-      pool = d3d9::D3DPOOL_MANAGED;
-    else if (desc2->ddsCaps.dwCaps & DDSCAPS_SYSTEMMEMORY)
-      // We can't know beforehand if a texture is or isn't going to be
-      // used in SetTexture() calls, and textures placed in D3DPOOL_SYSTEMMEM
-      // will not work in that context in dxvk, so revert to D3DPOOL_MANAGED.
-      pool = m_commonSurf->IsTextureOrCubeMap() ? d3d9::D3DPOOL_MANAGED : d3d9::D3DPOOL_SYSTEMMEM;
-
-    // Place all possible render targets in DEFAULT
-    //
-    // Note: This is somewhat problematic for textures and cube maps
-    // which will have D3DUSAGE_RENDERTARGET, but also need to have
-    // D3DUSAGE_DYNAMIC for locking/uploads to work. The flag combination
-    // isn't supported in D3D9, but we have a D3D7 exception in place.
-    //
-    if (m_commonSurf->IsRenderTarget() || initRT) {
-      Logger::debug("DDraw7Surface::InitializeD3D9: Usage: D3DUSAGE_RENDERTARGET");
-      pool  = d3d9::D3DPOOL_DEFAULT;
-      usage |= D3DUSAGE_RENDERTARGET;
-    }
-    // All depth stencils will be created in DEFAULT
-    if (m_commonSurf->IsDepthStencil()) {
-      Logger::debug("DDraw7Surface::InitializeD3D9: Usage: D3DUSAGE_DEPTHSTENCIL");
-      pool  = d3d9::D3DPOOL_DEFAULT;
-      usage |= D3DUSAGE_DEPTHSTENCIL;
-    }
-
-    // General usage flags
-    if (m_commonSurf->IsTextureOrCubeMap()) {
-      if (pool == d3d9::D3DPOOL_DEFAULT) {
-        Logger::debug("DDraw7Surface::InitializeD3D9: Usage: D3DUSAGE_DYNAMIC");
-        usage |= D3DUSAGE_DYNAMIC;
-      }
-      if (unlikely(m_commonIntf->GetOptions()->autoGenMipMaps)) {
-        Logger::debug("DDraw7Surface::InitializeD3D9: Usage: D3DUSAGE_AUTOGENMIPMAP");
-        usage |= D3DUSAGE_AUTOGENMIPMAP;
-      }
-    }
-
-    const char* poolPlacement = pool == d3d9::D3DPOOL_DEFAULT ? "D3DPOOL_DEFAULT" :
-                                pool == d3d9::D3DPOOL_SYSTEMMEM ? "D3DPOOL_SYSTEMMEM" : "D3DPOOL_MANAGED";
-
-    Logger::debug(str::format("DDraw7Surface::InitializeD3D9: Placing in: ", poolPlacement));
-
-    // Use the MSAA type that was determined to be supported during device creation
-    const d3d9::D3DMULTISAMPLE_TYPE multiSampleType = m_commonIntf->GetCommonD3DDevice()->GetMultiSampleType();
-    const uint32_t index = m_commonSurf->GetBackBufferIndex();
-
-    Com<d3d9::IDirect3DSurface9> surf;
-
-    HRESULT hr = DDERR_GENERIC;
-
-    // Front Buffer
-    if (m_commonSurf->IsFrontBuffer()) {
-      Logger::debug("DDraw7Surface::InitializeD3D9: Initializing front buffer...");
-
-      m_d3d9Device->GetBackBuffer(0, index, d3d9::D3DBACKBUFFER_TYPE_MONO, &surf);
-
-      if (unlikely(surf == nullptr)) {
-        Logger::err("DDraw7Surface::InitializeD3D9: Failed to retrieve front buffer");
-        m_d3d9 = nullptr;
-        return hr;
-      }
-
-      m_d3d9 = std::move(surf);
-
-      m_commonSurf->MarkAsD3D9BackBuffer();
-
-    // Back Buffer
-    } else if (m_commonSurf->IsBackBufferOrFlippable()) {
-      Logger::debug("DDraw7Surface::InitializeD3D9: Initializing back buffer...");
-
-      m_d3d9Device->GetBackBuffer(0, index, d3d9::D3DBACKBUFFER_TYPE_MONO, &surf);
-
-      if (unlikely(surf == nullptr)) {
-        Logger::err("DDraw7Surface::InitializeD3D9: Failed to retrieve back buffer");
-        m_d3d9 = nullptr;
-        return hr;
-      }
-
-      m_d3d9 = std::move(surf);
-
-      m_commonSurf->MarkAsD3D9BackBuffer();
-
-    // Cube maps
-    } else if (m_commonSurf->IsCubeMap()) {
-      Logger::debug("DDraw7Surface::InitializeD3D9: Initializing cube map...");
-
-      Com<d3d9::IDirect3DCubeTexture9> cubetex;
-
-      hr = m_d3d9Device->CreateCubeTexture(
-        desc2->dwWidth, m_commonSurf->GetMipCount(), usage,
-        format, pool, &cubetex, nullptr);
-
-      if (unlikely(FAILED(hr))) {
-        Logger::err("DDraw7Surface::InitializeD3D9: Failed to create cube map");
-        m_cubeMap9 = nullptr;
-        return hr;
-      }
-
-      if (unlikely(m_commonIntf->GetOptions()->autoGenMipMaps))
-        cubetex->SetAutoGenFilterType(d3d9::D3DTEXF_ANISOTROPIC);
-
-      // Always attach the positive X face to this surface
-      cubetex->GetCubeMapSurface(d3d9::D3DCUBEMAP_FACE_POSITIVE_X, 0, &surf);
-      m_d3d9 = (std::move(surf));
-
-      Logger::debug("DDraw7Surface::InitializeD3D9: Retrieving cube map faces");
-
-      CubeMapAttachedSurfaces cubeMapAttachedSurfaces;
-      m_proxy->EnumAttachedSurfaces(&cubeMapAttachedSurfaces, EnumAndAttachCubeMapFacesCallback);
-
-      // The positive X surfaces is this surface, so nothing should be retrieved
-      if (unlikely(cubeMapAttachedSurfaces.positiveX != nullptr))
-        Logger::warn("DDraw7Surface::InitializeD3D9: Non-null positive X cube map face");
-
-      m_cubeMapSurfaces[0] = m_proxy.ptr();
-
-      // We can't know in advance which faces have been generated,
-      // so check them one by one, initialize and bind as needed
-      if (cubeMapAttachedSurfaces.negativeX != nullptr) {
-        Logger::debug("DDraw7Surface::InitializeD3D9: Detected negative X cube map face");
-        m_cubeMapSurfaces[1] = cubeMapAttachedSurfaces.negativeX;
-        InitializeAndAttachCubeFace(cubeMapAttachedSurfaces.negativeX, cubetex.ptr(),
-                                    d3d9::D3DCUBEMAP_FACE_NEGATIVE_X);
-      }
-      if (cubeMapAttachedSurfaces.positiveY != nullptr) {
-        Logger::debug("DDraw7Surface::InitializeD3D9: Detected positive Y cube map face");
-        m_cubeMapSurfaces[2] = cubeMapAttachedSurfaces.positiveY;
-        InitializeAndAttachCubeFace(cubeMapAttachedSurfaces.positiveY, cubetex.ptr(),
-                                    d3d9::D3DCUBEMAP_FACE_POSITIVE_Y);
-      }
-      if (cubeMapAttachedSurfaces.negativeY != nullptr) {
-        Logger::debug("DDraw7Surface::InitializeD3D9: Detected negative Y cube map face");
-        m_cubeMapSurfaces[3] = cubeMapAttachedSurfaces.negativeY;
-        InitializeAndAttachCubeFace(cubeMapAttachedSurfaces.negativeY, cubetex.ptr(),
-                                    d3d9::D3DCUBEMAP_FACE_NEGATIVE_Y);
-      }
-      if (cubeMapAttachedSurfaces.positiveZ != nullptr) {
-        Logger::debug("DDraw7Surface::InitializeD3D9: Detected positive Z cube map face");
-        m_cubeMapSurfaces[4] = cubeMapAttachedSurfaces.positiveZ;
-        InitializeAndAttachCubeFace(cubeMapAttachedSurfaces.positiveZ, cubetex.ptr(),
-                                    d3d9::D3DCUBEMAP_FACE_POSITIVE_Z);
-      }
-      if (cubeMapAttachedSurfaces.negativeZ != nullptr) {
-        Logger::debug("DDraw7Surface::InitializeD3D9: Detected negative Z cube map face");
-        m_cubeMapSurfaces[5] = cubeMapAttachedSurfaces.negativeZ;
-        InitializeAndAttachCubeFace(cubeMapAttachedSurfaces.negativeZ, cubetex.ptr(),
-                                    d3d9::D3DCUBEMAP_FACE_NEGATIVE_Z);
-      }
-
-      Logger::debug("DDraw7Surface::InitializeD3D9: Created cube map");
-      m_cubeMap9 = std::move(cubetex);
-
-    // Textures
-    } else if (m_commonSurf->IsTexture()) {
-      Logger::debug("DDraw7Surface::InitializeD3D9: Initializing texture...");
-
-      Com<d3d9::IDirect3DTexture9> tex;
-
-      hr = m_d3d9Device->CreateTexture(
-        desc2->dwWidth, desc2->dwHeight, m_commonSurf->GetMipCount(), usage,
-        format, pool, &tex, nullptr);
-
-      if (unlikely(FAILED(hr))) {
-        Logger::err("DDraw7Surface::InitializeD3D9: Failed to create texture");
-        m_texture9 = nullptr;
-        return hr;
-      }
-
-      if (unlikely(m_commonIntf->GetOptions()->autoGenMipMaps))
-        tex->SetAutoGenFilterType(d3d9::D3DTEXF_ANISOTROPIC);
-
-      // Attach level 0 to this surface
-      tex->GetSurfaceLevel(0, &surf);
-      m_d3d9 = (std::move(surf));
-
-      Logger::debug("DDraw7Surface::InitializeD3D9: Created texture");
-      m_texture9 = std::move(tex);
-
-    // Depth Stencil
-    } else if (m_commonSurf->IsDepthStencil()) {
-      Logger::debug("DDraw7Surface::InitializeD3D9: Initializing depth stencil...");
-
-      hr = m_d3d9Device->CreateDepthStencilSurface(
-        desc2->dwWidth, desc2->dwHeight, format,
-        multiSampleType, 0, FALSE, &surf, nullptr);
-
-      if (unlikely(FAILED(hr))) {
-        Logger::err("DDraw7Surface::InitializeD3D9: Failed to create DS");
-        m_d3d9 = nullptr;
-        return hr;
-      }
-
-      Logger::debug("DDraw7Surface::InitializeD3D9: Created depth stencil surface");
-
-      m_d3d9 = std::move(surf);
-
-    // Offscreen Plain Surfaces
-    } else if (m_commonSurf->IsOffScreenPlainSurface()) {
-      Logger::debug("DDraw7Surface::InitializeD3D9: Initializing offscreen plain surface...");
-
-      // Sometimes we get passed offscreen plain surfaces which should be tied to the back buffer,
-      // either as existing RTs or during SetRenderTarget() calls, which are tracked with initRT
-      if (unlikely(m_commonIntf->GetCommonD3DDevice()->IsCurrentRenderTarget(this) || initRT)) {
-        Logger::debug("DDraw7Surface::InitializeD3D9: Offscreen plain surface is the RT");
-
-        m_d3d9Device->GetBackBuffer(0, index, d3d9::D3DBACKBUFFER_TYPE_MONO, &surf);
-
-        if (unlikely(surf == nullptr)) {
-          Logger::err("DDraw7Surface::InitializeD3D9: Failed to retrieve offscreen plain surface");
-          m_d3d9 = nullptr;
-          return hr;
-        }
-      } else {
-        hr = m_d3d9Device->CreateOffscreenPlainSurface(
-          desc2->dwWidth, desc2->dwHeight, format,
-          pool, &surf, nullptr);
-
-        if (unlikely(FAILED(hr))) {
-          Logger::err("DDraw7Surface::InitializeD3D9: Failed to create offscreen plain surface");
-          m_d3d9 = nullptr;
-          return hr;
-        }
-      }
-
-      m_d3d9 = std::move(surf);
-
-      m_commonSurf->MarkAsD3D9BackBuffer();
-
-    // Overlays (haven't seen any actual use of overlays in the wild)
-    } else if (m_commonSurf->IsOverlay()) {
-      Logger::debug("DDraw7Surface::InitializeD3D9: Initializing overlay...");
-
-      // Always link overlays to the back buffer
-      m_d3d9Device->GetBackBuffer(0, index, d3d9::D3DBACKBUFFER_TYPE_MONO, &surf);
-
-      if (unlikely(surf == nullptr)) {
-        Logger::err("DDraw7Surface::InitializeD3D9: Failed to retrieve overlay surface");
-        m_d3d9 = nullptr;
-        return hr;
-      }
-
-      m_d3d9 = std::move(surf);
-
-      m_commonSurf->MarkAsD3D9BackBuffer();
-
-    // Generic render target
-    } else if (m_commonSurf->IsRenderTarget()) {
-      Logger::debug("DDraw7Surface::InitializeD3D9: Initializing render target...");
-
-      // Must be lockable for blitting to work. Note that
-      // D3D9 does not allow the creation of lockable RTs when
-      // using MSAA, but we have a D3D7 exception in place.
-      hr = m_d3d9Device->CreateRenderTarget(
-        desc2->dwWidth, desc2->dwHeight, format,
-        multiSampleType, usage, TRUE, &surf, nullptr);
-
-      if (unlikely(FAILED(hr))) {
-        Logger::err("DDraw7Surface::InitializeD3D9: Failed to create render target");
-        m_d3d9 = nullptr;
-        return hr;
-      }
-
-      m_d3d9 = std::move(surf);
-
-    // We sometimes get generic surfaces, with only dimensions, format and placement info
-    } else if (!m_commonSurf->IsNotKnown()) {
-      Logger::debug("DDraw7Surface::InitializeD3D9: Initializing generic surface...");
-
-      hr = m_d3d9Device->CreateOffscreenPlainSurface(
-          desc2->dwWidth, desc2->dwHeight, format,
-          pool, &surf, nullptr);
-
-      if (unlikely(FAILED(hr))) {
-        Logger::err("DDraw7Surface::InitializeD3D9: Failed to create offscreen plain surface");
-        m_d3d9 = nullptr;
-        return hr;
-      }
-
-      Logger::debug("DDraw7Surface::InitializeD3D9: Created offscreen plain surface");
-
-      m_d3d9 = std::move(surf);
-    } else {
-      Logger::warn("DDraw7Surface::InitializeD3D9: Skipping initialization of unknown surface");
-    }
-
-    if (m_shadowSurf != nullptr)
-      m_shadowSurf->SetD3D9(m_d3d9.ptr());
-
-    UploadSurfaceData();
-
-    return DD_OK;
   }
 
   inline HRESULT DDraw7Surface::UploadSurfaceData() {
@@ -1651,45 +1395,45 @@ namespace dxvk {
       // so check them one by one, and upload as needed
       const uint16_t mipCount = m_commonSurf->GetMipCount();
       if (likely(m_cubeMapSurfaces[0] != nullptr)) {
-        BlitToD3D9CubeMap(m_cubeMap9.ptr(), format, m_cubeMapSurfaces[0], mipCount);
+        BlitToD3D9CubeMap(m_commonSurf->GetD3D9CubeTexture(), format, m_cubeMapSurfaces[0], mipCount);
       } else {
         Logger::debug("DDraw7Surface::UploadSurfaceData: Positive X face is null, skpping");
       }
       if (likely(m_cubeMapSurfaces[1] != nullptr)) {
-        BlitToD3D9CubeMap(m_cubeMap9.ptr(), format, m_cubeMapSurfaces[1], mipCount);
+        BlitToD3D9CubeMap(m_commonSurf->GetD3D9CubeTexture(), format, m_cubeMapSurfaces[1], mipCount);
       } else {
         Logger::debug("DDraw7Surface::UploadSurfaceData: Negative X face is null, skpping");
       }
       if (likely(m_cubeMapSurfaces[2] != nullptr)) {
-        BlitToD3D9CubeMap(m_cubeMap9.ptr(), format, m_cubeMapSurfaces[2], mipCount);
+        BlitToD3D9CubeMap(m_commonSurf->GetD3D9CubeTexture(), format, m_cubeMapSurfaces[2], mipCount);
       } else {
         Logger::debug("DDraw7Surface::UploadSurfaceData: Positive Y face is null, skpping");
       }
       if (likely(m_cubeMapSurfaces[3] != nullptr)) {
-        BlitToD3D9CubeMap(m_cubeMap9.ptr(), format, m_cubeMapSurfaces[3], mipCount);
+        BlitToD3D9CubeMap(m_commonSurf->GetD3D9CubeTexture(), format, m_cubeMapSurfaces[3], mipCount);
       } else {
         Logger::debug("DDraw7Surface::UploadSurfaceData: Negative Y face is null, skpping");
       }
       if (likely(m_cubeMapSurfaces[4] != nullptr)) {
-        BlitToD3D9CubeMap(m_cubeMap9.ptr(), format, m_cubeMapSurfaces[4], mipCount);
+        BlitToD3D9CubeMap(m_commonSurf->GetD3D9CubeTexture(), format, m_cubeMapSurfaces[4], mipCount);
       } else {
         Logger::debug("DDraw7Surface::UploadSurfaceData: Positive Z face is null, skpping");
       }
       if (likely(m_cubeMapSurfaces[5] != nullptr)) {
-        BlitToD3D9CubeMap(m_cubeMap9.ptr(), format, m_cubeMapSurfaces[5], mipCount);
+        BlitToD3D9CubeMap(m_commonSurf->GetD3D9CubeTexture(), format, m_cubeMapSurfaces[5], mipCount);
       } else {
         Logger::debug("DDraw7Surface::UploadSurfaceData: Negative Z face is null, skpping");
       }
     // Blit all the mips for textures
     } else if (m_commonSurf->IsTexture()) {
-      BlitToD3D9Texture<IDirectDrawSurface7, DDSURFACEDESC2>(m_texture9.ptr(), format,
+      BlitToD3D9Texture<IDirectDrawSurface7, DDSURFACEDESC2>(m_commonSurf->GetD3D9Texture(), format,
                                                              m_proxy.ptr(), m_commonSurf->GetMipCount());
     // Blit surfaces directly
     } else {
       if (unlikely(m_commonSurf->IsDepthStencil()))
         Logger::debug("DDrawSurface::UploadSurfaceData: Uploading depth stencil");
 
-      BlitToD3D9Surface<IDirectDrawSurface7, DDSURFACEDESC2>(m_d3d9.ptr(), format, GetShadowOrProxied());
+      BlitToD3D9Surface<IDirectDrawSurface7, DDSURFACEDESC2>(m_commonSurf->GetD3D9Surface(), format, GetShadowOrProxied());
     }
 
     m_commonSurf->UnDirtyDDrawSurface();
@@ -1697,23 +1441,22 @@ namespace dxvk {
     return DD_OK;
   }
 
-  inline void DDraw7Surface::RefreshD3D9Device() {
-    D3DCommonDevice* commonDevice = m_commonIntf->GetCommonD3DDevice();
+  inline d3d9::IDirect3DDevice9* DDraw7Surface::RefreshD3D9Device() {
+    D3DCommonDevice* commonD3DDevice = m_commonIntf->GetCommonD3DDevice();
 
-    d3d9::IDirect3DDevice9* d3d9Device = commonDevice != nullptr ? commonDevice->GetD3D9Device() : nullptr;
-    if (unlikely(m_d3d9Device != d3d9Device)) {
+    if (unlikely(m_commonD3DDevice != commonD3DDevice)) {
       // Check if the device has been recreated and reset all D3D9 resources
-      if (m_d3d9Device != nullptr) {
+      if (m_commonD3DDevice != nullptr) {
         Logger::debug("DDraw7Surface: Device context has changed, clearing all D3D9 resources");
-        m_cubeMap9 = nullptr;
-        m_texture9 = nullptr;
-        m_d3d9 = nullptr;
-        if (m_shadowSurf != nullptr)
-          m_shadowSurf->SetD3D9(nullptr);
+        m_commonSurf->SetD3D9CubeTexture(nullptr);
+        m_commonSurf->SetD3D9Texture(nullptr);
+        m_commonSurf->SetD3D9Surface(nullptr);
       }
 
-      m_d3d9Device = d3d9Device;
+      m_commonD3DDevice = commonD3DDevice;
     }
+
+    return m_commonD3DDevice != nullptr ? m_commonD3DDevice->GetD3D9Device() : nullptr;
   }
 
 }

--- a/src/ddraw/ddraw7/ddraw7_surface.h
+++ b/src/ddraw/ddraw7/ddraw7_surface.h
@@ -13,10 +13,12 @@
 
 namespace dxvk {
 
+  class D3DCommonDevice;
+
   /**
   * \brief IDirectDrawSurface7 interface implementation
   */
-  class DDraw7Surface final : public DDrawWrappedObject<DDraw7Interface, IDirectDrawSurface7, d3d9::IDirect3DSurface9> {
+  class DDraw7Surface final : public DDrawWrappedObject<DDraw7Interface, IDirectDrawSurface7> {
 
   public:
 
@@ -149,16 +151,8 @@ namespace dxvk {
       return m_commonIntf;
     }
 
-    d3d9::IDirect3DDevice9* GetD3D9Device() const {
-      return m_d3d9Device;
-    }
-
-    d3d9::IDirect3DTexture9* GetD3D9Texture() const {
-      return m_texture9.ptr();
-    }
-
-    d3d9::IDirect3DCubeTexture9* GetD3D9CubeTexture() const {
-      return m_cubeMap9.ptr();
+    D3DCommonDevice* GetCommonD3DDevice() const {
+      return m_commonD3DDevice;
     }
 
     DDraw7Surface* GetAttachedDepthStencil() {
@@ -194,16 +188,18 @@ namespace dxvk {
 
   private:
 
+    inline void UpdateMipMapCount();
+
     inline void InitializeAndAttachCubeFace(
         IDirectDrawSurface7* surf,
         d3d9::IDirect3DCubeTexture9* cubeTex9,
         d3d9::D3DCUBEMAP_FACES face);
 
-    inline HRESULT InitializeD3D9(const bool initRT);
+    inline void InitializeAllCubeMapSurfaces();
 
     inline HRESULT UploadSurfaceData();
 
-    inline void RefreshD3D9Device();
+    inline d3d9::IDirect3DDevice9* RefreshD3D9Device();
 
     bool             m_isChildObject = false;
 
@@ -211,18 +207,15 @@ namespace dxvk {
     uint32_t         m_surfCount     = 0;
 
     Com<DDrawCommonSurface>             m_commonSurf;
-    DDrawCommonInterface*               m_commonIntf = nullptr;
+    DDrawCommonInterface*               m_commonIntf      = nullptr;
 
-    DDraw7Surface*                      m_parentSurf = nullptr;
+    DDraw7Surface*                      m_parentSurf      = nullptr;
 
-    d3d9::IDirect3DDevice9*             m_d3d9Device = nullptr;
+    D3DCommonDevice*                    m_commonD3DDevice = nullptr;
 
-    Com<d3d9::IDirect3DCubeTexture9>    m_cubeMap9;
     std::array<IDirectDrawSurface7*, 6> m_cubeMapSurfaces;
 
-    Com<d3d9::IDirect3DTexture9>        m_texture9;
-
-    DDraw7Surface*                      m_nextFlippable = nullptr;
+    DDraw7Surface*                      m_nextFlippable   = nullptr;
 
     // Offscreen plain surface we use to mask unwanted DDraw interactions, such
     // as forced swapchain presents caused by blits/locks on primary surfaces

--- a/src/ddraw/ddraw_clipper.cpp
+++ b/src/ddraw/ddraw_clipper.cpp
@@ -5,7 +5,7 @@ namespace dxvk {
   DDrawClipper::DDrawClipper(
         Com<IDirectDrawClipper>&& clipperProxy,
         IUnknown* pParent)
-    : DDrawWrappedObject<IUnknown, IDirectDrawClipper, IUnknown>(pParent, std::move(clipperProxy), nullptr) {
+    : DDrawWrappedObject<IUnknown, IDirectDrawClipper>(pParent, std::move(clipperProxy)) {
     Logger::debug("DDrawClipper: Created a new clipper");
   }
 

--- a/src/ddraw/ddraw_clipper.h
+++ b/src/ddraw/ddraw_clipper.h
@@ -5,7 +5,7 @@
 
 namespace dxvk {
 
-  class DDrawClipper final : public DDrawWrappedObject<IUnknown, IDirectDrawClipper, IUnknown> {
+  class DDrawClipper final : public DDrawWrappedObject<IUnknown, IDirectDrawClipper> {
 
   public:
 

--- a/src/ddraw/ddraw_common_surface.cpp
+++ b/src/ddraw/ddraw_common_surface.cpp
@@ -1,5 +1,7 @@
 #include "ddraw_common_surface.h"
 
+#include "d3d_common_device.h"
+
 #include "ddraw7/ddraw7_surface.h"
 #include "ddraw4/ddraw4_surface.h"
 #include "ddraw2/ddraw3_surface.h"
@@ -113,6 +115,267 @@ namespace dxvk {
       if (unlikely(FAILED(hr)))
         return hr;
       m_desc = desc;
+    }
+
+    return DD_OK;
+  }
+
+  HRESULT DDrawCommonSurface::InitializeD3D9(const bool initRenderTarget) {
+    const DWORD dwHeight = (m_desc2.dwFlags & DDSD_HEIGHT) ? m_desc2.dwHeight : m_desc.dwHeight;
+    const DWORD dwWidth  = (m_desc2.dwFlags & DDSD_WIDTH)  ? m_desc2.dwWidth  : m_desc.dwWidth;
+    const DWORD dwCaps   = (m_desc2.dwFlags & DDSD_CAPS)   ? m_desc2.ddsCaps.dwCaps  : m_desc.ddsCaps.dwCaps;
+    const DWORD dwCaps2  = (m_desc2.dwFlags & DDSD_CAPS)   ? m_desc2.ddsCaps.dwCaps2 : 0;
+
+    if (unlikely(dwHeight == 0 || dwWidth == 0)) {
+      Logger::err("DDrawCommonSurface::InitializeD3D9: Surface has 0 height or width");
+      return DDERR_GENERIC;
+    }
+
+    if (unlikely(m_format9 == d3d9::D3DFMT_UNKNOWN)) {
+      Logger::err("DDrawCommonSurface::InitializeD3D9: Surface has an unknown format");
+      return DDERR_GENERIC;
+    }
+
+    // Don't initialize P8 textures/surfaces since we don't support them.
+    // Some applications do require them to be created by ddraw, otherwise
+    // they will simply fail to start, so just ignore them for now.
+    if (unlikely(m_format9 == d3d9::D3DFMT_P8)) {
+      static bool s_formatP8ErrorShown;
+
+      if (!std::exchange(s_formatP8ErrorShown, true))
+        Logger::warn("DDrawCommonSurface::InitializeD3D9: Unsupported format D3DFMT_P8");
+
+      return DD_OK;
+
+    // Similarly, D3DFMT_R3G3B2 isn't supported by D3D9 dxvk, however some
+    // applications require it to be supported by ddraw, even if they do not
+    // use it. Simply ignore any D3DFMT_R3G3B2 textures/surfaces for now.
+    } else if (unlikely(m_format9 == d3d9::D3DFMT_R3G3B2)) {
+      static bool s_formatR3G3B2ErrorShown;
+
+      if (!std::exchange(s_formatR3G3B2ErrorShown, true))
+        Logger::warn("DDrawCommonSurface::InitializeD3D9: Unsupported format D3DFMT_R3G3B2");
+
+      return DD_OK;
+    }
+
+    d3d9::D3DPOOL pool  = d3d9::D3DPOOL_DEFAULT;
+    DWORD         usage = 0;
+
+    // General surface/texture pool placement
+    if (dwCaps & DDSCAPS_LOCALVIDMEM)
+      pool = d3d9::D3DPOOL_DEFAULT;
+    // There's no explicit non-local video memory placement
+    // per se, but D3DPOOL_MANAGED is close enough
+    else if ((dwCaps & DDSCAPS_NONLOCALVIDMEM) || (dwCaps2 & DDSCAPS2_TEXTUREMANAGE))
+      pool = d3d9::D3DPOOL_MANAGED;
+    else if (dwCaps & DDSCAPS_SYSTEMMEMORY)
+      // We can't know beforehand if a texture is or isn't going to be
+      // used in SetTexture() calls, and textures placed in D3DPOOL_SYSTEMMEM
+      // will not work in that context in dxvk, so revert to D3DPOOL_MANAGED.
+      pool = IsTextureOrCubeMap() ? d3d9::D3DPOOL_MANAGED : d3d9::D3DPOOL_SYSTEMMEM;
+
+    // Place all possible render targets in DEFAULT
+    //
+    // Note: This is somewhat problematic for textures and cube maps
+    // which will have D3DUSAGE_RENDERTARGET, but also need to have
+    // D3DUSAGE_DYNAMIC for locking/uploads to work. The flag combination
+    // isn't supported in D3D9, but we have a D3D7 exception in place.
+    //
+    if (IsRenderTarget() || initRenderTarget) {
+      Logger::debug("DDrawCommonSurface::InitializeD3D9: Usage: D3DUSAGE_RENDERTARGET");
+      pool  = d3d9::D3DPOOL_DEFAULT;
+      usage |= D3DUSAGE_RENDERTARGET;
+    }
+    // All depth stencils will be created in DEFAULT
+    if (IsDepthStencil()) {
+      Logger::debug("DDrawCommonSurface::InitializeD3D9: Usage: D3DUSAGE_DEPTHSTENCIL");
+      pool  = d3d9::D3DPOOL_DEFAULT;
+      usage |= D3DUSAGE_DEPTHSTENCIL;
+    }
+
+    // General usage flags
+    if (IsTextureOrCubeMap()) {
+      if (pool == d3d9::D3DPOOL_DEFAULT) {
+        Logger::debug("DDrawCommonSurface::InitializeD3D9: Usage: D3DUSAGE_DYNAMIC");
+        usage |= D3DUSAGE_DYNAMIC;
+      }
+      if (unlikely(m_commonIntf->GetOptions()->autoGenMipMaps)) {
+        Logger::debug("DDrawCommonSurface::InitializeD3D9: Usage: D3DUSAGE_AUTOGENMIPMAP");
+        usage |= D3DUSAGE_AUTOGENMIPMAP;
+      }
+    }
+
+    const char* poolPlacement = pool == d3d9::D3DPOOL_DEFAULT ? "D3DPOOL_DEFAULT" :
+                                pool == d3d9::D3DPOOL_SYSTEMMEM ? "D3DPOOL_SYSTEMMEM" : "D3DPOOL_MANAGED";
+
+    Logger::debug(str::format("DDrawCommonSurface::InitializeD3D9: Placing in: ", poolPlacement));
+
+    // Use the MSAA type that was determined to be supported during device creation
+    const d3d9::D3DMULTISAMPLE_TYPE multiSampleType = m_commonIntf->GetCommonD3DDevice()->GetMultiSampleType();
+    d3d9::IDirect3DDevice9* d3d9Device = m_commonIntf->GetCommonD3DDevice()->GetD3D9Device();
+
+    HRESULT hr = DDERR_GENERIC;
+
+    // Front Buffer
+    if (IsFrontBuffer()) {
+      Logger::debug("DDrawCommonSurface::InitializeD3D9: Initializing front buffer...");
+
+      hr = d3d9Device->GetBackBuffer(0, m_backBufferIndex, d3d9::D3DBACKBUFFER_TYPE_MONO, &m_surface9);
+
+      if (unlikely(unlikely(FAILED(hr)))) {
+        Logger::err("DDrawCommonSurface::InitializeD3D9: Failed to retrieve front buffer");
+        return hr;
+      }
+
+      MarkAsD3D9BackBuffer();
+
+    // Back Buffer
+    } else if (IsBackBufferOrFlippable()) {
+      Logger::debug("DDrawCommonSurface::InitializeD3D9: Initializing back buffer...");
+
+      hr = d3d9Device->GetBackBuffer(0, m_backBufferIndex, d3d9::D3DBACKBUFFER_TYPE_MONO, &m_surface9);
+
+      if (unlikely(FAILED(hr))) {
+        Logger::err("DDrawCommonSurface::InitializeD3D9: Failed to retrieve back buffer");
+        return hr;
+      }
+
+      MarkAsD3D9BackBuffer();
+
+    // Cube maps
+    } else if (IsCubeMap()) {
+      Logger::debug("DDrawCommonSurface::InitializeD3D9: Initializing cube map...");
+
+      hr = d3d9Device->CreateCubeTexture(
+        dwWidth, m_mipCount, usage,
+        m_format9, pool, &m_cubeMap9, nullptr);
+
+      if (unlikely(FAILED(hr))) {
+        Logger::err("DDrawCommonSurface::InitializeD3D9: Failed to create cube map");
+        return hr;
+      }
+
+      if (unlikely(m_commonIntf->GetOptions()->autoGenMipMaps))
+        m_cubeMap9->SetAutoGenFilterType(d3d9::D3DTEXF_ANISOTROPIC);
+
+      // Always attach the positive X face to this surface
+      m_cubeMap9->GetCubeMapSurface(d3d9::D3DCUBEMAP_FACE_POSITIVE_X, 0, &m_surface9);
+
+      Logger::debug("DDrawCommonSurface::InitializeD3D9: Created cube map");
+
+    // Textures
+    } else if (IsTexture()) {
+      Logger::debug("DDrawCommonSurface::InitializeD3D9: Initializing texture...");
+
+      hr = d3d9Device->CreateTexture(
+        dwWidth, dwHeight, m_mipCount, usage,
+        m_format9, pool, &m_texture9, nullptr);
+
+      if (unlikely(FAILED(hr))) {
+        Logger::err("DDrawCommonSurface::InitializeD3D9: Failed to create texture");
+        return hr;
+      }
+
+      if (unlikely(m_commonIntf->GetOptions()->autoGenMipMaps))
+        m_texture9->SetAutoGenFilterType(d3d9::D3DTEXF_ANISOTROPIC);
+
+      // Attach level 0 to this surface
+      m_texture9->GetSurfaceLevel(0, &m_surface9);
+
+      Logger::debug("DDrawCommonSurface::InitializeD3D9: Created texture");
+
+    // Depth Stencil
+    } else if (IsDepthStencil()) {
+      Logger::debug("DDrawCommonSurface::InitializeD3D9: Initializing depth stencil...");
+
+      hr = d3d9Device->CreateDepthStencilSurface(
+        dwWidth, dwHeight, m_format9,
+        multiSampleType, 0, FALSE, &m_surface9, nullptr);
+
+      if (unlikely(FAILED(hr))) {
+        Logger::err("DDrawCommonSurface::InitializeD3D9: Failed to create depth stencil");
+        return hr;
+      }
+
+      Logger::debug("DDrawCommonSurface::InitializeD3D9: Created depth stencil surface");
+
+    // Offscreen Plain Surfaces
+    } else if (IsOffScreenPlainSurface()) {
+      Logger::debug("DDrawCommonSurface::InitializeD3D9: Initializing offscreen plain surface...");
+
+      if (unlikely(initRenderTarget)) {
+        Logger::debug("DDrawCommonSurface::InitializeD3D9: Offscreen plain surface is the render target");
+
+        hr = d3d9Device->GetBackBuffer(0, m_backBufferIndex, d3d9::D3DBACKBUFFER_TYPE_MONO, &m_surface9);
+
+        if (unlikely(unlikely(FAILED(hr)))) {
+          Logger::err("DDrawCommonSurface::InitializeD3D9: Failed to retrieve offscreen plain surface");
+          return hr;
+        }
+
+        MarkAsD3D9BackBuffer();
+
+      } else {
+        hr = d3d9Device->CreateOffscreenPlainSurface(
+          dwWidth, dwHeight, m_format9,
+          pool, &m_surface9, nullptr);
+
+        if (unlikely(FAILED(hr))) {
+          Logger::err("DDrawCommonSurface::InitializeD3D9: Failed to create offscreen plain surface");
+          return hr;
+        }
+
+        Logger::debug("DDrawCommonSurface::InitializeD3D9: Created offscreen plain surface");
+      }
+    // Overlays (haven't seen any actual use of overlays in the wild)
+    } else if (IsOverlay()) {
+      Logger::debug("DDrawCommonSurface::InitializeD3D9: Initializing overlay...");
+
+      // Always link overlays to the back buffer
+      hr = d3d9Device->GetBackBuffer(0, m_backBufferIndex, d3d9::D3DBACKBUFFER_TYPE_MONO, &m_surface9);
+
+      if (unlikely(FAILED(hr))) {
+        Logger::err("DDrawCommonSurface::InitializeD3D9: Failed to retrieve overlay surface");
+        return hr;
+      }
+
+      MarkAsD3D9BackBuffer();
+
+    // Generic render target
+    } else if (IsRenderTarget()) {
+      Logger::debug("DDrawCommonSurface::InitializeD3D9: Initializing render target...");
+
+      // Must be lockable for blitting to work. Note that
+      // D3D9 does not allow the creation of lockable RTs when
+      // using MSAA, but we have a D3D7 exception in place.
+      hr = d3d9Device->CreateRenderTarget(
+        dwWidth, dwHeight, m_format9,
+        multiSampleType, usage, TRUE, &m_surface9, nullptr);
+
+      if (unlikely(FAILED(hr))) {
+        Logger::err("DDrawCommonSurface::InitializeD3D9: Failed to create render target");
+        return hr;
+      }
+
+      Logger::debug("DDrawCommonSurface::InitializeD3D9: Created render target");
+
+    // We sometimes get generic surfaces, with only dimensions, format and placement info
+    } else if (!IsNotKnown()) {
+      Logger::debug("DDrawCommonSurface::InitializeD3D9: Initializing generic surface...");
+
+      hr = d3d9Device->CreateOffscreenPlainSurface(
+          dwWidth, dwHeight, m_format9,
+          pool, &m_surface9, nullptr);
+
+      if (unlikely(FAILED(hr))) {
+        Logger::err("DDrawCommonSurface::InitializeD3D9: Failed to create offscreen plain surface");
+        return hr;
+      }
+
+      Logger::debug("DDrawCommonSurface::InitializeD3D9: Created offscreen plain surface");
+    } else {
+      Logger::warn("DDrawCommonSurface::InitializeD3D9: Skipping initialization of unknown surface");
     }
 
     return DD_OK;

--- a/src/ddraw/ddraw_common_surface.h
+++ b/src/ddraw/ddraw_common_surface.h
@@ -35,8 +35,38 @@ namespace dxvk {
 
     HRESULT RefreshSurfaceDescripton();
 
+    HRESULT InitializeD3D9(const bool initRenderTarget);
+
+    bool IsInitialized() const {
+      return m_surface9 != nullptr;
+    }
+
     DDrawCommonInterface* GetCommonInterface() const {
       return m_commonIntf.ptr();
+    }
+
+    void SetD3D9Surface(Com<d3d9::IDirect3DSurface9>&& surface9) {
+      m_surface9 = surface9;
+    }
+
+    d3d9::IDirect3DSurface9* GetD3D9Surface() const {
+      return m_surface9.ptr();
+    }
+
+    void SetD3D9Texture(Com<d3d9::IDirect3DTexture9>&& texture9) {
+      m_texture9 = texture9;
+    }
+
+    d3d9::IDirect3DTexture9* GetD3D9Texture() const {
+      return m_texture9.ptr();
+    }
+
+    void SetD3D9CubeTexture(Com<d3d9::IDirect3DCubeTexture9>&& cubeMap9) {
+      m_cubeMap9 = cubeMap9;
+    }
+
+    d3d9::IDirect3DCubeTexture9* GetD3D9CubeTexture() const {
+      return m_cubeMap9.ptr();
     }
 
     bool IsDesc2Set() const {
@@ -327,7 +357,8 @@ namespace dxvk {
 
     bool IsTextureOrCubeMap() const {
       return m_desc2.ddsCaps.dwCaps  & DDSCAPS_TEXTURE
-          || m_desc2.ddsCaps.dwCaps2 & DDSCAPS2_CUBEMAP;
+          || m_desc2.ddsCaps.dwCaps2 & DDSCAPS2_CUBEMAP
+          || m_desc.ddsCaps.dwCaps   & DDSCAPS_TEXTURE;
     }
 
     bool IsBackBufferOrFlippable() const {
@@ -371,6 +402,7 @@ namespace dxvk {
       if (IsPrimarySurface())             type = "primary surface";
       else if (IsFrontBuffer())           type = "front buffer";
       else if (IsBackBuffer())            type = "back buffer";
+      else if (IsCubeMap())               type = "cube texture";
       else if (IsTextureMip())            type = "texture mipmap";
       else if (IsTexture())               type = "texture";
       else if (IsDepthStencil())          type = "depth stencil";
@@ -398,41 +430,45 @@ namespace dxvk {
 
   private:
 
-    bool                      m_dirtyDDraw         = false;
-    bool                      m_dirtyD3D9          = false;
+    bool                             m_dirtyDDraw         = false;
+    bool                             m_dirtyD3D9          = false;
 
-    bool                      m_isAttached         = false;
-    bool                      m_isD3D9BackBuffer   = false;
-    bool                      m_isD3D9DepthStencil = false;
+    bool                             m_isAttached         = false;
+    bool                             m_isD3D9BackBuffer   = false;
+    bool                             m_isD3D9DepthStencil = false;
 
-    bool                      m_isDesc2Set         = false;
-    bool                      m_isDescSet          = false;
+    bool                             m_isDesc2Set         = false;
+    bool                             m_isDescSet          = false;
 
-    bool                      m_isBackBufferOrFlippable = false;
-    bool                      m_isRenderTarget          = false;
+    bool                             m_isBackBufferOrFlippable = false;
+    bool                             m_isRenderTarget          = false;
 
-    uint16_t                  m_mipCount        = 1;
-    uint32_t                  m_backBufferIndex = 0;
+    uint16_t                         m_mipCount        = 1;
+    uint32_t                         m_backBufferIndex = 0;
 
-    DDSURFACEDESC             m_desc  = { };
-    DDSURFACEDESC2            m_desc2 = { };
-    d3d9::D3DFORMAT           m_format9 = d3d9::D3DFMT_UNKNOWN;
+    DDSURFACEDESC                    m_desc  = { };
+    DDSURFACEDESC2                   m_desc2 = { };
+    d3d9::D3DFORMAT                  m_format9 = d3d9::D3DFMT_UNKNOWN;
 
-    Com<DDrawClipper>         m_clipper;
-    Com<DDrawPalette>         m_palette;
+    Com<DDrawClipper>                m_clipper;
+    Com<DDrawPalette>                m_palette;
 
-    Com<DDrawCommonInterface> m_commonIntf;
+    Com<DDrawCommonInterface>        m_commonIntf;
+
+    Com<d3d9::IDirect3DSurface9>     m_surface9;
+    Com<d3d9::IDirect3DTexture9>     m_texture9;
+    Com<d3d9::IDirect3DCubeTexture9> m_cubeMap9;
 
     // Track all possible surface versions of the same object
-    DDraw7Surface*            m_surf7        = nullptr;
-    DDraw4Surface*            m_surf4        = nullptr;
-    DDraw3Surface*            m_surf3        = nullptr;
-    DDraw2Surface*            m_surf2        = nullptr;
-    DDrawSurface*             m_surf         = nullptr;
+    DDraw7Surface*                   m_surf7  = nullptr;
+    DDraw4Surface*                   m_surf4  = nullptr;
+    DDraw3Surface*                   m_surf3  = nullptr;
+    DDraw2Surface*                   m_surf2  = nullptr;
+    DDrawSurface*                    m_surf   = nullptr;
 
     // Track the origin surface, as in the DDraw surface
     // that gets created through a CreateSurface call
-    IUnknown*                 m_origin       = nullptr;
+    IUnknown*                        m_origin = nullptr;
 
   };
 

--- a/src/ddraw/ddraw_gamma.cpp
+++ b/src/ddraw/ddraw_gamma.cpp
@@ -8,7 +8,7 @@ namespace dxvk {
         DDrawCommonSurface* commonSurf,
         Com<IDirectDrawGammaControl>&& proxyGamma,
         IUnknown* pParent)
-    : DDrawWrappedObject<IUnknown, IDirectDrawGammaControl, IUnknown>(pParent, std::move(proxyGamma), nullptr)
+    : DDrawWrappedObject<IUnknown, IDirectDrawGammaControl>(pParent, std::move(proxyGamma))
     , m_commonSurf ( commonSurf ) {
     Logger::debug("DDrawGammaControl: Created a new gamma control interface");
   }

--- a/src/ddraw/ddraw_gamma.h
+++ b/src/ddraw/ddraw_gamma.h
@@ -7,7 +7,7 @@
 
 namespace dxvk {
 
-  class DDrawGammaControl final : public DDrawWrappedObject<IUnknown, IDirectDrawGammaControl, IUnknown> {
+  class DDrawGammaControl final : public DDrawWrappedObject<IUnknown, IDirectDrawGammaControl> {
 
   public:
 

--- a/src/ddraw/ddraw_options.h
+++ b/src/ddraw/ddraw_options.h
@@ -77,6 +77,9 @@ namespace dxvk {
     /// Uses a tolerance interval for color key inverval matching
     bool colorKeyTolerance;
 
+    /// Extends features and relaxes validations to enable apitrace debugging
+    bool apitraceMode;
+
     /// By default guards against legacy presents while inside of a scene
     D3DLegacyPresentGuard legacyPresentGuard;
 
@@ -106,6 +109,7 @@ namespace dxvk {
       this->deviceResourceSharing = config.getOption<bool>   ("ddraw.deviceResourceSharing", false);
       this->colorKeyMasking       = config.getOption<bool>   ("ddraw.colorKeyMasking",       false);
       this->colorKeyTolerance     = config.getOption<bool>   ("ddraw.colorKeyTolerance",     false);
+      this->apitraceMode          = config.getOption<bool>   ("ddraw.apitraceMode",          false);
 
       // Clamp the vertex offset in the (sensible) -1.0f/1.0f range
       this->vertexOffset = dxvk::fclamp(this->vertexOffset, -1.0f, 1.0f);

--- a/src/ddraw/ddraw_palette.cpp
+++ b/src/ddraw/ddraw_palette.cpp
@@ -9,7 +9,7 @@ namespace dxvk {
   DDrawPalette::DDrawPalette(
         Com<IDirectDrawPalette>&& paletteProxy,
         IUnknown* pParent)
-    : DDrawWrappedObject<IUnknown, IDirectDrawPalette, IUnknown>(pParent, std::move(paletteProxy), nullptr) {
+    : DDrawWrappedObject<IUnknown, IDirectDrawPalette>(pParent, std::move(paletteProxy)) {
     if (m_parent != nullptr)
       m_parent->AddRef();
 

--- a/src/ddraw/ddraw_palette.h
+++ b/src/ddraw/ddraw_palette.h
@@ -7,7 +7,7 @@ namespace dxvk {
 
   class DDrawCommonSurface;
 
-  class DDrawPalette final : public DDrawWrappedObject<IUnknown, IDirectDrawPalette, IUnknown> {
+  class DDrawPalette final : public DDrawWrappedObject<IUnknown, IDirectDrawPalette> {
 
   public:
 

--- a/src/ddraw/ddraw_wrapped_object.h
+++ b/src/ddraw/ddraw_wrapped_object.h
@@ -4,19 +4,17 @@
 
 namespace dxvk {
 
-  template <typename ParentType, typename DDrawType, typename D3D9Type>
+  template <typename ParentType, typename DDrawType>
   class DDrawWrappedObject : public ComObjectClamp<DDrawType> {
 
   public:
 
     using Parent = ParentType;
     using DDraw = DDrawType;
-    using D3D9 = D3D9Type;
 
-    DDrawWrappedObject(Parent* parent, Com<DDraw>&& proxiedIntf, Com<D3D9>&& object)
+    DDrawWrappedObject(Parent* parent, Com<DDraw>&& proxiedIntf)
       : m_parent ( parent )
-      , m_proxy ( std::move(proxiedIntf) )
-      , m_d3d9  ( std::move(object) ) {
+      , m_proxy ( std::move(proxiedIntf) ) {
     }
 
     void UpdateParent(Parent* parent) {
@@ -29,31 +27,6 @@ namespace dxvk {
 
     DDraw* GetProxied() const {
       return m_proxy.ptr();
-    }
-
-    D3D9* GetD3D9() const {
-      return m_d3d9.ptr();
-    }
-
-    void SetD3D9(Com<D3D9>&& object) {
-      m_d3d9 = std::move(object);
-    }
-
-    bool IsInitialized() const {
-      return m_d3d9 != nullptr;
-    }
-
-    // For cases where the object may be null.
-    static D3D9* GetD3D9Nullable(DDrawWrappedObject* self) {
-      if (unlikely(self == NULL)) {
-        return NULL;
-      }
-      return self->m_d3d9.ptr();
-    }
-
-    template <typename T>
-    static D3D9* GetD3D9Nullable(Com<T>& self) {
-      return GetD3D9Nullable(self.ptr());
     }
 
     IUnknown* GetInterface(REFIID riid) {
@@ -88,7 +61,6 @@ namespace dxvk {
     Parent*    m_parent = nullptr;
 
     Com<DDraw> m_proxy;
-    Com<D3D9>  m_d3d9;
 
   };
 

--- a/src/util/config/config.cpp
+++ b/src/util/config/config.cpp
@@ -1722,10 +1722,6 @@ namespace dxvk {
     { R"(\\h&d\.exe$)", {{
       { "ddraw.forceLegacyPresent",         "True" },
     }} },
-    /* Dungeon Keeper 2                           */
-    { R"(\\DKII(-DX)?\.exe$)", {{
-      { "ddraw.ignoreExclusiveMode",        "True" },
-    }} },
     /* Star Wars: Rogue Squadron 3D               */
     { R"(\\Rogue Squadron\.exe$)", {{
       { "d3d9.maxFrameRate",                 "-60" },
@@ -1849,6 +1845,14 @@ namespace dxvk {
      * Fixes white backgrounds on text            */
     { R"(\\Combat Mission\.exe$)", {{
       { "ddraw.colorKeyMasking",            "True" },
+    }} },
+    /* X: Beyond the Frontier                     */
+    { R"(\\X\.exe$)", {{
+      { "ddraw.forceSingleBackBuffer",      "True" },
+    }} },
+    /* X: Tension                                 */
+    { R"(\\X-TENSION\.exe$)", {{
+      { "ddraw.forceSingleBackBuffer",      "True" },
     }} },
 
     /**********************************************/


### PR DESCRIPTION
Mostly cleaning up code, but part of an effort to unify the d3d9 side of things even among shared interfaces of the same object. The only visible impact (hopefully) will be an overall (slight) reduction in the overall memory footprint.