### PR TITLE
[meta] Emulate DDraw side swapchain flips

### DIFF
--- a/src/ddraw/ddraw/ddraw_surface.cpp
+++ b/src/ddraw/ddraw/ddraw_surface.cpp
@@ -607,8 +607,11 @@ namespace dxvk {
 
         if (unlikely(rt != nullptr)) {
           Logger::debug("DDrawSurface::Flip: Presenting from DDraw RT");
-          if (unlikely(m_commonIntf->GetOptions()->emulateFrontBuffer))
+          if (unlikely(m_commonIntf->GetOptions()->emulateFrontBuffer)) {
             InitializeOrUploadD3D9();
+            if (m_shadowSurf != nullptr && rt->GetCommonSurface()->IsDDrawSurfaceDirty())
+              GetShadowOrProxied()->BltFast(0, 0, rt->GetShadowOrProxied(), nullptr, DDBLTFAST_NOCOLORKEY);
+          }
           rt->InitializeOrUploadD3D9();
           d3d9Device->Present(NULL, NULL, NULL, NULL);
           return DD_OK;
@@ -616,8 +619,11 @@ namespace dxvk {
       }
 
       if (likely(m_nextFlippable != nullptr)) {
-        if (unlikely(m_commonIntf->GetOptions()->emulateFrontBuffer))
+        if (unlikely(m_commonIntf->GetOptions()->emulateFrontBuffer)) {
           InitializeOrUploadD3D9();
+          if (m_shadowSurf != nullptr && m_nextFlippable->GetCommonSurface()->IsDDrawSurfaceDirty())
+            GetShadowOrProxied()->BltFast(0, 0, m_nextFlippable->GetShadowOrProxied(), nullptr, DDBLTFAST_NOCOLORKEY);
+        }
         m_nextFlippable->InitializeOrUploadD3D9();
       } else {
         InitializeOrUploadD3D9();

--- a/src/ddraw/ddraw2/ddraw2_surface.cpp
+++ b/src/ddraw/ddraw2/ddraw2_surface.cpp
@@ -551,8 +551,11 @@ namespace dxvk {
 
         if (unlikely(rt != nullptr)) {
           Logger::debug("DDraw2Surface::Flip: Presenting from DDraw RT");
-          if (unlikely(m_commonIntf->GetOptions()->emulateFrontBuffer))
+          if (unlikely(m_commonIntf->GetOptions()->emulateFrontBuffer)) {
             InitializeOrUploadD3D9();
+            if (m_shadowSurf != nullptr && rt->GetCommonSurface()->IsDDrawSurfaceDirty())
+              GetShadowOrProxied()->BltFast(0, 0, rt->GetShadowOrProxied(), nullptr, DDBLTFAST_NOCOLORKEY);
+          }
           rt->InitializeOrUploadD3D9();
           d3d9Device->Present(NULL, NULL, NULL, NULL);
           return DD_OK;
@@ -562,8 +565,11 @@ namespace dxvk {
       DDrawSurface* nextFlippable = m_parent->GetNextFlippable();
 
       if (likely(nextFlippable != nullptr)) {
-        if (unlikely(m_commonIntf->GetOptions()->emulateFrontBuffer))
+        if (unlikely(m_commonIntf->GetOptions()->emulateFrontBuffer)) {
           InitializeOrUploadD3D9();
+          if (m_shadowSurf != nullptr && nextFlippable->GetCommonSurface()->IsDDrawSurfaceDirty())
+            m_parent->GetShadowOrProxied()->BltFast(0, 0, nextFlippable->GetShadowOrProxied(), nullptr, DDBLTFAST_NOCOLORKEY);
+        }
         nextFlippable->InitializeOrUploadD3D9();
       } else {
         InitializeOrUploadD3D9();

--- a/src/ddraw/ddraw2/ddraw3_surface.cpp
+++ b/src/ddraw/ddraw2/ddraw3_surface.cpp
@@ -555,8 +555,11 @@ namespace dxvk {
 
         if (unlikely(rt != nullptr)) {
           Logger::debug("DDraw3Surface::Flip: Presenting from DDraw RT");
-          if (unlikely(m_commonIntf->GetOptions()->emulateFrontBuffer))
+          if (unlikely(m_commonIntf->GetOptions()->emulateFrontBuffer)) {
             InitializeOrUploadD3D9();
+            if (m_shadowSurf != nullptr && rt->GetCommonSurface()->IsDDrawSurfaceDirty())
+              GetShadowOrProxied()->BltFast(0, 0, rt->GetShadowOrProxied(), nullptr, DDBLTFAST_NOCOLORKEY);
+          }
           rt->InitializeOrUploadD3D9();
           d3d9Device->Present(NULL, NULL, NULL, NULL);
           return DD_OK;
@@ -566,8 +569,11 @@ namespace dxvk {
       DDrawSurface* nextFlippable = m_parent->GetNextFlippable();
 
       if (likely(nextFlippable != nullptr)) {
-        if (unlikely(m_commonIntf->GetOptions()->emulateFrontBuffer))
+        if (unlikely(m_commonIntf->GetOptions()->emulateFrontBuffer)) {
           InitializeOrUploadD3D9();
+          if (m_shadowSurf != nullptr && nextFlippable->GetCommonSurface()->IsDDrawSurfaceDirty())
+            m_parent->GetShadowOrProxied()->BltFast(0, 0, nextFlippable->GetShadowOrProxied(), nullptr, DDBLTFAST_NOCOLORKEY);
+        }
         nextFlippable->InitializeOrUploadD3D9();
       } else {
         InitializeOrUploadD3D9();

--- a/src/ddraw/ddraw4/ddraw4_surface.cpp
+++ b/src/ddraw/ddraw4/ddraw4_surface.cpp
@@ -587,8 +587,11 @@ namespace dxvk {
 
         if (unlikely(rt != nullptr)) {
           Logger::debug("DDraw4Surface::Flip: Presenting from DDraw RT");
-          if (unlikely(m_commonIntf->GetOptions()->emulateFrontBuffer))
+          if (unlikely(m_commonIntf->GetOptions()->emulateFrontBuffer)) {
             InitializeOrUploadD3D9();
+            if (m_shadowSurf != nullptr && rt->GetCommonSurface()->IsDDrawSurfaceDirty())
+              GetShadowOrProxied()->BltFast(0, 0, rt->GetShadowOrProxied(), nullptr, DDBLTFAST_NOCOLORKEY);
+          }
           rt->InitializeOrUploadD3D9();
           d3d9Device->Present(NULL, NULL, NULL, NULL);
           return DD_OK;
@@ -596,8 +599,11 @@ namespace dxvk {
       }
 
       if (likely(m_nextFlippable != nullptr)) {
-        if (unlikely(m_commonIntf->GetOptions()->emulateFrontBuffer))
+        if (unlikely(m_commonIntf->GetOptions()->emulateFrontBuffer)) {
           InitializeOrUploadD3D9();
+          if (m_shadowSurf != nullptr && m_nextFlippable->GetCommonSurface()->IsDDrawSurfaceDirty())
+            GetShadowOrProxied()->BltFast(0, 0, m_nextFlippable->GetShadowOrProxied(), nullptr, DDBLTFAST_NOCOLORKEY);
+        }
         m_nextFlippable->InitializeOrUploadD3D9();
       } else {
         InitializeOrUploadD3D9();

--- a/src/ddraw/ddraw7/ddraw7_surface.cpp
+++ b/src/ddraw/ddraw7/ddraw7_surface.cpp
@@ -554,8 +554,11 @@ namespace dxvk {
       }
 
       if (likely(m_nextFlippable != nullptr)) {
-        if (unlikely(m_commonIntf->GetOptions()->emulateFrontBuffer))
+        if (unlikely(m_commonIntf->GetOptions()->emulateFrontBuffer)) {
           InitializeOrUploadD3D9();
+          if (m_shadowSurf != nullptr && m_nextFlippable->GetCommonSurface()->IsDDrawSurfaceDirty())
+            GetShadowOrProxied()->BltFast(0, 0, m_nextFlippable->GetShadowOrProxied(), nullptr, DDBLTFAST_NOCOLORKEY);
+        }
         m_nextFlippable->InitializeOrUploadD3D9();
       } else {
         InitializeOrUploadD3D9();

--- a/src/ddraw/ddraw_options.h
+++ b/src/ddraw/ddraw_options.h
@@ -136,7 +136,7 @@ namespace dxvk {
         this->legacyPresentGuard = D3DLegacyPresentGuard::Auto;
       }
 
-      std::string emulateFSAAStr = Config::toLower(config.getOption<std::string>("ddraw.emulateFSAA", "auto"));
+      std::string emulateFSAAStr = Config::toLower(config.getOption<std::string>("ddraw.emulateFSAA", "false"));
       if (emulateFSAAStr == "true") {
         this->emulateFSAA = FSAAEmulation::Enabled;
       } else if (emulateFSAAStr == "forced") {

--- a/src/util/config/config.cpp
+++ b/src/util/config/config.cpp
@@ -1707,6 +1707,12 @@ namespace dxvk {
       { "ddraw.ignoreExclusiveMode",        "True" },
       { "ddraw.forceLegacyDiscard",         "True" },
     }} },
+    /* Praetorians                                *
+     * Fixes missing load screen backgrounds      */
+    { R"(\\Praetorians\.exe$)", {{
+      { "ddraw.forceLegacyPresent",         "True" },
+      { "ddraw.emulateFrontBuffer",         "True" },
+    }} },
 
     /**********************************************/
     /* D3D6 GAMES                                 */


### PR DESCRIPTION
Apparently, some games need us to emulate the front buffer advancement in the swapchain too, because they copy content on the next swapchain surface and expect it to appear on the back buffer on the next flip.

We already fix up such things on D3D9 side, but only partially since in such situation content can still be lost/discarded, so simply copy the contents of the current DDraw back buffer (if it's dirty) onto the current DDraw front buffer before we present and thus they get swapped (as far as D3D9 is concerned). During the next frame, the DDraw content will be what the game expects, so nothing will get lost once it's ultimately re-uploaded to D3D9.